### PR TITLE
Added flag for avoiding browser instance on code coverage test

### DIFF
--- a/tools/codecoverage.sh
+++ b/tools/codecoverage.sh
@@ -15,12 +15,15 @@ lcov --quiet --remove test_coverage.info '/test/*' -o test_coverage.info
 rm -r coverage/
 genhtml --quiet -o coverage $INFO_FILE --num-spaces 4
 
-if which xdg-open > /dev/null
+if [[ $* != *--nobrowser* ]]
 then
-	xdg-open 'coverage/index.html'
-elif which gnome-open > /dev/null
-then
-	gnome-open 'coverage/index.html'
-else
-	echo "Could not detect the web browser to use."
+	if which xdg-open > /dev/null
+	then
+		xdg-open 'coverage/index.html'
+	elif which gnome-open > /dev/null
+	then
+		gnome-open 'coverage/index.html'
+	else
+		echo "Could not detect the web browser to use."
+	fi
 fi


### PR DESCRIPTION
One can now pass `--nobrowser` to `codecoverage.sh` to avoid spawning a browser. Needed in order to add an automatic code coverage checker for `PRInt`. The alternative is having people spawn two browser tabs for each PR, but I think that might drive me mad quite fast. :)

Peer review @thomasfanell ?