### PR TITLE
fixed warnings in Env.ooc

### DIFF
--- a/source/system/os/Env.ooc
+++ b/source/system/os/Env.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-include stdlib | (__USE_BSD)
+include stdlib | (_DEFAULT_SOURCE)
 
 getenv: extern func (path: CString) -> CString
 


### PR DESCRIPTION
Fixes warnings related to `setenv` and `unsetenv` in https://github.com/magic-lang/ooc-kean/issues/1277
@marcusnaslund 