### PR TITLE
Implemented source and destination for DrawState.

### DIFF
--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -12,7 +12,7 @@ import Image
 import Map
 
 // Example
-// DrawState new(myImage) setMap(myShader) draw()
+// DrawState new(targetImage) setMap(shader) draw()
 
 DrawState: cover {
 	target: Image = null
@@ -21,6 +21,8 @@ DrawState: cover {
 	opacity := 1.0f
 	_transformNormalized := FloatTransform3D identity
 	viewport := IntBox2D new(0, 0, 0, 0)
+	destination := IntBox2D new(0, 0, 0, 0) // TODO: Accept FloatBox2D
+	_sourceNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	init: func@ ~default
 	init: func@ ~target (=target)
 	setTarget: func (target: Image) -> This {
@@ -39,6 +41,21 @@ DrawState: cover {
 		this viewport = viewport
 		this
 	}
+	setDestination: func (destination: IntBox2D) -> This {
+		this destination = destination
+		this
+	}
+	setSource: func ~Int (source: IntBox2D, imageSize: IntVector2D) -> This {
+		this setSource(source toFloatBox2D(), imageSize toFloatVector2D())
+	}
+	setSource: func ~Float (source: FloatBox2D, imageSize: FloatVector2D) -> This {
+		this setSourceNormalized(source / imageSize)
+	}
+	setSourceNormalized: func (source: FloatBox2D) -> This {
+		this _sourceNormalized = source
+		this
+	}
+	getSourceNormalized: func -> FloatBox2D { this _sourceNormalized }
 	setInputImage: func (inputImage: Image) -> This {
 		this inputImage = inputImage
 		this

--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -37,39 +37,50 @@ DrawState: cover {
 		this opacity = opacity
 		this
 	}
+	// Local region
 	setViewport: func (viewport: IntBox2D) -> This {
 		this viewport = viewport
 		this
 	}
+	// Local region
 	setDestination: func (destination: IntBox2D) -> This {
 		this destination = destination
 		this
 	}
+	// Local region
 	setSource: func ~Int (source: IntBox2D, imageSize: IntVector2D) -> This {
 		this setSource(source toFloatBox2D(), imageSize toFloatVector2D())
 	}
+	// Local region
 	setSource: func ~Float (source: FloatBox2D, imageSize: FloatVector2D) -> This {
 		this setSourceNormalized(source / imageSize)
 	}
+	// Normalized region
 	setSourceNormalized: func (source: FloatBox2D) -> This {
 		this _sourceNormalized = source
 		this
 	}
+	// Normalized region
 	getSourceNormalized: func -> FloatBox2D { this _sourceNormalized }
+	// Giving a single texture as "texture0"
 	setInputImage: func (inputImage: Image) -> This {
 		this inputImage = inputImage
 		this
 	}
+	// Reference transform
 	setTransformReference: func ~targetSize (transform: FloatTransform3D) -> This {
 		this setTransformNormalized(transform referenceToNormalized(this target size))
 	}
+	// Reference transform
 	setTransformReference: func ~explicit (transform: FloatTransform3D, imageSize: FloatVector2D) -> This {
 		this setTransformNormalized(transform referenceToNormalized(imageSize))
 	}
+	// Normalized transform
 	setTransformNormalized: func (transform: FloatTransform3D) -> This {
 		this _transformNormalized = transform
 		this
 	}
+	// Normalized transform
 	getTransformNormalized: func -> FloatTransform3D { this _transformNormalized }
 	draw: func { this target canvas draw(this) }
 }

--- a/source/draw/gpu/GpuSurface.ooc
+++ b/source/draw/gpu/GpuSurface.ooc
@@ -82,10 +82,10 @@ GpuSurface: abstract class extends Canvas {
 	}
 	draw: virtual func ~mesh (image: GpuImage, mesh: GpuMesh) { Debug raise("draw~mesh unimplemented!") }
 	readPixels: virtual func -> ByteBuffer { raise("readPixels unimplemented!"); null }
-	_createTextureTransform: static func ~Int (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
+	_createTextureTransform: static func ~LocalInt (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
 		This _createTextureTransform(imageSize toFloatVector2D(), box toFloatBox2D())
 	}
-	_createTextureTransform: static func ~Float (imageSize: FloatVector2D, box: FloatBox2D) -> FloatTransform3D {
+	_createTextureTransform: static func ~LocalFloat (imageSize: FloatVector2D, box: FloatBox2D) -> FloatTransform3D {
 		This _createTextureTransform(box / imageSize)
 	}
 	_createTextureTransform: static func ~Normalized (normalizedBox: FloatBox2D) -> FloatTransform3D {

--- a/source/draw/gpu/GpuSurface.ooc
+++ b/source/draw/gpu/GpuSurface.ooc
@@ -82,9 +82,15 @@ GpuSurface: abstract class extends Canvas {
 	}
 	draw: virtual func ~mesh (image: GpuImage, mesh: GpuMesh) { Debug raise("draw~mesh unimplemented!") }
 	readPixels: virtual func -> ByteBuffer { raise("readPixels unimplemented!"); null }
-	_createTextureTransform: static func (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
-		scaling := FloatTransform3D createScaling(box size x as Float / imageSize x, box size y as Float / imageSize y, 1.0f)
-		translation := FloatTransform3D createTranslation(box leftTop x as Float / imageSize x, box leftTop y as Float / imageSize y, 0.0f)
+	_createTextureTransform: static func ~Int (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
+		This _createTextureTransform(imageSize toFloatVector2D(), box toFloatBox2D())
+	}
+	_createTextureTransform: static func ~Float (imageSize: FloatVector2D, box: FloatBox2D) -> FloatTransform3D {
+		This _createTextureTransform(box / imageSize)
+	}
+	_createTextureTransform: static func ~Normalized (normalizedBox: FloatBox2D) -> FloatTransform3D {
+		scaling := FloatTransform3D createScaling(normalizedBox size x, normalizedBox size y, 1.0f)
+		translation := FloatTransform3D createTranslation(normalizedBox leftTop x, normalizedBox leftTop y, 0.0f)
 		translation * scaling
 	}
 }

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -22,6 +22,7 @@ OpenGLCanvas: class extends OpenGLSurface {
 	draw: override func ~DrawState (drawState: DrawState) {
 		gpuMap: GpuMap = drawState map as GpuMap ?? this context defaultMap
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
+		destination := (drawState destination hasZeroArea) ? IntBox2D new(this size) : drawState destination
 		this context backend setViewport(viewport)
 		gpuMap view = _toLocal * drawState getTransformNormalized() normalizedToReference(this size) * _toLocal
 		if (this _focalLength > 0.0f) {
@@ -32,7 +33,8 @@ OpenGLCanvas: class extends OpenGLSurface {
 			gpuMap projection = FloatTransform3D new(a, 0.0f, 0.0f, 0.0f, 0.0f, f, 0.0f, 0.0f, 0.0f, 0.0f, k, -1.0f, 0.0f, 0.0f, o, 0.0f)
 		} else
 			gpuMap projection = FloatTransform3D createScaling(2.0f / this size x, -(this _coordinateTransform e as Float) * 2.0f / this size y, 1.0f)
-		gpuMap model = this _createModelTransform(IntBox2D new(this size))
+		gpuMap model = this _createModelTransform(destination)
+		gpuMap textureTransform = This _createTextureTransform(drawState getSourceNormalized())
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)
 		else


### PR DESCRIPTION
Implemented the source and destination arguments from the old API.
I have compared the results between the old and new API without seeing any differing pixel so far.

There is a problem with encapsulation because automatically generated getters and setters on covers cannot guarantee that the side effect is not thrown away to a temporary clone of the value.
Callers should be using the `set` functions to change a `DrawState` even if only a single setting is changed so that the internal representation can change freely.