### PR TITLE
Fixed error message in PipeTest

### DIFF
--- a/test/io/PipeTest.ooc
+++ b/test/io/PipeTest.ooc
@@ -39,8 +39,8 @@ PipeTest: class extends Fixture {
 				data free()
 			}
 
-			reader close() . free()
 			process wait()
+			reader close() . free()
 			pipe free()
 			process free()
 		})


### PR DESCRIPTION
Removes the `Child received signal 13` error message in `PipeTest`.