### PR TITLE
fixed warnings from IO

### DIFF
--- a/source/system/IO.ooc
+++ b/source/system/IO.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-include stdio, fcntl, unistd
+include stdio | (_POSIX_SOURCE), fcntl, unistd
 
 stdout, stderr, stdin: extern FStream
 


### PR DESCRIPTION
Fixes warnings related to `fdopen` when building shared library.
The ones from `FileUnix` seems more ... persistent.
@marcusnaslund 