### PR TITLE
General cleanup in source/net

### DIFF
--- a/source/net/Address.ooc
+++ b/source/net/Address.ooc
@@ -172,155 +172,136 @@ IP4Address: class extends IPAddress {
 			InvalidAddress new("Could not parse address") throw()
 		}
 	}
-
 	init: func ~wildcard {
 		init("0.0.0.0")
 	}
-
 	init: func ~withAddr (addr: InAddr) {
 		family = AddressFamily IP4
 		memcpy(ai&, addr&, InAddr size)
 	}
-
-	broadcast: func -> Bool { ai s_addr == INADDR_NONE }
-	wildcard: func -> Bool { ai s_addr == INADDR_ANY }
-	globalMulticast: func -> Bool {
+	broadcast: override func -> Bool { ai s_addr == INADDR_NONE }
+	wildcard: override func -> Bool { ai s_addr == INADDR_ANY }
+	globalMulticast: override func -> Bool {
 		addr := ntohl(ai s_addr)
-		return addr >= 0xE0000100 && addr <= 0xEE000000
+		addr >= 0xE0000100 && addr <= 0xEE000000
 	}
-	ip4Compatible: func -> Bool { true }
-	ip4Mapped: func -> Bool { true }
-	linkLocal: func -> Bool { (ntohl(ai s_addr) & 0xFFFF0000) == 0xA9FE0000 }
-	linkLocalMulticast: func -> Bool { (ntohl(ai s_addr) & 0xFF000000) == 0xE0000000 }
-	loopback: func -> Bool { ntohl(ai s_addr) == 0x7F000001 }
-	multicast: func -> Bool { (ntohl(ai s_addr) & 0xF0000000) == 0xE0000000 }
-	nodeLocalMulticast: func -> Bool { false }
-	orgLocalMulticast: func -> Bool { (ntohl(ai s_addr) & 0xFFFF0000) == 0xEFC00000 }
-	siteLocal: func -> Bool {
+	ip4Compatible: override func -> Bool { true }
+	ip4Mapped: override func -> Bool { true }
+	linkLocal: override func -> Bool { (ntohl(ai s_addr) & 0xFFFF0000) == 0xA9FE0000 }
+	linkLocalMulticast: override func -> Bool { (ntohl(ai s_addr) & 0xFF000000) == 0xE0000000 }
+	loopback: override func -> Bool { ntohl(ai s_addr) == 0x7F000001 }
+	multicast: override func -> Bool { (ntohl(ai s_addr) & 0xF0000000) == 0xE0000000 }
+	nodeLocalMulticast: override func -> Bool { false }
+	orgLocalMulticast: override func -> Bool { (ntohl(ai s_addr) & 0xFFFF0000) == 0xEFC00000 }
+	siteLocal: override func -> Bool {
 		addr := ntohl(ai s_addr)
-		return (addr & 0xFF000000) == 0x0A000000 || (addr & 0xFFFF0000) == 0xC0A80000 || (addr >= 0xAC100000 && addr <= 0xAC1FFFFF)
+		(addr & 0xFF000000) == 0x0A000000 || (addr & 0xFFFF0000) == 0xC0A80000 || (addr >= 0xAC100000 && addr <= 0xAC1FFFFF)
 	}
-	siteLocalMulticast: func -> Bool { (ntohl(ai s_addr) & 0xFFFF0000) == 0xEFFF0000 }
-	wellKnownMulticast: func -> Bool { (ntohl(ai s_addr) & 0xFFFFFF00) == 0xE0000000 }
-	mask: func (mask: This) {
+	siteLocalMulticast: override func -> Bool { (ntohl(ai s_addr) & 0xFFFF0000) == 0xEFFF0000 }
+	wellKnownMulticast: override func -> Bool { (ntohl(ai s_addr) & 0xFFFFFF00) == 0xE0000000 }
+	mask: override func (mask: IPAddress) {
 		mask(mask, This new("0.0.0.0"))
 	}
-	mask: func ~withSet (mask, set: This) {
-		if (mask family != AddressFamily IP4 || set family != AddressFamily IP4) {
+	mask: override func ~withSet (mask, set: IPAddress) {
+		if (mask family != AddressFamily IP4 || set family != AddressFamily IP4)
 			NetError new("Both mask and set must be of IP4 family") throw()
-		}
 		maskAddr := (mask as This) ai
 		setAddr := (set as This) ai
-
 		ai s_addr = (ai s_addr & maskAddr s_addr) | (setAddr s_addr & ~maskAddr s_addr)
 	}
-
-	toString: func -> String {
+	toString: override func -> String {
 		addrStr := CharBuffer new(128)
 		Inet ntop(family, ai&, addrStr toCString(), 128)
 		addrStr sizeFromData()
-		return addrStr toString()
+		addrStr toString()
 	}
 }
 
-operator == (a1, a2: IP4Address) -> Bool {
-	memcmp(a1 ai&, a2 ai&, InAddr size) == 0
-}
+operator == (a1, a2: IP4Address) -> Bool { memcmp(a1 ai&, a2 ai&, InAddr size) == 0 }
 
-operator != (a1, a2: IP4Address) -> Bool {
-	! (a1 == a2)
-}
+operator != (a1, a2: IP4Address) -> Bool { !(a1 == a2) }
 
 IP6Address: class extends IPAddress {
 	ai: In6Addr
 
 	init: func (ipAddress: String) {
-		if (ipAddress empty()) {
+		if (ipAddress empty())
 			InvalidAddress new("Address must not be blank") throw()
-		}
-
 		family = AddressFamily IP6
-		if (Inet pton(family, ipAddress toCString(), ai&) == -1) {
+		if (Inet pton(family, ipAddress toCString(), ai&) == -1)
 			InvalidAddress new("Could not parse address") throw()
-		}
 	}
-
 	init: func ~withAddr (addr: In6Addr) {
 		family = AddressFamily IP6
 		memcpy(ai&, addr&, In6Addr size)
 	}
-
 	toWords: func -> UShort* { ai& as UShort* }
-
-	broadcast: func -> Bool { false }
-	wildcard: func -> Bool {
+	broadcast: override func -> Bool { false }
+	wildcard: override func -> Bool {
 		words := toWords()
-		return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&
+		words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&
 			words[4] == 0 && words[5] == 0 && words[6] == 0 && words[7] == 0
 	}
-	globalMulticast: func -> Bool {
+	globalMulticast: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFEF) == 0xFF0F
+		(words[0] & 0xFFEF) == 0xFF0F
 	}
-	ip4Compatible: func -> Bool {
+	ip4Compatible: override func -> Bool {
 		words := toWords()
-		return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&
-			words[4] == 0 && words[5] == 0
+		words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 && words[4] == 0 && words[5] == 0
 	}
-	ip4Mapped: func -> Bool {
+	ip4Mapped: override func -> Bool {
 		words := toWords()
-		return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&
-			words[4] == 0 && words[5] == 0xFFFF
+		words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 && words[4] == 0 && words[5] == 0xFFFF
 	}
-	linkLocal: func -> Bool {
+	linkLocal: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFE0) == 0xFE80
+		(words[0] & 0xFFE0) == 0xFE80
 	}
-	linkLocalMulticast: func -> Bool {
+	linkLocalMulticast: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFEF) == 0xFF02
+		(words[0] & 0xFFEF) == 0xFF02
 	}
-	loopback: func -> Bool {
+	loopback: override func -> Bool {
 		words := toWords()
-		return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&
+		words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&
 			words[4] == 0 && words[5] == 0 && words[6] == 0 && words[7] == 1
 	}
-	multicast: func -> Bool {
+	multicast: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFE0) == 0xFF00
+		(words[0] & 0xFFE0) == 0xFF00
 	}
-	nodeLocalMulticast: func -> Bool {
+	nodeLocalMulticast: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFEF) == 0xFF01
+		(words[0] & 0xFFEF) == 0xFF01
 	}
-	orgLocalMulticast: func -> Bool {
+	orgLocalMulticast: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFEF) == 0xFF08
+		(words[0] & 0xFFEF) == 0xFF08
 	}
-	siteLocal: func -> Bool {
+	siteLocal: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFE0) == 0xFEC0
+		(words[0] & 0xFFE0) == 0xFEC0
 	}
-	siteLocalMulticast: func -> Bool {
+	siteLocalMulticast: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFEF) == 0xFF05
+		(words[0] & 0xFFEF) == 0xFF05
 	}
-	wellKnownMulticast: func -> Bool {
+	wellKnownMulticast: override func -> Bool {
 		words := toWords()
-		return (words[0] & 0xFFF0) == 0xFF00
+		(words[0] & 0xFFF0) == 0xFF00
 	}
-	mask: func (mask: IPAddress) {
+	mask: override func (mask: IPAddress) {
 		mask(mask, null)
 	}
-	mask: func ~withSet (mask: IPAddress, set: IPAddress) {
+	mask: override func ~withSet (mask: IPAddress, set: IPAddress) {
 		NetError new("Mask is only supported with IP4 addresses") throw()
 	}
-
-	toString: func -> String {
+	toString: override func -> String {
 		addrStr := CharBuffer new(128)
 		Inet ntop(family, ai&, addrStr toCString(), 128)
 		addrStr sizeFromData()
-		return addrStr toString()
+		addrStr toString()
 	}
 }
 
@@ -333,13 +314,13 @@ operator != (a1, a2: IP6Address) -> Bool {
 }
 
 operator == (a1, a2: IPAddress) -> Bool {
-	if (a1 family != a2 family)
-		return false
-
-	if (a1 family == AddressFamily IP4)
-		return (a1 as IP4Address) == (a2 as IP4Address)
-	else
-		return (a1 as IP6Address) == (a2 as IP6Address)
+	result := false
+	if (a1 family == a2 family)
+		if (a1 family == AddressFamily IP4)
+			result = (a1 as IP4Address) == (a2 as IP4Address)
+		else
+			result = (a1 as IP6Address) == (a2 as IP6Address)
+	result
 }
 
 operator != (a1, a2: IPAddress) -> Bool {
@@ -350,39 +331,34 @@ SocketAddress: abstract class {
 	family: abstract func -> Int
 	host: abstract func -> IPAddress
 	port: abstract func -> Int
-
 	addr: abstract func -> SockAddr*
 	length: abstract func -> UInt
-
 	toString: func -> String {
 		"[%s]:%d" format(host() toString() toCString(), port())
 	}
 	new: static func (host: IPAddress, nPort: Int) -> This {
+		result: This
 		if (host family == AddressFamily IP4) {
 			ip4Host := host as IP4Address
-			return SocketAddressIP4 new(ip4Host ai, nPort)
+			result = SocketAddressIP4 new(ip4Host ai, nPort)
 		}
 		else if (host family == AddressFamily IP6) {
 			ip6Host := host as IP6Address
-			return SocketAddressIP6 new(ip6Host ai, nPort)
+			result = SocketAddressIP6 new(ip6Host ai, nPort)
 		}
-		else {
+		else
 			NetError new("Unsupported IP Address type!") throw()
-			return null
-		}
+		result
 	}
-
 	newFromSock: static func (addr: SockAddr*, len: UInt) -> This {
-		if (len == SockAddrIn size) {
-			return SocketAddressIP4 new(addr as SockAddrIn*)
-		}
-		else if (len == SockAddrIn6 size) {
-			return SocketAddressIP6 new(addr as SockAddrIn6*)
-		}
-		else {
+		result: This
+		if (len == SockAddrIn size)
+			result = SocketAddressIP4 new(addr as SockAddrIn*)
+		else if (len == SockAddrIn6 size)
+			result = SocketAddressIP6 new(addr as SockAddrIn6*)
+		else
 			NetError new("Unknown SockAddr type!") throw()
-			return null
-		}
+		result
 	}
 }
 
@@ -402,12 +378,11 @@ SocketAddressIP4: class extends SocketAddress {
 		memcpy(sa&, sockAddr, SockAddrIn size)
 	}
 
-	family: func -> Int { sa sin_family }
-	host: func -> IPAddress { IP4Address new(sa sin_addr) }
-	port: func -> Int { ntohs(sa sin_port) }
-
-	addr: func -> SockAddr* { (sa&) as SockAddr* }
-	length: func -> UInt { SockAddrIn size }
+	family: override func -> Int { sa sin_family }
+	host: override func -> IPAddress { IP4Address new(sa sin_addr) }
+	port: override func -> Int { ntohs(sa sin_port) }
+	addr: override func -> SockAddr* { (sa&) as SockAddr* }
+	length: override func -> UInt { SockAddrIn size }
 }
 
 SocketAddressIP6: class extends SocketAddress {
@@ -423,10 +398,9 @@ SocketAddressIP6: class extends SocketAddress {
 		memcpy(sa&, sockAddr, SockAddrIn6 size)
 	}
 
-	family: func -> Int { sa sin6_family }
-	host: func -> IPAddress { IP6Address new(sa sin6_addr) }
-	port: func -> Int { ntohs(sa sin6_port) }
-
-	addr: func -> SockAddr* { (sa&) as SockAddr* }
-	length: func -> UInt { SockAddrIn6 size }
+	family: override func -> Int { sa sin6_family }
+	host: override func -> IPAddress { IP6Address new(sa sin6_addr) }
+	port: override func -> Int { ntohs(sa sin6_port) }
+	addr: override func -> SockAddr* { (sa&) as SockAddr* }
+	length: override func -> UInt { SockAddrIn6 size }
 }

--- a/source/net/DNS.ooc
+++ b/source/net/DNS.ooc
@@ -19,7 +19,7 @@ DNS: class {
 		Returns information about the host that was found.
 	*/
 	resolve: static func (hostname: String) -> HostInfo {
-		return resolve(hostname, 0, 0)
+		resolve(hostname, 0, 0)
 	}
 	resolve: static func ~filter (hostname: String, socketType: Int, socketFamily: Int) -> HostInfo {
 		hints: AddrInfo
@@ -28,10 +28,9 @@ DNS: class {
 		hints ai_flags = AI_CANONNAME
 		hints ai_family = socketFamily
 		hints ai_socktype = socketType
-		if ((rv := getaddrinfo(hostname, null, hints&, info&)) != 0) {
+		if ((rv := getaddrinfo(hostname, null, hints&, info&)) != 0)
 			DNSError new(gai_strerror(rv as Int) as CString toString()) throw()
-		}
-		return HostInfo new(info)
+		HostInfo new(info)
 	}
 
 	/**
@@ -40,11 +39,11 @@ DNS: class {
 	*/
 	resolveOne: static func (host: String) -> IPAddress {
 		info := resolve(host)
-		return info addresses()[0]
+		info addresses()[0]
 	}
 	resolveOne: static func ~filter (host: String, socketType: Int, socketFamily: Int) -> IPAddress {
 		info := resolve(host, socketType, socketFamily)
-		return info addresses()[0]
+		info addresses()[0]
 	}
 
 	/**
@@ -52,7 +51,7 @@ DNS: class {
 		Returns the hostname of the specified address.
 	*/
 	reverse: static func (ip: IPAddress) -> String {
-		return reverse(SocketAddress new(ip, 0))
+		reverse(SocketAddress new(ip, 0))
 	}
 	reverse: static func ~withSockAddr (sockaddr: SocketAddress) -> String {
 		hostname := CharBuffer new(1024)
@@ -60,7 +59,7 @@ DNS: class {
 			DNSError new(gai_strerror(rv as Int) as CString toString()) throw()
 		}
 		hostname sizeFromData()
-		return hostname toString()
+		hostname toString()
 	}
 
 	/**
@@ -74,7 +73,7 @@ DNS: class {
 		Retreive host information about this system.
 	*/
 	localhost: static func -> HostInfo {
-		return resolve(hostname())
+		resolve(hostname())
 	}
 }
 

--- a/source/net/DNS.ooc
+++ b/source/net/DNS.ooc
@@ -65,16 +65,12 @@ DNS: class {
 	/**
 		Returns the hostname of this system.
 	*/
-	hostname: static func -> String {
-		System hostname()
-	}
+	hostname: static func -> String { System hostname() }
 
 	/**
 		Retreive host information about this system.
 	*/
-	localhost: static func -> HostInfo {
-		resolve(hostname())
-	}
+	localhost: static func -> HostInfo { resolve(hostname()) }
 }
 
 /**
@@ -92,7 +88,6 @@ HostInfo: class {
 	 */
 	init: func (addrinfo: AddrInfo*) {
 		addresses = LinkedList<IPAddress> new()
-
 		name = addrinfo@ ai_canonname as CString toString()
 		info := addrinfo
 		while (info) {
@@ -110,7 +105,5 @@ HostInfo: class {
 	/**
 		Returns a list of IPAddress associated with this host.
 	*/
-	addresses: func -> LinkedList<IPAddress> {
-		addresses
-	}
+	addresses: func -> LinkedList<IPAddress> { this addresses }
 }

--- a/source/net/UDPSocket.ooc
+++ b/source/net/UDPSocket.ooc
@@ -17,7 +17,6 @@ UDPSocket: class extends Socket {
 
 	/**
 		Initialize the socket. Binds to all available IPs.
-
 		:param port: The port, for example 8080, or 80.
 	*/
 	init: func ~port (port: Int) {
@@ -26,7 +25,6 @@ UDPSocket: class extends Socket {
 
 	/**
 		Initialize the socket
-
 		:param ip: The IP, for now it can NOT be a hostname (TODO: This is a bug! Fix it!)
 		:param port: The port, for example 8080, or 80.
 	*/
@@ -53,7 +51,6 @@ UDPSocket: class extends Socket {
 	   :param length: The length of the data to be sent
 	   :param flags: Send flags
 	   :param resend: Attempt to resend any data left unsent
-
 	   :return: The number of bytes sent
 	 */
 	send: func ~withLength (data: Char*, length: SizeT, flags: Int, resend: Bool) -> Int {
@@ -68,7 +65,7 @@ UDPSocket: class extends Socket {
 			SocketError new("Couldn't send an UDP datagram") throw()
 		}
 
-		return bytesSent
+		bytesSent
 	}
 
 	/**
@@ -80,7 +77,7 @@ UDPSocket: class extends Socket {
 	   :return: The number of bytes sent
 	 */
 	send: func ~withFlags (data: String, flags: Int, resend: Bool) -> Int {
-		send(data toCString(), data size, flags, resend)
+		this send(data toCString(), data size, flags, resend)
 	}
 
 	/**
@@ -90,7 +87,7 @@ UDPSocket: class extends Socket {
 
 	   :return: The number of bytes sent
 	 */
-	send: func ~withResend (data: String, resend: Bool) -> Int { send(data, 0, resend) }
+	send: func ~withResend (data: String, resend: Bool) -> Int { this send(data, 0, resend) }
 
 	/**
 	   Send a string through this socket with resend attempted for unsent data
@@ -98,7 +95,7 @@ UDPSocket: class extends Socket {
 
 	   :return: The number of bytes sent
 	 */
-	send: func (data: String) -> Int { send(data, true) }
+	send: func (data: String) -> Int { this send(data, true) }
 
 	/**
 	   Send a byte through this socket
@@ -106,14 +103,14 @@ UDPSocket: class extends Socket {
 	   :param flags: Send flags
 	 */
 	sendByte: func ~withFlags (byte: Char, flags: Int) {
-		send(byte&, Char size, flags, true)
+		this send(byte&, Char size, flags, true)
 	}
 
 	/**
 	   Send a byte through this socket
 	   :param byte: The byte to send
 	 */
-	sendByte: func (byte: Char) { sendByte(byte, 0) }
+	sendByte: func (byte: Char) { this sendByte(byte, 0) }
 
 	/**
 	   Receive bytes from this socket
@@ -126,13 +123,11 @@ UDPSocket: class extends Socket {
 	receive: func ~withFlags (chars: Char*, length: SizeT, flags: Int) -> Int {
 		socketLength := remote length()
 		bytesRecv := recvFrom(descriptor, chars, length, flags, remote addr(), socketLength&)
-		if (bytesRecv == -1) {
+		if (bytesRecv == -1)
 			SocketError new("Error receiveing from UDP socket") throw()
-		}
-		if (bytesRecv == 0) {
+		if (bytesRecv == 0)
 			connected = false // disconnected!
-		}
-		return bytesRecv
+		bytesRecv
 	}
 
 	/**
@@ -164,7 +159,7 @@ UDPSocket: class extends Socket {
 	receiveByte: func ~withFlags (flags: Int) -> Char {
 		c: Char
 		receive(c&, 1, 0)
-		return c
+		c
 	}
 
 	/**
@@ -173,6 +168,4 @@ UDPSocket: class extends Socket {
 	   :return: The byte read
 	 */
 	receiveByte: func -> Char { receiveByte(0) }
-
-//	receiveFrom:
 }

--- a/source/net/UDPSocket.ooc
+++ b/source/net/UDPSocket.ooc
@@ -126,7 +126,7 @@ UDPSocket: class extends Socket {
 		if (bytesRecv == -1)
 			SocketError new("Error receiveing from UDP socket") throw()
 		if (bytesRecv == 0)
-			connected = false // disconnected!
+			connected = false
 		bytesRecv
 	}
 

--- a/source/net/berkeley.ooc
+++ b/source/net/berkeley.ooc
@@ -12,7 +12,6 @@ include unistd | (__USE_BSD)
 
 version (windows) {
 	include winsock2
-	// Needs Windows XP or later for getnameinfo and getaddrinfo.
 	include ws2tcpip | (_WIN32_WINNT=0x0501)
 } else {
 	include sys/socket
@@ -61,7 +60,6 @@ AddrInfo: cover from struct addrinfo {
 	ai_family: extern Int
 	ai_socktype: extern Int
 	ai_protocol: extern Int
-
 	ai_addrlen: extern UInt
 	ai_canonname: extern Char*
 	ai_addr: extern SockAddr*
@@ -109,9 +107,7 @@ version (windows) {
 	SHUT_RD: extern Int
 	SHUT_WR: extern Int
 	SHUT_RDWR: extern Int
-}
-
-version (!windows) {
+} else {
 	SD_RECEIVE: extern Int
 	SD_SEND: extern Int
 	SD_BOTH: extern Int

--- a/source/net/berkeley.ooc
+++ b/source/net/berkeley.ooc
@@ -41,7 +41,7 @@ SockAddrIn: cover from struct sockaddr_in {
 }
 
 InAddr: cover from struct in_addr {
-	s_addr: extern ULong // load with inet_aton()
+	s_addr: extern ULong
 }
 
 SockAddrIn6: cover from struct sockaddr_in6 {
@@ -78,9 +78,9 @@ HostEntry: cover from struct hostent {
 
 version (!windows) {
 	PollFd: cover from struct pollfd {
-	fd: extern Int
-	events: extern Short
-	revents: extern Short
+		fd: extern Int
+		events: extern Short
+		revents: extern Short
 	}
 }
 
@@ -90,10 +90,10 @@ FdSet: cover from fd_set {
 	_clr: extern (FD_CLR) static func (fd: Int, fdset: This *)
 	_zero: extern (FD_ZERO) static func (fdset: This *)
 
-	set: func@(fd: Int) { _set(fd, this &) }
-	isSet: func@(fd: Int) -> Bool { _isSet(fd, this &) }
-	clr: func@(fd: Int) { _clr(fd, this &) }
-	zero: func@ { _zero(this &) }
+	set: func@(fd: Int) { _set(fd, this&) }
+	isSet: func@(fd: Int) -> Bool { _isSet(fd, this&) }
+	clr: func@(fd: Int) { _clr(fd, this&) }
+	zero: func@ { _zero(this&) }
 }
 
 TimeVal: cover from struct timeval {
@@ -172,12 +172,6 @@ AI_CANONIDN: extern Int
 AI_IDN_ALLOW_UNASSIGNED: extern Int
 AI_IDN_USE_STD3_ASCII_RULES: extern Int
 
-// The following are deprecated
-inet_ntoa: extern func (address: InAddr) -> CString
-inet_aton: extern func (ipAddress: CString, inp: InAddr*) -> Int
-inet_addr: extern func (ipAddress: CString) -> ULong
-// end deprecated
-
 version (!windows) {
 	inet_ntop: extern func (addressFamily: Int, address: Pointer, destination: CString, destinationSize: UInt) -> CString
 	inet_pton: extern func (addressFamily: Int, address: CString, destination: Pointer) -> Int
@@ -194,12 +188,12 @@ WSADATA: extern cover
 WSAStartup: extern func (versionRequested: WORD, wsaData: Pointer) -> Int
 
 initWinsock: func {
-	data: This
+	data: WSADATA
 	ret := WSAStartup(MAKEWORD(2, 2), data&)
 
-	if (ret != 0) {
+	if (ret != 0)
 		raise("Could not initialize winsock 2.2")
-	}
 }
+
 initWinsock()
 }

--- a/source/net/translation.ooc
+++ b/source/net/translation.ooc
@@ -10,63 +10,66 @@ import berkeley, Socket, Address
 
 Inet: class {
 	ntop: static func (addressFamily: Int, address: Pointer, destination: CString, destinationSize: UInt) -> CString {
-		version (!windows) {
+		result: CString
+		//version (!windows) {
 			// use built-in!
-			return inet_ntop(addressFamily, address, destination, destinationSize)
-		}
+			// TODO: Using the built-in inet_ntop results in a gcc warning because inet_ntop returns a const char*,
+			// and the const qualifier is not supported by rock...
+			//result = inet_ntop(addressFamily, address, destination, destinationSize)
+		//} else {
+			// Roll our own implementation, based on:
+			// https://github.com/pkulchenko/luasocket/blob/5a58786a39bbef7ed4805821cc921f1d40f12068/src/inet.c#L512
+			match addressFamily {
+				case AddressFamily IP4 =>
+					in: SockAddrIn
+					memset(in&, 0, SockAddrIn size)
+					in sin_family = AddressFamily IP4
+					getnameinfo(in& as SockAddr*, SockAddrIn size, destination,
+					destinationSize, null, 0, NI_NUMERICHOST)
+					result = destination
 
-	// Roll our own implementation, based on:
-	// https://github.com/pkulchenko/luasocket/blob/5a58786a39bbef7ed4805821cc921f1d40f12068/src/inet.c#L512
-	match addressFamily {
-		case AddressFamily IP4 =>
-			in: SockAddrIn
-			memset(in &, 0, SockAddrIn size)
-			in sin_family = AddressFamily IP4
-			getnameinfo(in & as SockAddr*, SockAddrIn size, destination,
-			destinationSize, null, 0, NI_NUMERICHOST)
-			destination
+				case AddressFamily IP6 =>
+					in: SockAddrIn6
+					memset(in&, 0, SockAddrIn6 size)
+					in sin6_family = AddressFamily IP6
+					getnameinfo(in& as SockAddr*, SockAddrIn6 size, destination,
+					destinationSize, null, 0, NI_NUMERICHOST)
+					result = destination
 
-		case AddressFamily IP6 =>
-			in: SockAddrIn6
-			memset(in &, 0, SockAddrIn6 size)
-			in sin6_family = AddressFamily IP6
-			getnameinfo(in & as SockAddr*, SockAddrIn6 size, destination,
-			destinationSize, null, 0, NI_NUMERICHOST)
-			destination
-
-		case =>
-			null
+				case =>
+					result = null
+			}
+		//}
+		result
 	}
-}
 
-pton: static func (addressFamily: Int, address: CString,
-	destination: Pointer) -> Int {
+	pton: static func (addressFamily: Int, address: CString, destination: Pointer) -> Int {
+		result: Int
 		version (!windows) {
 			// use built-in!
-			return inet_pton(addressFamily, address, destination)
+			result = inet_pton(addressFamily, address, destination)
+		} else {
+			// roll our own version, based on:
+			// https://github.com/diegonehab/luasocket/blob/master/src/inet.c
+			hints: AddrInfo
+			res: AddrInfo*
+			result = 1
+			memset(hints&, 0, AddrInfo size)
+			hints ai_family = addressFamily
+			hints ai_flags = AI_NUMERICHOST
+			if (getaddrinfo(address, null, hints&, res&) != 0) return -1
+			match (addressFamily) {
+				case AddressFamily IP4 =>
+					in := res@ ai_addr as SockAddrIn*
+					memcpy(destination, in@ sin_addr&, SockAddrIn size)
+				case AddressFamily IP6 =>
+					in := res@ ai_addr as SockAddrIn6*
+					memcpy(destination, in@ sin6_addr&, SockAddrIn6 size)
+				case =>
+					result = -1
+			}
+			freeaddrinfo(res)
 		}
-
-		// roll our own version, based on:
-		// https://github.com/diegonehab/luasocket/blob/master/src/inet.c
-
-		hints: AddrInfo
-		res: AddrInfo*
-		ret := 1
-		memset(hints&, 0, AddrInfo size)
-		hints ai_family = addressFamily
-		hints ai_flags = AI_NUMERICHOST
-		if (getaddrinfo(address, null, hints&, res&) != 0) return -1
-		match (addressFamily) {
-			case AddressFamily IP4 =>
-				in := res@ ai_addr as SockAddrIn*
-				memcpy(destination, in@ sin_addr&, SockAddrIn size)
-			case AddressFamily IP6 =>
-				in := res@ ai_addr as SockAddrIn6*
-				memcpy(destination, in@ sin6_addr&, SockAddrIn6 size)
-			case =>
-				ret = -1
-		}
-		freeaddrinfo(res)
-		ret
+		result
 	}
 }

--- a/source/net/utilities.ooc
+++ b/source/net/utilities.ooc
@@ -18,10 +18,10 @@ import berkeley, translation, Socket, Address, Exceptions
 ipType: func (ip: String) -> Int {
 	atColons := ip split(":")
 	atPeriods := ip split(".")
-	if (atColons size >= 2) {
+	if (atColons count >= 2) {
 		// 2 or more colons, assume IPv6
 		AddressFamily IP6
-	} else if (atPeriods size == 4 && atColons size == 1) {
+	} else if (atPeriods count == 4 && atColons count == 1) {
 		// No colons, 4 sections separated by 3 periods, assume IPv4
 		AddressFamily IP4
 	} else {

--- a/source/sdk/os/System.ooc
+++ b/source/sdk/os/System.ooc
@@ -64,8 +64,8 @@ System: class {
 		version (linux || apple) {
 			BUF_SIZE = 255 : SizeT
 			hostname := CharBuffer new(BUF_SIZE + 1)
-			result := gethostname(hostname data as Pointer, BUF_SIZE)
-			if (result != 0)
+			value := gethostname(hostname data as Pointer, BUF_SIZE)
+			if (value != 0)
 				Exception new("System host name longer than 256 characters!!") throw()
 			hostname sizeFromData()
 			result = hostname toString()

--- a/test/net/NetTest.ooc
+++ b/test/net/NetTest.ooc
@@ -1,0 +1,23 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+use unit
+use net
+
+//TODO: Write actual tests for source/net
+// Right now, this is just to make sure that the code is processed and compiled when testing
+NetTest: class extends Fixture {
+	init: func {
+		super("Net")
+		this add("No test", func {
+			expect(true)
+		})
+	}
+}
+
+NetTest new() run() . free()


### PR DESCRIPTION
Updated to conform with new versions of rock and style guides for `magic`, remove gcc warnings, and also includes some bug fixes.

Added a blank test which makes sure the code in `source/net` gets processed when running `./test.sh`. There is already an issue on writing actual tests: #757 