### PR TITLE
Taming the BlockedQueue beast once and for all

### DIFF
--- a/source/concurrent/SynchronizedQueue.ooc
+++ b/source/concurrent/SynchronizedQueue.ooc
@@ -68,15 +68,12 @@ BlockedQueue: class <T> extends SynchronizedQueue<T> {
 	wait: func (isOk := null as Bool*) -> T {
 		result: T = null
 		this _mutex lock()
-		while (this empty) {
+		while (this empty && !this _canceled)
 			this _populated wait(this _mutex)
-			if (this _canceled) {
-				if (isOk)
-					isOk@ = false
-				break
-			}
-		}
-		if (!this _canceled)
+		if (this _canceled) {
+			if (isOk)
+				isOk@ = false
+		} else
 			result = this _backend dequeue(result)
 		this _mutex unlock()
 		result

--- a/test/concurrent/BlockedQueueTest.ooc
+++ b/test/concurrent/BlockedQueueTest.ooc
@@ -14,16 +14,16 @@ import threading/Thread
 BlockedQueueTest: class extends Fixture {
 	init: func {
 		super("BlockedQueue")
-		version (!windows) { this add("cover", This _testWithCover) }
+		this add("cover", This _testWithCover)
 		this add("class", This _testWithClass)
 	}
 	_testWithCover: static func {
 		queue := BlockedQueue<Int> new()
-		numberOfThreads := 8
+		numberOfThreads := 4
 		countPerThread := 20_000
 		totalCount := numberOfThreads * countPerThread
 		produce := func {
-			for (i in 0 .. totalCount) {
+			for (i in 1 .. totalCount + 1) {
 				queue enqueue(i)
 				Thread yield()
 			}
@@ -32,9 +32,10 @@ BlockedQueueTest: class extends Fixture {
 			for (i in 0 .. countPerThread) {
 				value := queue wait()
 				expect(value < totalCount)
+				expect(value > 0)
 			}
 		}
-		queue enqueue(0)
+		queue enqueue(1)
 		threads := Thread[numberOfThreads] new()
 		for (i in 0 .. numberOfThreads) {
 			threads[i] = Thread new(consume)
@@ -58,7 +59,7 @@ BlockedQueueTest: class extends Fixture {
 	}
 	_testWithClass: static func {
 		queue := BlockedQueue<Cell<Int>> new()
-		numberOfThreads := 8
+		numberOfThreads := 4
 		countPerThread := 20_000
 		totalCount := numberOfThreads * countPerThread
 		produce := func {
@@ -95,6 +96,4 @@ BlockedQueueTest: class extends Fixture {
 	}
 }
 
-test := BlockedQueueTest new()
-test run()
-test free()
+BlockedQueueTest new() run() . free()

--- a/test/concurrent/ThreadPoolTest.ooc
+++ b/test/concurrent/ThreadPoolTest.ooc
@@ -11,8 +11,7 @@ use concurrent
 use unit
 import threading/Thread
 
-//TODO Reimplement these tests once the problems with BlockedQueue have been fixed
-/*ThreadPoolTest: class extends Fixture {
+ThreadPoolTest: class extends Fixture {
 	init: func {
 		super("ThreadPool")
 		this add("threaded_noresult", func {
@@ -104,5 +103,4 @@ import threading/Thread
 	}
 }
 
-ThreadPoolTest new() run() . free()*/
-"ThreadPool [TODO: Temporarily suspended]" println()
+ThreadPoolTest new() run() . free()


### PR DESCRIPTION
Basically, the infamous deadlock would occur when `cancel` would be called *before* all threads were waiting on the empty queue. Those who were already waiting would receive the broadcast and finish. The other thread(s) would *later* call `wait()`, hold on the `WaitCondition` and never receive the broadcast because it had already been sent. The simple fix is to check the status of `_canceled` and if it's true *not* wait.

This PR...

- Fixes the deadlock that could occur, thereby closes #646 and is cause for a major celebration.
- Reopens the `ThreadPool` test
- Reduces the number of threads created in `BlockedQueueTest`, also does not add `0` to the test queue to make sure it is never returned.