### PR TITLE
String split() now returns VectorList

### DIFF
--- a/source/draw/gpu/opengl/backend/gles3/Gles3Debug.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Debug.ooc
@@ -55,7 +55,7 @@ getExtensions: func -> String {
 	result: CString = glGetString(GL_EXTENSIONS) as CString
 	String new(result, result length())
 }
-getExtensionList: func -> ArrayList<String> {
+getExtensionList: func -> VectorList<String> {
 	string := getExtensions()
 	string split(' ')
 }
@@ -66,7 +66,7 @@ queryExtension: func (extension: String) -> Bool {
 printExtensions: func {
 	array := getExtensionList()
 	Debug print("OpenGL extensions:")
-	for (i in 0 .. array size)
+	for (i in 0 .. array count)
 		Debug print(array[i])
 }
 printVersionInfo: func {

--- a/source/sdk/Backtrace.ooc
+++ b/source/sdk/Backtrace.ooc
@@ -121,8 +121,8 @@ BacktraceHandler: class {
 			line := lines[i] toString()
 			tokens := line split('|') map(|x| x trim())
 
-			if (tokens size <= 4) {
-				if (tokens size >= 2) {
+			if (tokens count <= 4) {
+				if (tokens count >= 2) {
 					binary := tokens[0]
 					file := "(from %s)" format(binary)
 					symbol := tokens[2]

--- a/source/sdk/CharBuffer.ooc
+++ b/source/sdk/CharBuffer.ooc
@@ -523,23 +523,23 @@ CharBuffer: class extends Iterable<Char> {
 
 	toCString: func -> CString { data as CString }
 
-	split: func ~withChar (c: Char, maxTokens: SSizeT) -> ArrayList<This> {
+	split: func ~withChar (c: Char, maxTokens: SSizeT) -> VectorList<This> {
 		split(c&, 1, maxTokens)
 	}
 
-	split: func ~withStringWithoutmaxTokens (s: This) -> ArrayList<This> {
+	split: func ~withStringWithoutmaxTokens (s: This) -> VectorList<This> {
 		split(s data, s size, -1)
 	}
 
-	split: func ~withCharWithoutmaxTokens (c: Char) -> ArrayList<This> {
+	split: func ~withCharWithoutmaxTokens (c: Char) -> VectorList<This> {
 		split(c&, 1, -1)
 	}
 
-	split: func ~withBufWithEmpties (s: This, empties: Bool) -> ArrayList<This> {
+	split: func ~withBufWithEmpties (s: This, empties: Bool) -> VectorList<This> {
 		split(s data, s size, empties ? -1 : 0)
 	}
 
-	split: func ~withCharWithEmpties (c: Char, empties: Bool) -> ArrayList<This> {
+	split: func ~withCharWithEmpties (c: Char, empties: Bool) -> VectorList<This> {
 		split(c&, 1, empties ? -1 : 0)
 	}
 
@@ -552,18 +552,18 @@ CharBuffer: class extends Iterable<Char> {
 	 *   - if negative, the string will be fully split into tokens
 	 *   - if zero, it will return all non-empty elements
 	 */
-	split: func ~buf (delimiter: This, maxTokens: SSizeT) -> ArrayList<This> {
+	split: func ~buf (delimiter: This, maxTokens: SSizeT) -> VectorList<This> {
 		split(delimiter data, delimiter size, maxTokens)
 	}
 
-	split: func ~pointer (delimiter: Char*, delimiterLength: SizeT, maxTokens: SSizeT) -> ArrayList<This> {
+	split: func ~pointer (delimiter: Char*, delimiterLength: SizeT, maxTokens: SSizeT) -> VectorList<This> {
 		findResults := findAll(delimiter, delimiterLength, true)
 		maxItems := ((maxTokens <= 0) || (maxTokens > findResults size + 1)) ? findResults size + 1 : maxTokens
-		result := ArrayList<This> new(maxItems)
+		result := VectorList<This> new(maxItems, false)
 		sstart: SizeT = 0 //source (this) start pos
 
 		for (item in 0 .. findResults size) {
-			if ((maxTokens > 0) && (result size == maxItems - 1)) break
+			if ((maxTokens > 0) && (result count == maxItems - 1)) break
 
 			sdist := findResults[item] - sstart // bytes to copy
 			if (maxTokens != 0 || sdist > 0) {
@@ -573,7 +573,7 @@ CharBuffer: class extends Iterable<Char> {
 			sstart += sdist + delimiterLength
 		}
 
-		if (result size < maxItems) {
+		if (result count < maxItems) {
 			sdist := size - sstart // bytes to copy
 			b := new((data + sstart) as CString, sdist)
 			result add(b)

--- a/source/sdk/lang/String.ooc
+++ b/source/sdk/lang/String.ooc
@@ -118,9 +118,9 @@ String: class extends Iterable<Char> {
 		(_buffer clone()) map(f). toString()
 	}
 
-	_bufArrayListToStrArrayList: func (x: ArrayList<CharBuffer>) -> ArrayList<This> {
-		result := ArrayList<This> new( x size )
-		for (i in 0 .. x size) result add (x[i] toString())
+	_bufArrayListToStrArrayList: func (x: VectorList<CharBuffer>) -> VectorList<This> {
+		result := VectorList<This> new( x count )
+		for (i in 0 .. x count) result add (x[i] toString())
 		result
 	}
 
@@ -284,26 +284,26 @@ String: class extends Iterable<Char> {
 
 	toCString: func -> CString { _buffer data as CString }
 
-	split: func ~withChar (c: Char, maxTokens: SSizeT) -> ArrayList<This> {
+	split: func ~withChar (c: Char, maxTokens: SSizeT) -> VectorList<This> {
 		_bufArrayListToStrArrayList(_buffer split(c, maxTokens))
 	}
 
-	split: func ~withStringWithoutmaxTokens (s: This) -> ArrayList<This> {
+	split: func ~withStringWithoutmaxTokens (s: This) -> VectorList<This> {
 		_bufArrayListToStrArrayList(_buffer split(s _buffer, -1))
 	}
 
-	split: func ~withCharWithoutmaxTokens (c: Char) -> ArrayList<This> {
+	split: func ~withCharWithoutmaxTokens (c: Char) -> VectorList<This> {
 		bufferSplit := _buffer split(c)
 		result := _bufArrayListToStrArrayList(bufferSplit)
 		bufferSplit free()
 		result
 	}
 
-	split: func ~withStringWithEmpties (s: This, empties: Bool) -> ArrayList<This> {
+	split: func ~withStringWithEmpties (s: This, empties: Bool) -> VectorList<This> {
 		_bufArrayListToStrArrayList(_buffer split(s _buffer, empties))
 	}
 
-	split: func ~withCharWithEmpties (c: Char, empties: Bool) -> ArrayList<This> {
+	split: func ~withCharWithEmpties (c: Char, empties: Bool) -> VectorList<This> {
 		_bufArrayListToStrArrayList(_buffer split(c, empties))
 	}
 
@@ -316,7 +316,7 @@ String: class extends Iterable<Char> {
 	 *   - if negative, the string will be fully split into tokens
 	 *   - if zero, it will return all non-empty elements
 	 */
-	split: func ~str (delimiter: This, maxTokens: SSizeT) -> ArrayList<This> {
+	split: func ~str (delimiter: This, maxTokens: SSizeT) -> VectorList<This> {
 		_bufArrayListToStrArrayList(_buffer split(delimiter _buffer, maxTokens))
 	}
 }


### PR DESCRIPTION
`CharBuffer split` returns a `VectorList` which doesn't free its contents, and so works just like the old `ArrayList`.