### PR TITLE
Added ThreadId cover

### DIFF
--- a/source/concurrent/SynchronizedResource.ooc
+++ b/source/concurrent/SynchronizedResource.ooc
@@ -8,22 +8,21 @@
 
 use base
 use concurrent
-import threading/Thread
-import threading/Mutex
+import threading/[Thread, Mutex]
 import structs/HashMap
 
 SynchronizedResource: abstract class {
-	_threadAffinity := 0L
+	_threadAffinity: ThreadId
 	_recycle := true
 	init: func { this _threadAffinity = Thread currentThreadId() }
 	checkThreadAffinity: func -> Bool {
-		Thread equals(this _threadAffinity, Thread currentThreadId())
+		this _threadAffinity equals(Thread currentThreadId())
 	}
 }
 
 SynchronizedResourceRecycler: class {
 	_mutex := Mutex new()
-	_resources := HashMap<Long, VectorList<SynchronizedResource>> new()
+	_resources := HashMap<ThreadId, VectorList<SynchronizedResource>> new()
 	init: func
 	free: override func {
 		this _clear()

--- a/source/system/threading/Thread.ooc
+++ b/source/system/threading/Thread.ooc
@@ -35,20 +35,12 @@ Thread: abstract class {
 			result = ThreadWin32 _currentThread()
 		result
 	}
-	currentThreadId: static func -> Long {
-		result: Long = 0L
+	currentThreadId: static func -> ThreadId {
+		result: ThreadId
 		version (unix || apple)
-			result = pthread_self() as Long
+			result = pthread_self() as ThreadId
 		version (windows)
-			result = GetCurrentThread() as Long
-		result
-	}
-	equals: static func (threadId1, threadId2: Long) -> Bool {
-		result: Bool
-		version (unix || apple)
-			result = pthread_equal(threadId1 as PThread, threadId2 as PThread) != 0
-		else
-			result = threadId1 == threadId2
+			result = GetCurrentThread() as ThreadId
 		result
 	}
 	yield: static func -> Bool {
@@ -58,5 +50,25 @@ Thread: abstract class {
 		version (windows)
 			result = ThreadWin32 _yield()
 		result
+	}
+}
+
+version (unix || apple) {
+	include pthread | (_POSIX_C_SOURCE=200809L)
+
+	ThreadId: cover from PThread {
+		equals: func (other: This) -> Bool {
+			pthread_equal(this as PThread, other as PThread) != 0
+		}
+	}
+}
+
+version (windows) {
+	include windows
+
+	ThreadId: cover from DWORD {
+		equals: func (other: This) -> Bool {
+			this == other
+		}
 	}
 }

--- a/source/system/threading/ThreadLocal.ooc
+++ b/source/system/threading/ThreadLocal.ooc
@@ -11,7 +11,7 @@ import Thread
 import Mutex
 
 ThreadLocal: class <T> {
-	_values := HashMap<ULong, T> new()
+	_values := HashMap<ThreadId, T> new()
 	_mutex := Mutex new()
 	init: func
 	set: func (value: T) {

--- a/test/concurrent/WorkerThreadTest.ooc
+++ b/test/concurrent/WorkerThreadTest.ooc
@@ -12,7 +12,7 @@ use unit
 import threading/Thread
 
 WorkerThreadTest: class extends Fixture {
-	threads := static SynchronizedList<Long> new()
+	threads := static SynchronizedList<ThreadId> new()
 	sum: static Long = 0
 	taskUp := func {
 		This threads add(Thread currentThreadId())

--- a/test/system/ThreadTest.ooc
+++ b/test/system/ThreadTest.ooc
@@ -68,7 +68,7 @@ ThreadTest: class extends Fixture {
 	}
 	_testThreadId: static func {
 		myId := Thread currentThreadId()
-		otherId := Cell<Long> new(0L)
+		otherId := Cell<ThreadId> new(0L)
 		job := func {
 			otherId set(Thread currentThreadId())
 		}
@@ -76,10 +76,10 @@ ThreadTest: class extends Fixture {
 		expect(thread start())
 		expect(thread wait())
 		thread free()
-		expect(Thread equals(myId, otherId get()) == false)
+		expect(myId equals(otherId get()) == false)
 		otherId free()
 		(job as Closure) free()
-		expect(Thread equals(myId, Thread currentThreadId()))
+		expect(myId equals(Thread currentThreadId()) == true)
 	}
 	_timedJoin: static func {
 		job := func {


### PR DESCRIPTION
Fixes #1360 

Not at all ready, but is this what you had in mind @sebastianbaginski ?

I think we should change the static `equals` away in `Thread` to a `ThreadId` method.