### PR TITLE
Removed the Dynlib memory leak present in all ooc/magic programs

### DIFF
--- a/source/sdk/os/Dynlib.ooc
+++ b/source/sdk/os/Dynlib.ooc
@@ -1,7 +1,7 @@
 use sdk-dynlib
 
 Dynlib: abstract class {
-	suffix: static String = ""
+	suffix: static String
 	path: String
 	success := false
 
@@ -22,7 +22,6 @@ Dynlib: abstract class {
 	symbol: abstract func (name: String) -> Pointer
 
 	// This must be the last called method on a given instance.
-	// If a Dynlib is not closed explicitly, it will be freed when the
 	close: abstract func -> Bool
 }
 


### PR DESCRIPTION
Lines 29-37 will definitely set `Dynlib suffix` to something, and the original empty string is thus lost.

Building an empty test program now leaks only 64 bytes instead of 192 bytes.

Peer review @sebastianbaginski 