### PR TITLE
Removes the warning from Android build

### DIFF
--- a/draw.use
+++ b/draw.use
@@ -25,7 +25,5 @@ Imports: Canvas
 Imports: Pen
 Imports: Map
 Imports: DrawState
-Additionals: source/draw/stb_image/stb_image.h
-Additionals: source/draw/stb_image/stb_image_write.h
 Additionals: source/draw/stb_image/stb_image_impl.c
 Libs: -lm


### PR DESCRIPTION
Removed the warnings that pop up when building for Android.

Peer review @sebastianbaginski 