### PR TITLE
Destination

### DIFF
--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -14,6 +14,8 @@ import Map
 // Example
 // DrawState new(targetImage) setMap(shader) draw()
 
+// See README.md about input arguments and coordinate systems
+
 DrawState: cover {
 	target: Image = null
 	inputImage: Image = null
@@ -21,7 +23,7 @@ DrawState: cover {
 	opacity := 1.0f
 	_transformNormalized := FloatTransform3D identity
 	viewport := IntBox2D new(0, 0, 0, 0)
-	destination := IntBox2D new(0, 0, 0, 0) // TODO: Accept FloatBox2D
+	_destinationNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	_sourceNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	init: func@ ~default
 	init: func@ ~target (=target)
@@ -43,11 +45,25 @@ DrawState: cover {
 		this
 	}
 	// Local region
-	setDestination: func (destination: IntBox2D) -> This {
-		this destination = destination
-		this
+	// Precondition: target exists
+	setDestination: func ~TargetSize (destination: IntBox2D) -> This {
+		this setDestination(destination, this target size)
 	}
 	// Local region
+	setDestination: func ~Int (destination: IntBox2D, imageSize: IntVector2D) -> This {
+		this setDestination(destination toFloatBox2D(), imageSize toFloatVector2D())
+	}
+	// Local region
+	setDestination: func ~Float (destination: FloatBox2D, imageSize: FloatVector2D) -> This {
+		this setDestinationNormalized(destination / imageSize)
+	}
+	// Normalized region
+	setDestinationNormalized: func (destination: FloatBox2D) -> This {
+		this _destinationNormalized = destination
+		this
+	}
+	getDestinationNormalized: func -> FloatBox2D { this _destinationNormalized }
+	// The texture coordinate source region in local coordinates
 	setSource: func ~Int (source: IntBox2D, imageSize: IntVector2D) -> This {
 		this setSource(source toFloatBox2D(), imageSize toFloatVector2D())
 	}
@@ -62,17 +78,21 @@ DrawState: cover {
 	}
 	// Normalized region
 	getSourceNormalized: func -> FloatBox2D { this _sourceNormalized }
-	// Giving a single texture as "texture0"
 	setInputImage: func (inputImage: Image) -> This {
 		this inputImage = inputImage
 		this
 	}
 	// Reference transform
-	setTransformReference: func ~targetSize (transform: FloatTransform3D) -> This {
+	// Precondition: target exists
+	setTransformReference: func ~TargetSize (transform: FloatTransform3D) -> This {
 		this setTransformNormalized(transform referenceToNormalized(this target size))
 	}
 	// Reference transform
-	setTransformReference: func ~explicit (transform: FloatTransform3D, imageSize: FloatVector2D) -> This {
+	setTransformReference: func ~ExplicitIntSize (transform: FloatTransform3D, imageSize: IntVector2D) -> This {
+		this setTransformNormalized(transform referenceToNormalized(imageSize))
+	}
+	// Reference transform
+	setTransformReference: func ~ExplicitFloatSize (transform: FloatTransform3D, imageSize: FloatVector2D) -> This {
 		this setTransformNormalized(transform referenceToNormalized(imageSize))
 	}
 	// Normalized transform

--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -45,8 +45,10 @@ DrawState: cover {
 		this
 	}
 	// Local region
-	// Precondition: target exists
 	setDestination: func ~TargetSize (destination: IntBox2D) -> This {
+		version(safe)
+			if (this target == null)
+				raise("Can't set local destination relative to a target that does not exist.")
 		this setDestination(destination, this target size)
 	}
 	// Local region
@@ -83,8 +85,10 @@ DrawState: cover {
 		this
 	}
 	// Reference transform
-	// Precondition: target exists
 	setTransformReference: func ~TargetSize (transform: FloatTransform3D) -> This {
+		version(safe)
+			if (this target == null)
+				raise("Can't set reference transform relative to a target that does not exist.")
 		this setTransformNormalized(transform referenceToNormalized(this target size))
 	}
 	// Reference transform
@@ -102,5 +106,10 @@ DrawState: cover {
 	}
 	// Normalized transform
 	getTransformNormalized: func -> FloatTransform3D { this _transformNormalized }
-	draw: func { this target canvas draw(this) }
+	draw: func {
+		version(safe)
+			if (this target == null)
+				raise("Can't draw without a selected target.")
+		this target canvas draw(this)
+	}
 }

--- a/source/draw/gpu/GpuSurface.ooc
+++ b/source/draw/gpu/GpuSurface.ooc
@@ -49,10 +49,16 @@ GpuSurface: abstract class extends Canvas {
 		}
 	}
 	init: func (size: IntVector2D, =_context, =_defaultMap, =_coordinateTransform) { super(size) }
-	_createModelTransform: func (box: IntBox2D) -> FloatTransform3D {
+	_createModelTransform: func ~LocalInt (box: IntBox2D) -> FloatTransform3D {
+		this _createModelTransform(box toFloatBox2D())
+	}
+	_createModelTransform: func ~LocalFloat (box: FloatBox2D) -> FloatTransform3D {
 		toReference := FloatTransform3D createTranslation((box size x - this size x) / 2, (this size y - box size y) / 2, 0.0f)
 		translation := this _toLocal * FloatTransform3D createTranslation(box leftTop x, box leftTop y, this focalLength) * this _toLocal
 		translation * toReference * FloatTransform3D createScaling(box size x / 2.0f, box size y / 2.0f, 1.0f)
+	}
+	_createModelTransformNormalized: func (imageSize: IntVector2D, box: FloatBox2D) -> FloatTransform3D {
+		this _createModelTransform(box * imageSize toFloatVector2D())
 	}
 	_getDefaultMap: virtual func (image: Image) -> GpuMap { this _defaultMap }
 	clear: func { this fill() }

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -22,7 +22,6 @@ OpenGLCanvas: class extends OpenGLSurface {
 	draw: override func ~DrawState (drawState: DrawState) {
 		gpuMap: GpuMap = drawState map as GpuMap ?? this context defaultMap
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
-		destination := (drawState destination hasZeroArea) ? IntBox2D new(this size) : drawState destination
 		this context backend setViewport(viewport)
 		gpuMap view = _toLocal * drawState getTransformNormalized() normalizedToReference(this size) * _toLocal
 		if (this _focalLength > 0.0f) {
@@ -33,7 +32,7 @@ OpenGLCanvas: class extends OpenGLSurface {
 			gpuMap projection = FloatTransform3D new(a, 0.0f, 0.0f, 0.0f, 0.0f, f, 0.0f, 0.0f, 0.0f, 0.0f, k, -1.0f, 0.0f, 0.0f, o, 0.0f)
 		} else
 			gpuMap projection = FloatTransform3D createScaling(2.0f / this size x, -(this _coordinateTransform e as Float) * 2.0f / this size y, 1.0f)
-		gpuMap model = this _createModelTransform(destination)
+		gpuMap model = this _createModelTransformNormalized(this size, drawState getDestinationNormalized())
 		gpuMap textureTransform = This _createTextureTransform(drawState getSourceNormalized())
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)


### PR DESCRIPTION
Normalized the internal representation of destination so that the same value can be used for multiple resolutions. You can now set a destination for multiple resolutions at the same time. Viewport is however still stored in pixels because it is just defining a subset of the target.
```ooc
// Create a DrawState with destination and transform for both Y and UV
state := DrawState new() setDestination(location, frame size) setTransformReference(rotation, frame size)
// Clone and set targets for Y and UV draw calls
stateY := state setTarget(inputImage y)
stateUV := state setTarget(inputImage uv)
// Use the draw states for drawing to Y and UV
stateY setInputImage(result y) draw()
stateUV setInputImage(result uv) draw()
```