### PR TITLE
Removed gc_ prefix from C memory routines

### DIFF
--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -38,7 +38,7 @@ ByteBuffer: class {
 			this _referenceCount free()
 		this _referenceCount = null
 		if (this _ownsMemory)
-			gc_free(this _pointer)
+			memfree(this _pointer)
 		this _pointer = null
 		super()
 	}

--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -127,7 +127,7 @@ _RecyclableByteBuffer: class extends ByteBuffer {
 		}
 		This _lock unlock()
 		version(debugByteBuffer) { if (buffer == null) Debug print("No RecyclableByteBuffer available in the bin; allocating a new one") }
-		buffer == null ? This new(gc_malloc_atomic(size), size) : buffer
+		buffer == null ? This new(malloc(size), size) : buffer
 	}
 	_getBin: static func (size: Int) -> VectorList<This> {
 		size < 10000 ? This _smallRecycleBin : (size < 100000 ? This _mediumRecycleBin : This _largeRecycleBin)

--- a/source/collections/LinkedList.ooc
+++ b/source/collections/LinkedList.ooc
@@ -157,7 +157,7 @@ Node: class <T> {
 	init: func ~withParams (=prev, =next, =data)
 	free: override func {
 		if (T inheritsFrom?(Object))
-			gc_free(data)
+			memfree(data)
 		super()
 	}
 }

--- a/source/collections/PointerVector.ooc
+++ b/source/collections/PointerVector.ooc
@@ -84,7 +84,7 @@ PointerHeapVector: class extends PointerVector {
 	}
 
 	_allocate: func (count: Int) {
-		this _backend = gc_realloc(this _backend, count * Pointer size)
+		this _backend = realloc(this _backend, count * Pointer size)
 	}
 
 	resize: override func (count: Int) {

--- a/source/collections/PointerVector.ooc
+++ b/source/collections/PointerVector.ooc
@@ -27,7 +27,7 @@ PointerVector: abstract class {
 	}
 	free: override func {
 		this _free(0, this count)
-		gc_free(this _backend)
+		memfree(this _backend)
 		super()
 	}
 	_free: func ~range (start, end: Int) {

--- a/source/collections/PointerVectorList.ooc
+++ b/source/collections/PointerVectorList.ooc
@@ -32,7 +32,7 @@ PointerVectorList: class {
 	init: func (=_vector)
 	free: override func {
 		for (i in 0 .. this count)
-			gc_free(this _vector[i])
+			memfree(this _vector[i])
 		this _vector free()
 		super()
 	}

--- a/source/collections/Queue.ooc
+++ b/source/collections/Queue.ooc
@@ -20,7 +20,7 @@ VectorQueue: class <T> extends Queue<T> {
 
 	init: func (capacity := 32) {
 		this _capacity = capacity
-		this _backend = gc_calloc(capacity as SizeT, T size)
+		this _backend = calloc(capacity as SizeT, T size)
 		super()
 	}
 	free: override func {
@@ -60,7 +60,7 @@ VectorQueue: class <T> extends Queue<T> {
 		newCapacity := this _capacity + this _chunkCount
 		moveCount := oldCapacity - this _head
 		bytes := newCapacity * T size
-		this _backend = gc_realloc(this _backend, bytes)
+		this _backend = realloc(this _backend, bytes)
 		sourcePtr: Byte* = this _backend as Byte* + (this _head * T size)
 		destinationPtr := sourcePtr + (this _chunkCount * T size)
 		memmove(destinationPtr, sourcePtr, moveCount * T size)

--- a/source/collections/Queue.ooc
+++ b/source/collections/Queue.ooc
@@ -24,7 +24,7 @@ VectorQueue: class <T> extends Queue<T> {
 		super()
 	}
 	free: override func {
-		gc_free(_backend)
+		memfree(_backend)
 		super()
 	}
 	clear: override func {

--- a/source/collections/Vector2D.ooc
+++ b/source/collections/Vector2D.ooc
@@ -28,7 +28,7 @@ Vector2D: class <T> {
 		memset(this _backend, 0, this rowCount * this columnCount * T size)
 	}
 	free: override func {
-		gc_free(this _backend)
+		memfree(this _backend)
 		super()
 	}
 	_allocate: func (rows, columns: Int) {
@@ -52,13 +52,13 @@ Vector2D: class <T> {
 			if (newRowCount > this rowCount && newColumnCount > this columnCount)
 				temporaryResult = calloc(newRowCount * newColumnCount, T size)
 			else
-				temporaryResult = calloc(1, newRowCount * newColumnCount * T size)
+				temporaryResult = calloc(newRowCount * newColumnCount, T size)
 
 			for (row in 0 .. minimumRowCount)
 				memcpy(temporaryResult[T size * this _elementPosition(row, 0, newColumnCount)]&,
 					this _backend[T size * this _elementPosition(row, 0)]&, minimumColumnCount * T size)
 
-			gc_free(this _backend)
+			memfree(this _backend)
 			this init(temporaryResult, newRowCount, newColumnCount)
 		}
 	}

--- a/source/collections/Vector2D.ooc
+++ b/source/collections/Vector2D.ooc
@@ -32,7 +32,7 @@ Vector2D: class <T> {
 		super()
 	}
 	_allocate: func (rows, columns: Int) {
-		this _backend = gc_realloc(this _backend, rows * columns * T size)
+		this _backend = realloc(this _backend, rows * columns * T size)
 	}
 	_elementPosition: func (row, column: Int, columnCount := this columnCount) -> Int {
 		columnCount * row + column
@@ -50,9 +50,9 @@ Vector2D: class <T> {
 			minimumColumnCount := this columnCount minimum(newColumnCount)
 
 			if (newRowCount > this rowCount && newColumnCount > this columnCount)
-				temporaryResult = gc_calloc(newRowCount * newColumnCount, T size)
+				temporaryResult = calloc(newRowCount * newColumnCount, T size)
 			else
-				temporaryResult = gc_malloc(newRowCount * newColumnCount * T size)
+				temporaryResult = calloc(1, newRowCount * newColumnCount * T size)
 
 			for (row in 0 .. minimumRowCount)
 				memcpy(temporaryResult[T size * this _elementPosition(row, 0, newColumnCount)]&,

--- a/source/draw/FloatImage.ooc
+++ b/source/draw/FloatImage.ooc
@@ -10,7 +10,7 @@ FloatImage : class {
 	init: func ~IntVector2D (=_size)
 	init: func ~WidthAndHeight (width, height: Int) {
 		this _size = IntVector2D new(width, height)
-		this _pointer = gc_malloc(width * height * Float instanceSize)
+		this _pointer = calloc(1, width * height * Float instanceSize)
 	}
 
 	free: override func {

--- a/source/draw/FloatImage.ooc
+++ b/source/draw/FloatImage.ooc
@@ -10,11 +10,11 @@ FloatImage : class {
 	init: func ~IntVector2D (=_size)
 	init: func ~WidthAndHeight (width, height: Int) {
 		this _size = IntVector2D new(width, height)
-		this _pointer = calloc(1, width * height * Float instanceSize)
+		this _pointer = calloc(width * height, Float instanceSize)
 	}
 
 	free: override func {
-		gc_free(this _pointer)
+		memfree(this _pointer)
 		super()
 	}
 	operator [] (x, y: Int) -> Float {

--- a/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
@@ -108,13 +108,13 @@ Gles3ShaderProgram: class extends GLShaderProgram {
 			source println()
 			logSize: Int = 0
 			glGetShaderiv(shaderID, GL_INFO_LOG_LENGTH, logSize&)
-			compileLog := calloc(1, logSize * Char size) as CString
+			compileLog := calloc(logSize, Char size) as CString
 			length: Int
 			glGetShaderInfoLog(shaderID, logSize, length&, compileLog)
 			compileLogString := compileLog toString()
 			compileLogString println()
 			compileLogString free()
-			gc_free(compileLog)
+			memfree(compileLog)
 			raise("Shader compilation failed")
 		}
 		version(debugGL) { validateEnd("ShaderProgram _compileShader") }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
@@ -108,7 +108,7 @@ Gles3ShaderProgram: class extends GLShaderProgram {
 			source println()
 			logSize: Int = 0
 			glGetShaderiv(shaderID, GL_INFO_LOG_LENGTH, logSize&)
-			compileLog := gc_malloc(logSize * Char size) as CString
+			compileLog := calloc(1, logSize * Char size) as CString
 			length: Int
 			glGetShaderInfoLog(shaderID, logSize, length&, compileLog)
 			compileLogString := compileLog toString()

--- a/source/io/Pipe.ooc
+++ b/source/io/Pipe.ooc
@@ -11,7 +11,7 @@ Pipe: abstract class {
 		c
 	}
 	read: func ~string (len: Int) -> String {
-		buf := gc_malloc(len + 1) as CString
+		buf := calloc(1, len + 1) as CString
 		howmuch := read(buf, len)
 		result: String = null
 		if (howmuch != -1) {

--- a/source/io/native/ProcessUnix.ooc
+++ b/source/io/native/ProcessUnix.ooc
@@ -108,7 +108,7 @@ ProcessUnix: class extends Process {
 				chdir(cwd as CString)
 
 			/* run the stuff. */
-			cArgs : CString * = calloc(1, Pointer size * (args count + 1))
+			cArgs : CString * = calloc(args count + 1, Pointer size)
 			for (i in 0 .. args count) {
 				cArgs[i] = args[i] toCString()
 			}

--- a/source/io/native/ProcessUnix.ooc
+++ b/source/io/native/ProcessUnix.ooc
@@ -108,7 +108,7 @@ ProcessUnix: class extends Process {
 				chdir(cwd as CString)
 
 			/* run the stuff. */
-			cArgs : CString * = gc_malloc(Pointer size * (args count + 1))
+			cArgs : CString * = calloc(1, Pointer size * (args count + 1))
 			for (i in 0 .. args count) {
 				cArgs[i] = args[i] toCString()
 			}

--- a/source/io/native/ProcessWin32.ooc
+++ b/source/io/native/ProcessWin32.ooc
@@ -109,7 +109,7 @@ ProcessWin32: class extends Process {
 			envLength += 2 // one for the =, one for the \0
 		)
 
-		envString := gc_malloc(envLength) as Char*
+		envString := calloc(1, envLength) as Char*
 		index := 0
 		for (k in env keys) {
 			v := env get(k)

--- a/source/sdk/Backtrace.ooc
+++ b/source/sdk/Backtrace.ooc
@@ -11,7 +11,7 @@ BacktraceHandler: class {
 	raw := false
 
 	backtrace: func -> Backtrace {
-		buffer := calloc(1, Pointer size * BACKTRACE_LENGTH)
+		buffer := calloc(BACKTRACE_LENGTH, Pointer size)
 		result: Backtrace = null
 		if (lib) {
 			// use fancy-backtrace, best one!
@@ -33,7 +33,7 @@ BacktraceHandler: class {
 					stderr write("[Backtrace] No backtrace extension nor execinfo - use a debugger!\n")
 					This WARNED_ABOUT_FALLBACK = true
 				}
-				gc_free(buffer)
+				memfree(buffer)
 			}
 		}
 		result
@@ -41,7 +41,7 @@ BacktraceHandler: class {
 	backtraceWithContext: func (contextPtr: Pointer) -> Backtrace {
 		result: Backtrace = null
 		version (windows) {
-			buffer := calloc(1, Pointer size * BACKTRACE_LENGTH) as Pointer*
+			buffer := calloc(BACKTRACE_LENGTH, Pointer size) as Pointer*
 			f := (fancyBacktraceWithContext, null) as Func (Pointer*, Int, Pointer) -> Int
 			length := f(buffer, BACKTRACE_LENGTH, contextPtr)
 			result = Backtrace new(buffer, length)
@@ -202,7 +202,7 @@ Backtrace: class {
 	init: func (=buffer, =length)
 	free: override func {
 		if (this buffer)
-			gc_free(this buffer)
+			memfree(this buffer)
 		super()
 	}
 }

--- a/source/sdk/Backtrace.ooc
+++ b/source/sdk/Backtrace.ooc
@@ -11,7 +11,7 @@ BacktraceHandler: class {
 	raw := false
 
 	backtrace: func -> Backtrace {
-		buffer := gc_malloc(Pointer size * BACKTRACE_LENGTH)
+		buffer := calloc(1, Pointer size * BACKTRACE_LENGTH)
 		result: Backtrace = null
 		if (lib) {
 			// use fancy-backtrace, best one!
@@ -41,7 +41,7 @@ BacktraceHandler: class {
 	backtraceWithContext: func (contextPtr: Pointer) -> Backtrace {
 		result: Backtrace = null
 		version (windows) {
-			buffer := gc_malloc(Pointer size * BACKTRACE_LENGTH) as Pointer*
+			buffer := calloc(1, Pointer size * BACKTRACE_LENGTH) as Pointer*
 			f := (fancyBacktraceWithContext, null) as Func (Pointer*, Int, Pointer) -> Int
 			length := f(buffer, BACKTRACE_LENGTH, contextPtr)
 			result = Backtrace new(buffer, length)

--- a/source/sdk/Buffer.ooc
+++ b/source/sdk/Buffer.ooc
@@ -26,7 +26,7 @@ Buffer: cover {
 	free: func@ -> Bool {
 		result := this _pointer != null && this _size != 0
 		if (result) {
-			free(this _pointer)
+			memfree(this _pointer)
 			this _pointer = null
 			this _size = 0
 		}

--- a/source/sdk/CharBuffer.ooc
+++ b/source/sdk/CharBuffer.ooc
@@ -26,7 +26,7 @@ CharBuffer: class extends Iterable<Char> {
 
 	free: override func {
 		if (this data != null && this capacity > 0)
-			gc_free(this mallocAddr)
+			memfree(this mallocAddr)
 		super()
 	}
 

--- a/source/sdk/CharBuffer.ooc
+++ b/source/sdk/CharBuffer.ooc
@@ -57,7 +57,7 @@ CharBuffer: class extends Iterable<Char> {
 			rs := rshift
 			if (rs) shiftLeft(rs)
 
-			tmp := gc_realloc(mallocAddr, capacity)
+			tmp := realloc(mallocAddr, capacity)
 			if (!tmp) OutOfMemoryException new(This) throw()
 
 			// if we were coming from a string literal, copy the original data as well (gc_realloc cant work on text segment)

--- a/source/sdk/Character.ooc
+++ b/source/sdk/Character.ooc
@@ -147,7 +147,7 @@ CString: cover from Char* {
 		stdout write(this, 0, length()). write('\n')
 	}
 	new: static func ~withLength (length: Int) -> This {
-		result := gc_malloc(length + 1) as Char*
+		result := calloc(1, length + 1) as Char*
 		result[length] = '\0'
 		result as This
 	}

--- a/source/sdk/Exception.ooc
+++ b/source/sdk/Exception.ooc
@@ -28,7 +28,7 @@ StackFrame: cover from _StackFrame* {
 		calloc(1, _StackFrame size)
 	}
 	free: func {
-		gc_free(this as Void*)
+		memfree(this as Void*)
 	}
 }
 

--- a/source/sdk/Exception.ooc
+++ b/source/sdk/Exception.ooc
@@ -25,7 +25,7 @@ _StackFrame: cover {
 
 StackFrame: cover from _StackFrame* {
 	new: static func -> This {
-		gc_malloc(_StackFrame size)
+		calloc(1, _StackFrame size)
 	}
 	free: func {
 		gc_free(this as Void*)

--- a/source/sdk/Memory.ooc
+++ b/source/sdk/Memory.ooc
@@ -11,8 +11,7 @@ memset: extern func (Pointer, Int, SizeT) -> Pointer
 memcmp: extern func (Pointer, Pointer, SizeT) -> Int
 memmove: extern func (Pointer, Pointer, SizeT)
 memcpy: extern func (Pointer, Pointer, SizeT)
-free: extern func (Pointer)
-gc_free: extern (free) func (Pointer)
+memfree: extern (free) func (Pointer)
 alloca: extern func (SizeT) -> Pointer
 
 // note: sizeof is intentionally not here. sizeof(Int) will be translated

--- a/source/sdk/Memory.ooc
+++ b/source/sdk/Memory.ooc
@@ -2,17 +2,8 @@ include string // Memory routines in C are actually in string.h
 version(windows) { include malloc }
 else { include alloca }
 
-// GC_MALLOC zeroes the memory, so in the non-gc version, we prefer to use calloc
-// to the expense of some performance. Don't use malloc instead - existing ooc code
-// is written assuming that gc_malloc zeroes the memory.
-gc_malloc: func (size: SizeT) -> Pointer { gc_calloc(1, size) }
-gc_malloc_atomic: extern (malloc) func (size: SizeT) -> Pointer
-gc_strdup: extern (strdup) func (str: CString) -> CString
-gc_realloc: extern (realloc) func (ptr: Pointer, size: SizeT) -> Pointer
-gc_calloc: extern (calloc) func (nmemb, size: SizeT) -> Pointer
-gc_free: extern (free) func (ptr: Pointer)
-
-//TODO Remove the above functions when they're no longer used, instead switch to an OOP-approach
+// Note: Original SDK ooc code assumes allocated memory is zeroed (calloc)
+// Consider using Buffer instead of calling these functions directly
 malloc: extern func (SizeT) -> Pointer
 calloc: extern func (SizeT, SizeT) -> Pointer
 realloc: extern func (Pointer, SizeT) -> Pointer
@@ -21,9 +12,13 @@ memcmp: extern func (Pointer, Pointer, SizeT) -> Int
 memmove: extern func (Pointer, Pointer, SizeT)
 memcpy: extern func (Pointer, Pointer, SizeT)
 free: extern func (Pointer)
+gc_free: extern (free) func (Pointer)
 alloca: extern func (SizeT) -> Pointer
 
 // note: sizeof is intentionally not here. sizeof(Int) will be translated
 // to sizeof(Int_class()), and thus will always give the same value for
 // all types. 'Int size' should be used instead, which will be translated
 // to 'Int_class()->size'
+
+// This one is still here because rock is hard-coded to use it
+gc_malloc: func (size: SizeT) -> Pointer { calloc(1, size) }

--- a/source/sdk/OwnedBuffer.ooc
+++ b/source/sdk/OwnedBuffer.ooc
@@ -35,7 +35,7 @@ OwnedBuffer: cover {
 	free: func@ -> Bool {
 		result := this isOwned
 		if (result)
-			gc_free(this _pointer)
+			memfree(this _pointer)
 		this _pointer = null
 		this _size = 0
 		this _owner = Owner Unknown

--- a/source/sdk/OwnedBuffer.ooc
+++ b/source/sdk/OwnedBuffer.ooc
@@ -29,7 +29,7 @@ OwnedBuffer: cover {
 		this init(null, 0, Owner Unknown)
 	}
 	init: func@ ~fromSize (size: Int, owner := Owner Receiver) {
-		this init(gc_malloc(size), size, owner)
+		this init(calloc(1, size), size, owner)
 	}
 	init: func@ ~fromData (=_pointer, =_size, =_owner)
 	free: func@ -> Bool {

--- a/source/sdk/Time.ooc
+++ b/source/sdk/Time.ooc
@@ -57,12 +57,12 @@ Time: class {
 		result: String
 		version (windows) {
 			dateLength := GetDateFormat(LOCALE_USER_DEFAULT, 0, null, null, null, 0)
-			dateBuffer := gc_malloc(dateLength) as Char*
+			dateBuffer := calloc(1, dateLength) as Char*
 			GetDateFormat(LOCALE_USER_DEFAULT, 0, null, null, dateBuffer, dateLength)
 			date := String new(dateBuffer, dateLength - 1)
 
 			timeLength := GetTimeFormat(LOCALE_USER_DEFAULT, 0, null, null, null, 0)
-			timeBuffer := gc_malloc(timeLength) as Char*
+			timeBuffer := calloc(1, timeLength) as Char*
 			GetTimeFormat(LOCALE_USER_DEFAULT, 0, null, null, timeBuffer, timeLength)
 			time := String new(timeBuffer, timeLength - 1)
 

--- a/source/sdk/VarArgs.ooc
+++ b/source/sdk/VarArgs.ooc
@@ -25,7 +25,7 @@ VarArgs: cover {
 
 	// private api used by C code
 	init: func@ (=count, bytes: SizeT) {
-		args = gc_malloc(bytes + (count * Class size))
+		args = calloc(1, bytes + (count * Class size))
 		argsPtr = args
 	}
 

--- a/source/sdk/io/BinarySequence.ooc
+++ b/source/sdk/io/BinarySequence.ooc
@@ -128,7 +128,7 @@ BinarySequenceReader: class {
 		String new(s)
 	}
 	bytes: func (length: SizeT) -> Byte* {
-		value := gc_malloc(length * Byte size) as Byte*
+		value := calloc(length, Byte size) as Byte*
 		for (i in 0 .. length)
 			value[i] = u8() as Byte
 		value

--- a/source/sdk/io/native/FileUnix.ooc
+++ b/source/sdk/io/native/FileUnix.ooc
@@ -267,7 +267,7 @@ version (unix || apple) {
 		getAbsolutePath: override func -> String {
 			assert(path != null)
 			assert(!path empty())
-			actualPath := gc_malloc(MAX_PATH_LENGTH) as CString
+			actualPath := calloc(1, MAX_PATH_LENGTH) as CString
 			ret := realpath(path, actualPath)
 			if (ret == null) {
 				OSException new("failed to get absolute path for " + path) throw()

--- a/source/sdk/lang/Array.h
+++ b/source/sdk/lang/Array.h
@@ -1,13 +1,8 @@
 #ifndef OOC_LANG_ARRAY_H
 #define OOC_LANG_ARRAY_H
 
-#ifdef __OOC_USE_GC__
-#define array_malloc GC_malloc
-#define array_free GC_free
-#else
 #define array_malloc(size) calloc(1, (size))
 #define array_free free
-#endif // GC
 
 #include <stdint.h>
 

--- a/source/sdk/lang/String.ooc
+++ b/source/sdk/lang/String.ooc
@@ -376,7 +376,7 @@ strArrayFromCString: func ~hack (argc: Int, argv: String*) -> String[] {
 }
 
 cStringPtrToStringPtr: func (cstr: CString*, len: Int) -> String* {
-	toRet: String* = calloc(1, Pointer size * len) // otherwise the pointers are stack-allocated
+	toRet: String* = calloc(len, Pointer size) // otherwise the pointers are stack-allocated
 	for (i in 0 .. len) {
 		toRet[i] = makeStringLiteral(cstr[i], cstr[i] length())
 	}

--- a/source/sdk/lang/String.ooc
+++ b/source/sdk/lang/String.ooc
@@ -376,7 +376,7 @@ strArrayFromCString: func ~hack (argc: Int, argv: String*) -> String[] {
 }
 
 cStringPtrToStringPtr: func (cstr: CString*, len: Int) -> String* {
-	toRet: String* = gc_malloc(Pointer size * len) // otherwise the pointers are stack-allocated
+	toRet: String* = calloc(1, Pointer size * len) // otherwise the pointers are stack-allocated
 	for (i in 0 .. len) {
 		toRet[i] = makeStringLiteral(cstr[i], cstr[i] length())
 	}

--- a/source/sdk/lang/types.ooc
+++ b/source/sdk/lang/types.ooc
@@ -7,7 +7,7 @@ Object: abstract class {
 
 	free: virtual func {
 		this __destroy__()
-		free(this)
+		memfree(this)
 	}
 
 	/// Instance initializer: set default values for a new instance of this class
@@ -112,7 +112,7 @@ Closure: cover {
 	free: func@ -> Bool {
 		result := this context != null
 		if (result) {
-			gc_free(this context)
+			memfree(this context)
 			this context = null
 			this thunk = null
 		}
@@ -127,7 +127,7 @@ Cell: class <T> {
 	init: func ~noval
 
 	free: override func {
-		gc_free(this val)
+		memfree(this val)
 		super()
 	}
 

--- a/source/sdk/lang/types.ooc
+++ b/source/sdk/lang/types.ooc
@@ -50,7 +50,7 @@ Class: abstract class {
 
 	// Create a new instance of the object of type defined by this class
 	alloc: final func ~_class -> Object {
-		object := gc_malloc(instanceSize) as Object
+		object := calloc(1, instanceSize) as Object
 		if (object)
 			object class = this
 		object

--- a/source/sdk/structs/ArrayList.ooc
+++ b/source/sdk/structs/ArrayList.ooc
@@ -10,11 +10,11 @@ ArrayList: class <T> extends BackIterable<T> {
 	}
 
 	init: func ~withCapacity (=capacity) {
-		data = gc_malloc(capacity * T size)
+		data = calloc(1, capacity * T size)
 	}
 
 	init: func ~withData (.data, =_size) {
-		this data = gc_malloc(_size * T size)
+		this data = calloc(1, _size * T size)
 		memcpy(this data, data, _size * T size)
 		capacity = _size
 	}
@@ -158,7 +158,7 @@ ArrayList: class <T> extends BackIterable<T> {
 	ensureCapacity: func (newSize: SizeT) {
 		if (newSize > capacity) {
 			capacity = newSize * (newSize > 50000 ? 2 : 4)
-			tmpData := gc_realloc(data, capacity * T size)
+			tmpData := realloc(data, capacity * T size)
 			if (tmpData) {
 				data = tmpData
 			} else {

--- a/source/sdk/structs/ArrayList.ooc
+++ b/source/sdk/structs/ArrayList.ooc
@@ -10,17 +10,17 @@ ArrayList: class <T> extends BackIterable<T> {
 	}
 
 	init: func ~withCapacity (=capacity) {
-		data = calloc(1, capacity * T size)
+		data = calloc(capacity, T size)
 	}
 
 	init: func ~withData (.data, =_size) {
-		this data = calloc(1, _size * T size)
+		this data = calloc(_size, T size)
 		memcpy(this data, data, _size * T size)
 		capacity = _size
 	}
 
 	free: override func {
-		gc_free(this data)
+		memfree(this data)
 		super()
 	}
 

--- a/source/sdk/structs/HashMap.ooc
+++ b/source/sdk/structs/HashMap.ooc
@@ -33,12 +33,12 @@ HashEntry: cover {
 
 	init: func@ ~keyVal (=key, =value)
 	free: func {
-		free(this key)
-		free(this value)
+		memfree(this key)
+		memfree(this value)
 		if (this next != null) {
 			temp := this next@
 			temp free()
-			free(this next)
+			memfree(this next)
 		}
 	}
 }
@@ -304,8 +304,8 @@ HashMap: class <K, V> extends BackIterable<V> {
 		if (entry@ key != null) {
 			while (true) {
 				if (keyEquals(entry@ key as K, key)) {
-					free(entry@ key)
-					free(entry@ value)
+					memfree(entry@ key)
+					memfree(entry@ value)
 
 					if (prev)
 						prev@ next = entry@ next // re-connect the previous to the next one

--- a/source/sdk/structs/HashMap.ooc
+++ b/source/sdk/structs/HashMap.ooc
@@ -256,20 +256,20 @@ HashMap: class <K, V> extends BackIterable<V> {
 				while (currentPointer@ next)
 					currentPointer = currentPointer@ next
 
-				newEntry := gc_malloc(HashEntry size) as HashEntry*
+				newEntry := calloc(1, HashEntry size) as HashEntry*
 
-				newEntry@ key = gc_malloc(K size)
+				newEntry@ key = calloc(1, K size)
 				memcpy(newEntry@ key, key, K size)
 
-				newEntry@ value = gc_malloc(V size)
+				newEntry@ value = calloc(1, V size)
 				memcpy(newEntry@ value, value, V size)
 
 				currentPointer@ next = newEntry
 			} else {
-				entry key = gc_malloc(K size)
+				entry key = calloc(1, K size)
 				memcpy(entry key, key, K size)
 
-				entry value = gc_malloc(V size)
+				entry value = calloc(1, V size)
 				memcpy(entry value, value, V size)
 
 				entry next = null

--- a/source/sdk/structs/Stack.ooc
+++ b/source/sdk/structs/Stack.ooc
@@ -6,7 +6,7 @@ Stack: class <T> {
 	isEmpty ::= this size == 0
 	top ::= this peek()
 	init: func {
-		this _data = gc_malloc(this _capacity * T size)
+		this _data = calloc(1, this _capacity * T size)
 	}
 	free: override func {
 		gc_free(this _data)
@@ -40,6 +40,6 @@ Stack: class <T> {
 			this _capacity *= 2
 		else
 			this _capacity += 2048
-		this _data = gc_realloc(this _data, this _capacity * T size)
+		this _data = realloc(this _data, this _capacity * T size)
 	}
 }

--- a/source/sdk/structs/Stack.ooc
+++ b/source/sdk/structs/Stack.ooc
@@ -6,10 +6,10 @@ Stack: class <T> {
 	isEmpty ::= this size == 0
 	top ::= this peek()
 	init: func {
-		this _data = calloc(1, this _capacity * T size)
+		this _data = calloc(this _capacity, T size)
 	}
 	free: override func {
-		gc_free(this _data)
+		memfree(this _data)
 		super()
 	}
 	push: func (element: T) {

--- a/source/sdk/structs/Vector.ooc
+++ b/source/sdk/structs/Vector.ooc
@@ -102,7 +102,7 @@ HeapVector: class <T> extends Vector<T> {
 	}
 
 	_allocate: func (capacity: Int) {
-		this _backend = gc_realloc(this _backend, capacity * T size)
+		this _backend = realloc(this _backend, capacity * T size)
 	}
 
 	resize: override func (capacity: Int) {

--- a/source/sdk/structs/Vector.ooc
+++ b/source/sdk/structs/Vector.ooc
@@ -26,7 +26,7 @@ Vector: abstract class <T> {
 	}
 	free: override func {
 		if (!(this instanceOf?(StackVector)))
-			gc_free(this _backend)
+			memfree(this _backend)
 		super()
 	}
 	_free: func ~range (start, end: Int) {

--- a/source/sdk/threading/native/ConditionUnix.ooc
+++ b/source/sdk/threading/native/ConditionUnix.ooc
@@ -16,7 +16,7 @@ ConditionUnix: class extends WaitCondition {
 	_backend: PThreadCond*
 
 	init: func {
-		this _backend = gc_malloc(PThreadCond size) as PThreadCond*
+		this _backend = calloc(1, PThreadCond size) as PThreadCond*
 		result := pthread_cond_init(this _backend, null)
 		if (result != 0)
 			raise("Something went wrong when calling pthread_cond_init")

--- a/source/sdk/threading/native/ConditionUnix.ooc
+++ b/source/sdk/threading/native/ConditionUnix.ooc
@@ -23,7 +23,7 @@ ConditionUnix: class extends WaitCondition {
 	}
 	free: override func {
 		pthread_cond_destroy(this _backend)
-		gc_free(this _backend)
+		memfree(this _backend)
 		super()
 	}
 	wait: override func (mutex: Mutex) -> Bool {

--- a/source/ui/x11/X11Window.ooc
+++ b/source/ui/x11/X11Window.ooc
@@ -75,7 +75,7 @@ X11Window: class extends NativeWindow {
 		if (this _cacheSize != image size) {
 			if (this _xImage)
 				XDestroyImage(this _xImage)
-			imageData := calloc(1, image height * image stride * 4)
+			imageData := calloc(image height * image stride, 4)
 			this _xImage = XCreateImage(this display, CopyFromParent, this _displayDepth, ZPixmap, 0, imageData, image width, image height, 8, 0)
 			this _cacheSize = image size
 		}

--- a/source/ui/x11/X11Window.ooc
+++ b/source/ui/x11/X11Window.ooc
@@ -75,7 +75,7 @@ X11Window: class extends NativeWindow {
 		if (this _cacheSize != image size) {
 			if (this _xImage)
 				XDestroyImage(this _xImage)
-			imageData := gc_malloc(image height * image stride * 4)
+			imageData := calloc(1, image height * image stride * 4)
 			this _xImage = XCreateImage(this display, CopyFromParent, this _displayDepth, ZPixmap, 0, imageData, image width, image height, 8, 0)
 			this _cacheSize = image size
 		}


### PR DESCRIPTION
The `gc_` prefix makes no sense.

`gc_malloc(...) -> calloc(1, ...)` (or if there's a better way to write it)
`gc_calloc(..., ...) -> calloc(..., ...)`
`gc_malloc_atomic(...) -> malloc(...)`

`gc_free` has been renamed to `memfree` to make all these calls easier to find. If you have another suggestion, let me know.

After this, these calls should be replaced by the use of our `Buffer` cover which will handle memory management in an OOP manner.