### PR TITLE
Moved all data from `Canvas` to a new `Brush` class.

### DIFF
--- a/ooc-draw.use
+++ b/ooc-draw.use
@@ -22,6 +22,7 @@ Imports: RasterYuv420Semiplanar
 Imports: RasterYuv422Semipacked
 Imports: FloatImage
 Imports: Canvas
+Imports: Brush
 Imports: Pen
 Additionals: source/draw/stb_image/stb_image.c
 Additionals: source/draw/stb_image/stb_image_write.c

--- a/source/draw/Brush.ooc
+++ b/source/draw/Brush.ooc
@@ -23,18 +23,27 @@ InterpolationMode: enum {
 	Smooth // bilinear
 }
 
+BrushData: cover {
+	viewport: IntBox2D
+	pen: Pen
+	transform: FloatTransform3D
+	blend: Bool
+	opacity: Float
+	focalLength: Float
+	interpolationMode: InterpolationMode
+}
+
 Brush: class {
+	brushData: BrushData
 	_size: IntVector2D
-	_pen := Pen new()
-	_transform := FloatTransform3D identity
 	size ::= this _size
-	pen: Pen { get { this _pen } set(value) { this _pen = value } }
-	viewport: IntBox2D { get set }
-	blend: Bool { get set }
-	opacity: Float { get set }
-	transform: FloatTransform3D { get { this _transform } set(value) { this _transform = value } }
-	focalLength: Float { get set }
-	interpolationMode: InterpolationMode { get set }
+	pen: Pen { get { this brushData pen } set(value) { this brushData pen = value } }
+	viewport: IntBox2D { get { this brushData viewport } set(value) { this brushData viewport = value } }
+	blend: Bool { get { this brushData blend } set(value) { this brushData blend = value } }
+	opacity: Float { get { this brushData opacity } set(value) { this brushData opacity = value } }
+	transform: FloatTransform3D { get { this brushData transform } set(value) { this brushData transform = value } }
+	focalLength: Float { get { this brushData focalLength } set(value) { this brushData focalLength = value } }
+	interpolationMode: InterpolationMode { get { this brushData interpolationMode } set(value) { this brushData interpolationMode = value } }
 	init: func (=_size) {
 		this viewport = IntBox2D new(size)
 		this focalLength = 0.0f

--- a/source/draw/Brush.ooc
+++ b/source/draw/Brush.ooc
@@ -35,8 +35,6 @@ BrushData: cover {
 
 Brush: class {
 	brushData: BrushData
-	_size: IntVector2D
-	size ::= this _size
 	pen: Pen { get { this brushData pen } set(value) { this brushData pen = value } }
 	viewport: IntBox2D { get { this brushData viewport } set(value) { this brushData viewport = value } }
 	blend: Bool { get { this brushData blend } set(value) { this brushData blend = value } }
@@ -44,7 +42,7 @@ Brush: class {
 	transform: FloatTransform3D { get { this brushData transform } set(value) { this brushData transform = value } }
 	focalLength: Float { get { this brushData focalLength } set(value) { this brushData focalLength = value } }
 	interpolationMode: InterpolationMode { get { this brushData interpolationMode } set(value) { this brushData interpolationMode = value } }
-	init: func (=_size) {
+	init: func (size: IntVector2D) {
 		this viewport = IntBox2D new(size)
 		this focalLength = 0.0f
 		this blend = false

--- a/source/draw/Brush.ooc
+++ b/source/draw/Brush.ooc
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2011-2014 Simon Mika <simon@mika.se>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use ooc-base
+use ooc-geometry
+import Pen
+
+InterpolationMode: enum {
+	Fast // nearest neighbour
+	Smooth // bilinear
+}
+
+Brush: class {
+	_size: IntVector2D
+	_pen := Pen new()
+	_transform := FloatTransform3D identity
+	size ::= this _size
+	pen: Pen { get { this _pen } set(value) { this _pen = value } }
+	viewport: IntBox2D { get set }
+	blend: Bool { get set }
+	opacity: Float { get set }
+	transform: FloatTransform3D { get { this _transform } set(value) { this _transform = value } }
+	focalLength: Float { get set }
+	interpolationMode: InterpolationMode { get set }
+	init: func (=_size) {
+		this viewport = IntBox2D new(size)
+		this focalLength = 0.0f
+		this blend = false
+		this opacity = 1.0f
+		this interpolationMode = InterpolationMode Fast
+	}
+}

--- a/source/draw/Canvas.ooc
+++ b/source/draw/Canvas.ooc
@@ -17,31 +17,11 @@
 use ooc-base
 use ooc-geometry
 use ooc-collections
-import Image, Pen
+import Image, Brush
 
-InterpolationMode: enum {
-	Fast // nearest neighbour
-	Smooth // bilinear
-}
-
-Canvas: abstract class {
-	_size: IntVector2D
-	_pen := Pen new()
-	_transform := FloatTransform3D identity
-	size ::= this _size
-	pen: Pen { get { this _pen } set(value) { this _pen = value } }
-	viewport: IntBox2D { get set }
-	blend: Bool { get set }
-	opacity: Float { get set }
-	transform: FloatTransform3D { get { this _transform } set(value) { this _transform = value } }
-	focalLength: Float { get set }
-	interpolationMode: InterpolationMode { get set }
-	init: func (=_size) {
-		this viewport = IntBox2D new(size)
-		this focalLength = 0.0f
-		this blend = false
-		this opacity = 1.0f
-		this interpolationMode = InterpolationMode Fast
+Canvas: abstract class extends Brush {
+	init: func (size: IntVector2D) {
+		super(size)
 	}
 	drawPoint: virtual func (position: FloatPoint2D) {
 		list := VectorList<FloatPoint2D> new()

--- a/source/draw/Canvas.ooc
+++ b/source/draw/Canvas.ooc
@@ -20,8 +20,10 @@ use ooc-collections
 import Image, Brush
 
 Canvas: abstract class extends Brush {
-	init: func (size: IntVector2D) {
-		super(size)
+	_size: IntVector2D
+	size ::= this _size
+	init: func (=_size) {
+		super(this _size)
 	}
 	drawPoint: virtual func (position: FloatPoint2D) {
 		list := VectorList<FloatPoint2D> new()

--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -16,7 +16,7 @@
 
 use ooc-geometry
 use ooc-base
-import Canvas
+import Canvas, Brush
 
 CoordinateSystem: enum {
 	Default = 0x00

--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -21,7 +21,7 @@ import RasterImage
 import StbImage
 import Image
 import Color
-import Canvas, RasterCanvas
+import Canvas, Brush, RasterCanvas
 
 RasterBgrCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterBgr

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -21,7 +21,7 @@ import RasterImage
 import StbImage
 import Image
 import Color
-import Canvas, RasterCanvas
+import Canvas, Brush, RasterCanvas
 
 RasterBgraCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterBgra

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -71,6 +71,6 @@ RasterCanvas: abstract class extends Canvas {
 			}
 	}
 	_map: func (point: IntPoint2D) -> IntPoint2D {
-		point + this _size / 2
+		point + this size / 2
 	}
 }

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -22,7 +22,7 @@ import RasterImage
 import StbImage
 import Image, FloatImage
 import Color
-import Canvas, RasterCanvas
+import Canvas, Brush, RasterCanvas
 
 RasterMonochromeCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterMonochrome

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -24,7 +24,7 @@ import RasterBgra
 import RasterBgr
 import RasterMonochrome
 import Image
-import Canvas, RasterCanvas
+import Canvas, Brush, RasterCanvas
 
 RasterPackedCanvas: abstract class extends RasterCanvas {
 	target ::= this _target as RasterPacked

--- a/source/draw/gpu/GpuCanvas.ooc
+++ b/source/draw/gpu/GpuCanvas.ooc
@@ -40,9 +40,9 @@ GpuCanvasYuv420Semiplanar: class extends GpuSurface {
 		}
 	}
 	pen: Pen {
-		get { this _pen }
+		get { this pen }
 		set(value) {
-			this _pen = value
+			this pen = value
 			yuv := value color toYuv()
 			this _target y canvas pen = Pen new(ColorBgra new(yuv y, 0, 0, 255), value width)
 			this _target uv canvas pen = Pen new(ColorBgra new(yuv u, yuv v, 0, 255), value width)

--- a/source/draw/gpu/GpuSurface.ooc
+++ b/source/draw/gpu/GpuSurface.ooc
@@ -34,9 +34,9 @@ GpuSurface: abstract class extends Canvas {
 	_defaultMap: GpuMap
 	_coordinateTransform := IntTransform2D identity
 	transform: FloatTransform3D {
-		get { this _transform }
+		get { this transform }
 		set(value) {
-			this _transform = value
+			this transform = value
 			this _view = this _toLocal * value * this _toLocal
 		}
 	}


### PR DESCRIPTION
An experiment in changing the Draw API without breaking backward compability just to explore which options are possible.

Goals:
* To not have unwanted side effects between filters when color and projection changes before a draw call.
* To only need two draw methods where one is a simple wrapper on the other (Default settings or given from another Brush). Another canvas can be used as a brush by inheritance if you just gave the same settings there. If no Brush is given to the new draw call, the called canvas itself will be the brush.

Challenges:
* One settings object for both CPU and GPU.
* Abstraction while still working with OpenGL and CPU.