### PR TITLE
Fixed search function for List.

### DIFF
--- a/source/concurrent/RecycleBin.ooc
+++ b/source/concurrent/RecycleBin.ooc
@@ -26,9 +26,8 @@ RecycleBin: class <T> {
 			this _free(this _list remove(0))
 		this _list add(object)
 	}
-	search: func (matches: Func (T*) -> Bool) -> T {
+	search: func (matches: Func (T) -> Bool) -> T {
 		index := this _list search(matches)
-		(matches as Closure) free()
 		result: T = null
 		(index > -1) ? this _list remove(index) : result
 	}

--- a/source/system/structs/List.ooc
+++ b/source/system/structs/List.ooc
@@ -18,7 +18,7 @@ List: abstract class <T> {
 	removeAt: abstract func (index: Int)
 	clear: abstract func
 	reverse: abstract func -> This<T>
-	search: abstract func (matches: Func (T*) -> Bool) -> Int
+	search: abstract func (matches: Func (T) -> Bool) -> Int
 	sort: abstract func (greaterThan: Func (T, T) -> Bool)
 	copy: abstract func -> This<T>
 	apply: abstract func (function: Func(T))

--- a/source/system/structs/VectorList.ooc
+++ b/source/system/structs/VectorList.ooc
@@ -65,13 +65,14 @@ VectorList: class <T> extends List<T>{
 			result add(this[(this _count - 1) - i])
 		result
 	}
-	search: override func (matches: Func (T*) -> Bool) -> Int {
+	search: override func (matches: Func (T) -> Bool) -> Int {
 		result := -1
 		for (index in 0 .. this count)
 			if (matches(this[index]&)) {
 				result = index
 				break
 			}
+		(matches as Closure) free(Owner Receiver)
 		result
 	}
 	sort: override func (greaterThan: Func (T, T) -> Bool) {

--- a/test/concurrent/RecycleBinTest.ooc
+++ b/test/concurrent/RecycleBinTest.ooc
@@ -24,8 +24,7 @@ MyClass: class {
 			this bin add(this)
 	}
 	create: static func (content: Int) -> This {
-		matches := func (instance: This*) -> Bool { content == instance@ content }
-		This bin search(matches) ?? This new(content)
+		This bin search(|instance| content == instance content) ?? This new(content)
 	}
 }
 

--- a/test/system/VectorListTest.ooc
+++ b/test/system/VectorListTest.ooc
@@ -260,18 +260,12 @@ VectorListTest: class extends Fixture {
 	}
 	_testVectorListSearch: static func {
 		list := VectorList<Int> new()
-		matches := func (instance: Int*) -> Bool { 1 == instance@ }
-		expect(list search(matches), is equal to(-1))
+		expect(list search(|instance| 1 == instance), is equal to(-1))
 		for (i in 0 .. 10)
 			list add(i)
-		expect(list search(matches), is equal to(1))
-		(matches as Closure) free()
-		matches = func (instance: Int*) -> Bool { 9 == instance@ }
-		expect(list search(matches), is equal to(9))
-		(matches as Closure) free()
-		matches = func (instance: Int*) -> Bool { 10 == instance@ }
-		expect(list search(matches), is equal to(-1))
-		(matches as Closure) free()
+		expect(list search(|instance| 1 == instance), is equal to(1))
+		expect(list search(|instance| 9 == instance), is equal to(9))
+		expect(list search(|instance| 10 == instance), is equal to(-1))
 		list free()
 	}
 }


### PR DESCRIPTION
Changed the API to how we want it. It works for lists of covers if you use the cleaner closure syntax: `|instance| instance == 1` instead of `func (instance: Int) -> Bool { instance == 1 }`. This is why it works for similar functions in `VectorList` like `modify`.

@marcusnaslund peer review