### PR TITLE
Removed never-used VarArgs functions

### DIFF
--- a/source/net/TCPSocket.ooc
+++ b/source/net/TCPSocket.ooc
@@ -285,17 +285,6 @@ TCPSocketWriter: class extends Writer {
 	write: func (chars: Char*, length: SizeT) -> SizeT {
 		return dest send(chars, length, 0, true)
 	}
-
-	vwritef: func (fmt: String, list: VaList) {
-		list2: VaList
-		va_copy(list2, list)
-		length := vsnprintf(null, 0, fmt toCString(), list2)
-		va_end (list2)
-		buffer := CharBuffer new (length)
-		vsnprintf(buffer data, length + 1, fmt toCString(), list)
-		buffer setLength(length)
-		write(buffer toCString(), length)
-	}
 }
 
 TCPReaderWriterPair: class { // I thought TCPSocketReaderWriterPair was a bit too long

--- a/source/sdk/io/BufferWriter.ooc
+++ b/source/sdk/io/BufferWriter.ooc
@@ -33,15 +33,4 @@ BufferWriter: class extends Writer {
 		this pos += length
 		length
 	}
-	// This version is mostly for internal usage (it is called by writef)
-	vwritef: func (fmt: String, list: VaList) {
-		list2: VaList
-		va_copy(list2, list)
-		length := vsnprintf(null, 0, fmt, list2)
-		va_end(list2)
-
-		_makeRoom(pos + length + 1)
-		vsnprintf(this buffer data + pos, length + 1, fmt, list)
-		pos += length
-	}
 }


### PR DESCRIPTION
In line with #741 

Unlike what the comment says, `writef` does not call `vwritef`. Nothing does. They seem more like old remnants.

Objections @sebastianbaginski ?