### PR TITLE
Projection

### DIFF
--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -32,16 +32,16 @@ OpenGLCanvas: class extends OpenGLSurface {
 		gpuMap: GpuMap = drawState map as GpuMap ?? this context defaultMap
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
 		this context backend setViewport(viewport)
-		gpuMap view = _toLocal * drawState getTransformNormalized() normalizedToReference(this size) * _toLocal
+		gpuMap view = _toLocal * drawState getTransformNormalized() * _toLocal
 		if (this _focalLength > 0.0f) {
-			a := 2.0f * this _focalLength / this size x
-			f := -(this _coordinateTransform e as Float) * 2.0f * this _focalLength / this size y
+			a := this _focalLength
+			f := -(this _coordinateTransform e as Float) * this _focalLength
 			k := (this _farPlane + this _nearPlane) / (this _farPlane - this _nearPlane)
 			o := 2.0f * this _farPlane * this _nearPlane / (this _farPlane - this _nearPlane)
 			gpuMap projection = FloatTransform3D new(a, 0.0f, 0.0f, 0.0f, 0.0f, f, 0.0f, 0.0f, 0.0f, 0.0f, k, -1.0f, 0.0f, 0.0f, o, 0.0f)
 		} else
-			gpuMap projection = FloatTransform3D createScaling(2.0f / this size x, -(this _coordinateTransform e as Float) * 2.0f / this size y, 1.0f)
-		gpuMap model = this _createModelTransform(IntBox2D new(this size))
+			gpuMap projection = FloatTransform3D createScaling(1.0f, -(this _coordinateTransform e as Float), 1.0f)
+		gpuMap model = FloatTransform3D identity
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)
 		else

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -32,7 +32,7 @@ OpenGLCanvas: class extends OpenGLSurface {
 		gpuMap: GpuMap = drawState map as GpuMap ?? this context defaultMap
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
 		this context backend setViewport(viewport)
-		gpuMap model = FloatTransform3D identity // TODO: set using a destination argument in drawState
+		gpuMap model = FloatTransform3D createTranslation(0.0f, 0.0f, this focalLength) // TODO: set using a destination argument in drawState
 		gpuMap view = _toLocal * drawState getTransformNormalized() * _toLocal
 		gpuMap projection = FloatTransform3D createProjection(this _focalLength, this _nearPlane, this _farPlane, this _coordinateTransform)
 		// Set opacity

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -32,16 +32,10 @@ OpenGLCanvas: class extends OpenGLSurface {
 		gpuMap: GpuMap = drawState map as GpuMap ?? this context defaultMap
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
 		this context backend setViewport(viewport)
+		gpuMap model = FloatTransform3D identity // TODO: set using a destination argument in drawState
 		gpuMap view = _toLocal * drawState getTransformNormalized() * _toLocal
-		if (this _focalLength > 0.0f) {
-			a := this _focalLength
-			f := -(this _coordinateTransform e as Float) * this _focalLength
-			k := (this _farPlane + this _nearPlane) / (this _farPlane - this _nearPlane)
-			o := 2.0f * this _farPlane * this _nearPlane / (this _farPlane - this _nearPlane)
-			gpuMap projection = FloatTransform3D new(a, 0.0f, 0.0f, 0.0f, 0.0f, f, 0.0f, 0.0f, 0.0f, 0.0f, k, -1.0f, 0.0f, 0.0f, o, 0.0f)
-		} else
-			gpuMap projection = FloatTransform3D createScaling(1.0f, -(this _coordinateTransform e as Float), 1.0f)
-		gpuMap model = FloatTransform3D identity
+		gpuMap projection = FloatTransform3D createProjection(this _focalLength, this _nearPlane, this _farPlane, this _coordinateTransform)
+		// Set opacity
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)
 		else

--- a/source/geometry/FloatTransform3D.ooc
+++ b/source/geometry/FloatTransform3D.ooc
@@ -23,6 +23,7 @@ import FloatVector3D
 import FloatPoint2D
 import FloatPoint3D
 import FloatBox2D
+import IntTransform2D
 import FloatTransform2D
 
 // The 3D transform is a 4x4 homogeneous coordinate matrix.
@@ -252,6 +253,16 @@ FloatTransform3D: cover {
 	createReflectionZ: static func -> This { This new(1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f) }
 	createProjection: static func (focalLength: Float) -> This {
 		This new(focalLength, 0, 0, 0, 0, focalLength, 0, 0, 0, 0, focalLength, 1.0f, 0, 0, 0, 0)
+	}
+	createProjection: static func ~flip (focalLength, nearPlane, farPlane: Float, coordinateTransform: IntTransform2D) -> This {
+		if (focalLength > 0.0f) {
+			a := (coordinateTransform a as Float) * focalLength
+			f := -(coordinateTransform e as Float) * focalLength
+			k := (farPlane + nearPlane) / (farPlane - nearPlane)
+			o := 2.0f * farPlane * nearPlane / (farPlane - nearPlane)
+			This new(a, 0.0f, 0.0f, 0.0f, 0.0f, f, 0.0f, 0.0f, 0.0f, 0.0f, k, -1.0f, 0.0f, 0.0f, o, 0.0f)
+		} else
+			This createScaling((coordinateTransform a as Float), -(coordinateTransform e as Float), 1.0f)
 	}
 	referenceToNormalized: func ~float (imageSize: FloatVector2D) -> This {
 		toReference := This createScaling(imageSize x / 2.0f, imageSize y / 2.0f, 1.0f)


### PR DESCRIPTION
Applying reference coordinates relative to the target image when reference coordinates are relative to the input image of another resolution caused the need to convert to and from normalized coordinates every time a transform is used. The external interface was improved by allowing both normalized and reference coordinates in the DrawState interface but the initial solution was just another layer of conversion on top of the old code. This PR removes a conversion back to reference coordinates that was canceled out by the projections given to the GPU. DrawState now uses normalized coordinates in the OpenGL implementation to avoid the two conversions and get simpler code.

More testing will be applied once the whole DrawState API is complete since things will change a lot.