### PR TITLE
Readpixels fix

### DIFF
--- a/source/draw/gpu/GpuSurface.ooc
+++ b/source/draw/gpu/GpuSurface.ooc
@@ -87,7 +87,6 @@ GpuSurface: abstract class extends Canvas {
 			temporary free()
 	}
 	draw: virtual func ~mesh (image: GpuImage, mesh: GpuMesh) { Debug raise("draw~mesh unimplemented!") }
-	readPixels: virtual func -> ByteBuffer { raise("readPixels unimplemented!"); null }
 	_createTextureTransform: static func ~LocalInt (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
 		This _createTextureTransform(imageSize toFloatVector2D(), box toFloatBox2D())
 	}

--- a/source/draw/gpu/opengl/OpenGLBgra.ooc
+++ b/source/draw/gpu/opengl/OpenGLBgra.ooc
@@ -24,7 +24,7 @@ OpenGLBgra: class extends OpenGLPacked {
 		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, rasterImage coordinateSystem, context)
 	}
 	toRasterDefault: override func -> RasterImage {
-		buffer := this canvas readPixels()
+		buffer := (this canvas as OpenGLCanvas) readPixels()
 		RasterBgra new(buffer, this size)
 	}
 	create: override func (size: IntVector2D) -> This { this context createBgra(size) as This }

--- a/source/draw/gpu/opengl/OpenGLBgra.ooc
+++ b/source/draw/gpu/opengl/OpenGLBgra.ooc
@@ -9,6 +9,7 @@
 use geometry
 use draw
 use draw-gpu
+use base
 import backend/GLTexture
 import OpenGLCanvas, OpenGLPacked, OpenGLContext
 
@@ -24,7 +25,8 @@ OpenGLBgra: class extends OpenGLPacked {
 		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, rasterImage coordinateSystem, context)
 	}
 	toRasterDefault: override func -> RasterImage {
-		buffer := (this canvas as OpenGLCanvas) readPixels()
+		buffer := ByteBuffer new(this size area * 4)
+		(this canvas as OpenGLCanvas) readPixels(buffer)
 		RasterBgra new(buffer, this size)
 	}
 	create: override func (size: IntVector2D) -> This { this context createBgra(size) as This }

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -62,6 +62,6 @@ OpenGLCanvas: class extends OpenGLSurface {
 		this _renderTarget clear()
 		this _unbind()
 	}
-	readPixels: override func -> ByteBuffer { this _renderTarget readPixels() }
+	readPixels: func -> ByteBuffer { this _renderTarget readPixels() }
 }
 }

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -62,6 +62,6 @@ OpenGLCanvas: class extends OpenGLSurface {
 		this _renderTarget clear()
 		this _unbind()
 	}
-	readPixels: func -> ByteBuffer { this _renderTarget readPixels() }
+	readPixels: func (buffer: ByteBuffer) { this _renderTarget readPixels(buffer) }
 }
 }

--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -9,6 +9,7 @@
 use geometry
 use draw
 use draw-gpu
+use base
 import OpenGLPacked, OpenGLCanvas, OpenGLMap, OpenGLContext
 import backend/GLTexture
 
@@ -26,7 +27,8 @@ OpenGLMonochrome: class extends OpenGLPacked {
 	toRasterDefault: override func -> RasterImage {
 		packed := this context createBgra(IntVector2D new(this size x / 4, this size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
-		buffer := (packed canvas as OpenGLCanvas) readPixels()
+		buffer := ByteBuffer new(this size area)
+		(packed canvas as OpenGLCanvas) readPixels(buffer)
 		result := RasterMonochrome new(buffer, this size)
 		packed free()
 		result

--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -26,7 +26,7 @@ OpenGLMonochrome: class extends OpenGLPacked {
 	toRasterDefault: override func -> RasterImage {
 		packed := this context createBgra(IntVector2D new(this size x / 4, this size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
-		buffer := packed canvas readPixels()
+		buffer := (packed canvas as OpenGLCanvas) readPixels()
 		result := RasterMonochrome new(buffer, this size)
 		packed free()
 		result

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -9,6 +9,7 @@
 use geometry
 use draw
 use draw-gpu
+use base
 import backend/GLTexture
 import OpenGLCanvas, OpenGLPacked, OpenGLContext, OpenGLMap
 
@@ -28,7 +29,8 @@ OpenGLUv: class extends OpenGLPacked {
 	toRasterDefault: override func -> RasterImage {
 		packed := this context createBgra(IntVector2D new(this size x / 2, this size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
-		buffer := (packed canvas as OpenGLCanvas) readPixels()
+		buffer := ByteBuffer new(this size area * 2)
+		(packed canvas as OpenGLCanvas) readPixels(buffer)
 		result := RasterUv new(buffer, this size)
 		packed free()
 		result

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -28,7 +28,7 @@ OpenGLUv: class extends OpenGLPacked {
 	toRasterDefault: override func -> RasterImage {
 		packed := this context createBgra(IntVector2D new(this size x / 2, this size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
-		buffer := packed canvas readPixels()
+		buffer := (packed canvas as OpenGLCanvas) readPixels()
 		result := RasterUv new(buffer, this size)
 		packed free()
 		result

--- a/source/draw/gpu/opengl/backend/GLFramebufferObject.ooc
+++ b/source/draw/gpu/opengl/backend/GLFramebufferObject.ooc
@@ -21,7 +21,7 @@ GLFramebufferObject: abstract class {
 	unbind: abstract func
 	clear: abstract func
 	setClearColor: abstract func (color: ColorBgra)
-	readPixels: abstract func -> ByteBuffer
+	readPixels: abstract func (buffer: ByteBuffer)
 	invalidate: abstract func
 }
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3FramebufferObject.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3FramebufferObject.ooc
@@ -38,9 +38,8 @@ Gles3FramebufferObject: class extends GLFramebufferObject {
 		glClearColor(tuple c, tuple b, tuple a, tuple d)
 		version(debugGL) { validateEnd("FramebufferObject setClearColor") }
 	}
-	readPixels: override func -> ByteBuffer {
+	readPixels: override func(buffer: ByteBuffer) {
 		version(debugGL) { validateStart("FramebufferObject readPixels") }
-		buffer := ByteBuffer new(this size area * 4)
 		pointer := buffer pointer
 		this bind()
 		glPixelStorei(GL_PACK_ALIGNMENT, 1)
@@ -48,7 +47,6 @@ Gles3FramebufferObject: class extends GLFramebufferObject {
 		glReadPixels(0, 0, this size x, this size y, GL_RGBA, GL_UNSIGNED_BYTE, pointer)
 		this unbind()
 		version(debugGL) { validateEnd("FramebufferObject readPixels") }
-		buffer
 	}
 	setTarget: func (texture: Gles3Texture) {
 		version(debugGL) { validateStart("FramebufferObject setTarget") }


### PR DESCRIPTION
* Moved the allocation of the target `ByteBuffer` to a higher abstraction level, resulting in more control of where the result is written. This is mainly to prepare for the implementation of `toRaster(target: RasterImage)` for `GpuImage`.

* Removed `readPixels` from `GpuSurface` API since it should not be public.

@sebastianbaginski peer review