### PR TITLE
Draw API

### DIFF
--- a/draw.use
+++ b/draw.use
@@ -24,6 +24,7 @@ Imports: FloatImage
 Imports: Canvas
 Imports: Pen
 Imports: Map
+Imports: DrawState
 Additionals: source/draw/stb_image/stb_image.h
 Additionals: source/draw/stb_image/stb_image_write.h
 Additionals: source/draw/stb_image/stb_image_impl.c

--- a/source/draw/Canvas.ooc
+++ b/source/draw/Canvas.ooc
@@ -17,7 +17,9 @@
 use base
 use geometry
 use collections
-import Image, Pen, DrawState
+import Image
+import Pen
+import DrawState
 
 InterpolationMode: enum {
 	Fast // nearest neighbour

--- a/source/draw/Canvas.ooc
+++ b/source/draw/Canvas.ooc
@@ -17,7 +17,7 @@
 use base
 use geometry
 use collections
-import Image, Pen
+import Image, Pen, DrawState
 
 InterpolationMode: enum {
 	Fast // nearest neighbour
@@ -68,6 +68,7 @@ Canvas: abstract class {
 		positions free()
 	}
 	fill: abstract func
+	draw: virtual func ~DrawState (drawState: DrawState) { Debug raise("draw~DrawState unimplemented!") }
 	draw: abstract func ~ImageSourceDestination (image: Image, source, destination: IntBox2D)
 	draw: func ~ImageDestination (image: Image, destination: IntBox2D) { this draw(image, IntBox2D new(image size), destination) }
 	draw: func ~Image (image: Image) { this draw(image, IntBox2D new(image size)) }

--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -15,7 +15,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use geometry
-import Pen, Image, Map
+import Pen
+import Image
+import Map
 
 // Example
 // DrawState new(myImage) setMap(myShader) draw()

--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2011-2014 Simon Mika <simon@mika.se>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use geometry
+import Pen, Image, Map
+
+// Example
+// DrawState new(myImage) setMap(myShader) draw()
+
+DrawState: cover {
+	target: Image = null
+	inputImage: Image = null
+	map: Map = null
+	opacity := 1.0f
+	_transformNormalized := FloatTransform3D identity
+	viewport := IntBox2D new(0, 0, 0, 0)
+	init: func@ ~default
+	init: func@ ~target (=target)
+	setTarget: func (target: Image) -> This {
+		this target = target
+		this
+	}
+	setMap: func (map: Map) -> This {
+		this map = map
+		this
+	}
+	setOpacity: func (opacity: Float) -> This {
+		this opacity = opacity
+		this
+	}
+	setViewport: func (viewport: IntBox2D) -> This {
+		this viewport = viewport
+		this
+	}
+	setInputImage: func (inputImage: Image) -> This {
+		this inputImage = inputImage
+		this
+	}
+	setTransformReference: func ~targetSize (transform: FloatTransform3D) -> This {
+		this setTransformNormalized(transform referenceToNormalized(this target size))
+	}
+	setTransformReference: func ~explicit (transform: FloatTransform3D, imageSize: FloatVector2D) -> This {
+		this setTransformNormalized(transform referenceToNormalized(imageSize))
+	}
+	setTransformNormalized: func (transform: FloatTransform3D) -> This {
+		this _transformNormalized = transform
+		this
+	}
+	getTransformNormalized: func -> FloatTransform3D { this _transformNormalized }
+	draw: func { this target canvas draw(this) }
+}

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -20,6 +20,7 @@ use collections
 import Image
 import Canvas
 import Pen
+import DrawState
 import RasterImage
 
 RasterCanvas: abstract class extends Canvas {

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -29,14 +29,10 @@ OpenGLCanvas: class extends OpenGLSurface {
 	_renderTarget: GLFramebufferObject
 	context ::= this _context as OpenGLContext
 	draw: override func ~DrawState (drawState: DrawState) {
-		// Set shader
-		gpuMap: GpuMap = (drawState map == null) ? this context defaultMap : drawState map as GpuMap
-		// Set viewport
+		gpuMap: GpuMap = drawState map as GpuMap ?? this context defaultMap
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
 		this context backend setViewport(viewport)
-		// Set transform
 		gpuMap view = _toLocal * drawState getTransformNormalized() normalizedToReference(this size) * _toLocal
-		// Set model and projection matrices
 		if (this _focalLength > 0.0f) {
 			a := 2.0f * this _focalLength / this size x
 			f := -(this _coordinateTransform e as Float) * 2.0f * this _focalLength / this size y
@@ -46,15 +42,12 @@ OpenGLCanvas: class extends OpenGLSurface {
 		} else
 			gpuMap projection = FloatTransform3D createScaling(2.0f / this size x, -(this _coordinateTransform e as Float) * 2.0f / this size y, 1.0f)
 		gpuMap model = this _createModelTransform(IntBox2D new(this size))
-		// Set opacity
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)
 		else
 			this context backend enableBlend(false)
-		// Set texture
 		if (drawState inputImage)
 			gpuMap add("texture0", drawState inputImage)
-		// Draw
 		gpuMap use()
 		this _bind()
 		this context drawQuad()


### PR DESCRIPTION
An alternative draw API that can be used next to the old API for backward compability.

The only usability problem so far is that you can forget to call `draw` after creating the `DrawState`.

Remaining steps for other pull requests:
* Implement drawing of points, lines and meshes using the Pen cover, source viewport and other new settings.
* Support drawing without GPU.
* Make lots of test cases.
* Slowly get everyone to use the new API while testing everything properly.
* Clean up `pen`, `transform`, `opacity`, `blend`, `viewport`,... from canvas where they do not belong.
* Give matrices in normalized coordinates directly to the vertex shader to reduce the double, tripple, quadruple,... conversions between reference and normalized coordinates.