### PR TITLE
Implemented raise(Text)

### DIFF
--- a/source/system/Exception.ooc
+++ b/source/system/Exception.ooc
@@ -114,6 +114,11 @@ raise: func ~assert (condition: Bool, message: String, origin: Class = null) {
 	if (condition)
 		raise(message, origin)
 }
+raise: func ~textWithClass (message: Text, origin: Class = null) { raise(message toString(), origin) }
+raise: func ~textAssert (condition: Bool, message: Text, origin: Class = null) {
+	if (condition)
+		raise(message, origin)
+}
 
 Exception: class {
 	backtraces := Stack<Backtrace> new()


### PR DESCRIPTION
Fixes #1316 and will allow us to start replacing one of the biggest uses of `String`.
@thomasfanell ?