### PR TITLE
Removed gcc warnings for pthread_kill, kill, usleep

### DIFF
--- a/source/io/native/ProcessUnix.ooc
+++ b/source/io/native/ProcessUnix.ooc
@@ -12,7 +12,8 @@ import ../[Process, Pipe]
 import PipeUnix
 
 version(unix || apple) {
-include errno, signal
+include errno | (_POSIX_SOURCE)
+include signal | (_POSIX_SOURCE)
 
 errno : extern Int
 SIGTERM: extern Int

--- a/source/sdk/Time.ooc
+++ b/source/sdk/Time.ooc
@@ -9,8 +9,9 @@
 import os/win32
 
 version(linux) {
-	include unistd | (__USE_BSD), sys/time | (__USE_BSD), time | (__USE_BSD)
-	//include unistd, sys/time, time
+	include unistd | (__USE_BSD, _BSD_SOURCE, _DEFAULT_SOURCE)
+	include sys/time | (__USE_BSD, _BSD_SOURCE, _DEFAULT_SOURCE)
+	include time | (__USE_BSD, _BSD_SOURCE, _DEFAULT_SOURCE)
 } else {
 	include unistd, sys/time
 }

--- a/source/sdk/threading/native/ThreadUnix.ooc
+++ b/source/sdk/threading/native/ThreadUnix.ooc
@@ -8,7 +8,7 @@
 
 import ../[Thread]
 
-include unistd
+include unistd | (_POSIX_C_SOURCE=200809L)
 
 version(unix || apple) {
 ThreadUnix: class extends Thread {
@@ -82,8 +82,9 @@ ThreadUnix: class extends Thread {
 }
 
 // C interface
-include pthread
+include pthread | (_POSIX_C_SOURCE=200809L)
 include sched
+include signal
 
 PThread: cover from pthread_t
 TimeT: cover from time_t


### PR DESCRIPTION
Takes care of three points of #1277 
Peer review @sebastianbaginski ?