### PR TITLE
Fixed singularity problem in Quaternion weightedMean

### DIFF
--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -237,9 +237,11 @@ Quaternion: cover {
 		// Rotate quaternions if the angle is close to pi to avoid singularity problem
 		centerQuaternion := quaternions[quaternions count / 2]
 		preRotate := centerQuaternion angle(This identity) equals(Float pi, 0.5f)
-		if (preRotate)
+		if (preRotate) {
+			centerQuaternionInverse := centerQuaternion inverse
 			for (index in 0 .. quaternions count)
-				quaternions[index] = centerQuaternion inverse * quaternions[index]
+				quaternions[index] = centerQuaternionInverse * quaternions[index]
+		}
 		observationVectors := This _createVectorMeasurementsForQuest(quaternions)
 		normalizedWeights := weights / weights sum
 

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -234,7 +234,12 @@ Quaternion: cover {
 		// W - observationVectors
 		// Y - gibbsVector
 		// Z - vectorQuantityZ
-		// TODO: Fix singularity problem when the angle is close to PI, using sequential rotations
+		// Rotate quaternions if the angle is close to pi to avoid singularity problem
+		centerQuaternion := quaternions[quaternions count / 2]
+		preRotate := centerQuaternion angle(This identity) equals(Float pi, 0.5f)
+		if (preRotate)
+			for (index in 0 .. quaternions count)
+				quaternions[index] = centerQuaternion inverse * quaternions[index]
 		observationVectors := This _createVectorMeasurementsForQuest(quaternions)
 		normalizedWeights := weights / weights sum
 
@@ -268,7 +273,7 @@ Quaternion: cover {
 		matrixQuantityS free()
 		vectorQuantityZ free()
 		gibbsVector free()
-		result
+		preRotate ? centerQuaternion * result : result
 	}
 	_approximateMaximumEigenvalueForQuest: static func (matrixQuantityS, vectorQuantityZ: FloatMatrix, initialGuess: Float, maximumIterationCount := 20) -> Float {
 		sigma := 0.5f * matrixQuantityS trace()


### PR DESCRIPTION
I have tested this in applied usage and it seems to get rid of the problems that were apparent before.

I could not find an issue for this TODO.