### PR TITLE
Separated Queue.ooc into three files

### DIFF
--- a/collections.use
+++ b/collections.use
@@ -6,6 +6,7 @@ Requires: base
 Imports: Vector2D
 Imports: PointerVector
 Imports: PointerVectorList
-Imports: Queue
+Imports: VectorQueue
+Imports: CircularQueue
 Imports: HashDictionary
 Imports: LinkedList

--- a/source/collections/CircularQueue.ooc
+++ b/source/collections/CircularQueue.ooc
@@ -1,0 +1,50 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+import VectorQueue
+
+CircularQueue: class <T> extends Queue<T> {
+	_backend: VectorQueue<T>
+	_cleanupCallback: Func (T)
+	_maximumCapacity: Int
+	count ::= this _backend count
+	capacity ::= this _backend capacity
+	init: func ~defaultCallback (capacity: Int) {
+		callback: Func (T)
+		if (T inheritsFrom(Object))
+			callback = func (t : T) {
+				if (t != null)
+					(t as Object) free()
+			}
+		else
+			callback = func (t: T)
+		this init(capacity, callback)
+	}
+	init: func (=_maximumCapacity, =_cleanupCallback) {
+		this _backend = VectorQueue<T> new(this _maximumCapacity)
+	}
+	free: override func {
+		this clear()
+		this _backend free()
+		(this _cleanupCallback as Closure) free(Owner Receiver)
+		super()
+	}
+	clear: override func {
+		while (this count > 0)
+			this _cleanupCallback(this dequeue(null))
+		this _backend clear()
+	}
+	enqueue: override func (item: T) {
+		while (this count >= this _maximumCapacity)
+			this _cleanupCallback(this dequeue(null))
+		this _backend enqueue(item)
+	}
+	dequeue: override func ~default (fallback: T) -> T { this _backend dequeue(fallback) }
+	peek: override func ~default (fallback: T) -> T { this _backend peek(fallback) }
+	operator [] (index: Int) -> T { this _backend[index] }
+}

--- a/source/concurrent/SynchronizedQueue.ooc
+++ b/source/concurrent/SynchronizedQueue.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-import Queue
+use collections
 import threading/[Thread, Mutex, WaitCondition]
 
 SynchronizedQueue: class <T> extends Queue<T> {

--- a/source/system/structs/Queue.ooc
+++ b/source/system/structs/Queue.ooc
@@ -1,0 +1,18 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+Queue: abstract class <T> {
+	_count := 0
+	count ::= this _count
+	empty ::= this count == 0
+	init: func
+	clear: abstract func
+	enqueue: abstract func (item: T)
+	dequeue: abstract func ~default (fallback: T) -> T
+	peek: abstract func ~default (fallback: T) -> T
+}

--- a/system.use
+++ b/system.use
@@ -23,6 +23,7 @@ Imports: Time
 Imports: VarArgs
 Imports: structs/HashMap
 Imports: structs/List
+Imports: structs/Queue
 Imports: structs/Stack
 Imports: structs/Vector
 Imports: structs/VectorList

--- a/test/collections/CircularQueueTest.ooc
+++ b/test/collections/CircularQueueTest.ooc
@@ -1,0 +1,61 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+ use collections
+ use unit
+
+MyClass: class {
+	instanceCount := static 0
+	content: Int
+	init: func (=content) { ++This instanceCount }
+	init: func ~default { this init(0) }
+	increase: func { this content += 1 }
+	free: override func {
+		--This instanceCount
+		super()
+	}
+}
+
+CircularQueueTest: class extends Fixture {
+	init: func {
+		super("CircularQueue")
+		this add("with cover", func {
+			queue := CircularQueue<Int> new(3)
+			queue enqueue(1)
+			queue enqueue(2)
+			queue enqueue(3)
+			queue enqueue(4)
+			expect(queue count, is equal to(3))
+			expect(queue dequeue(0), is equal to(2))
+			expect(queue dequeue(0), is equal to(3))
+			expect(queue dequeue(0), is equal to(4))
+			expect(queue empty, is equal to(true))
+			queue free()
+		})
+		this add("with class", func {
+			initialCount := MyClass instanceCount
+			queue := CircularQueue<MyClass> new(3)
+			queue enqueue(MyClass new(1))
+			queue enqueue(MyClass new(2))
+			queue enqueue(MyClass new(3))
+			queue enqueue(MyClass new(4))
+			expect(queue count, is equal to(3))
+			object := queue dequeue(null)
+			expect(object != null)
+			expect(object content, is equal to(2))
+			object free()
+			object = queue dequeue(null)
+			expect(object content, is equal to(3))
+			object free()
+			queue free()
+			expect(MyClass instanceCount, is equal to(initialCount))
+		})
+	}
+}
+
+CircularQueueTest new() run() . free()

--- a/test/collections/VectorQueueTest.ooc
+++ b/test/collections/VectorQueueTest.ooc
@@ -7,7 +7,6 @@
  */
 
 use unit
-use base
 use collections
 
 MyCover: cover {
@@ -17,15 +16,10 @@ MyCover: cover {
 	increase: func { this content += 1 }
 }
 MyClass: class {
-	instanceCount := static 0
 	content: Int
-	init: func (=content) { ++This instanceCount }
+	init: func (=content)
 	init: func ~default { this init(0) }
 	increase: func { this content += 1 }
-	free: override func {
-		--This instanceCount
-		super()
-	}
 }
 
 VectorQueueTest: class extends Fixture {
@@ -164,37 +158,6 @@ VectorQueueTest: class extends Fixture {
 			expect(queue empty, is equal to(true))
 			expect(queue dequeue(null), is equal to(null))
 			queue free()
-		})
-		this add("CircularQueue with cover", func {
-			queue := CircularQueue<Int> new(3)
-			queue enqueue(1)
-			queue enqueue(2)
-			queue enqueue(3)
-			queue enqueue(4)
-			expect(queue count, is equal to(3))
-			expect(queue dequeue(0), is equal to(2))
-			expect(queue dequeue(0), is equal to(3))
-			expect(queue dequeue(0), is equal to(4))
-			expect(queue empty, is equal to(true))
-			queue free()
-		})
-		this add("CircularQueue with class", func {
-			initialCount := MyClass instanceCount
-			queue := CircularQueue<MyClass> new(3)
-			queue enqueue(MyClass new(1))
-			queue enqueue(MyClass new(2))
-			queue enqueue(MyClass new(3))
-			queue enqueue(MyClass new(4))
-			expect(queue count, is equal to(3))
-			object := queue dequeue(null)
-			expect(object != null)
-			expect(object content, is equal to(2))
-			object free()
-			object = queue dequeue(null)
-			expect(object content, is equal to(3))
-			object free()
-			queue free()
-			expect(MyClass instanceCount, is equal to(initialCount))
 		})
 	}
 	_createQueue: func (capacity, fill: Int, replace := 0) -> VectorQueue<Int> {


### PR DESCRIPTION
Moved `Queue` to `system/structs`
`VectorQueue` and `CircularQueue` are now two separate files in `collections`.
Also separated the test files to match.