### PR TITLE
Removed last extenson of Iterable

### DIFF
--- a/source/system/Iterators.ooc
+++ b/source/system/Iterators.ooc
@@ -35,7 +35,6 @@ Iterable: abstract class <T> {
 
 BackIterable: abstract class <T> extends Iterable<T> {
 	iterator: abstract func -> BackIterator<T>
-	/** Returns an iterator at the back or end of the Iterable. */
 	backIterator: func -> BackIterator<T> {
 		iter := iterator()
 		while (iter hasNext())

--- a/source/system/structs/HashMap.ooc
+++ b/source/system/structs/HashMap.ooc
@@ -106,7 +106,7 @@ getStandardHashFunc: func <T> (T: Class) -> Func <T> (T) -> SizeT {
 		murmurHash
 }
 
-HashMap: class <K, V> extends BackIterable<V> {
+HashMap: class <K, V> {
 	_size: SizeT
 	capacity: SizeT
 	hashKey: Func <K> (K) -> SizeT
@@ -168,7 +168,9 @@ HashMap: class <K, V> extends BackIterable<V> {
 	}
 	copy: func -> This<K, V> {
 		copy := This<K, V> new()
-		this each(|k, v| copy put(k, v))
+		f := func (k: K, v: V) { copy put(k, v) }
+		this each(f)
+		(f as Closure) free()
 		copy
 	}
 	merge: func (other: This<K, V>) -> This<K, V> {
@@ -295,7 +297,7 @@ HashMap: class <K, V> extends BackIterable<V> {
 		this keys free()
 		this keys = oldKeys
 	}
-	iterator: override func -> BackIterator<V> {
+	iterator: func -> BackIterator<V> {
 		HashMapValueIterator<K, V> new(this)
 	}
 	backIterator: func -> BackIterator<V> {
@@ -311,7 +313,7 @@ HashMap: class <K, V> extends BackIterable<V> {
 	}
 	each: func ~withKeys (f: Func (K, V)) {
 		for (i in 0 .. this keys count) {
-			key := keys[i]
+			key := this keys[i]
 			f(key, get(key))
 		}
 	}


### PR DESCRIPTION
`HashMap` no longer inherits from `BackIterable` and `copy` doesn't leak a function.

Peer review @jonathanudd ?