### PR TITLE
string_literal module to workaround memory leak caused by 'makeStringLiteral'

### DIFF
--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -6,29 +6,31 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+include ./string/string_literal
+
+string_literal_new: extern func (String)
+string_literal_free: extern func (String)
+string_literal_free_all: extern func
+
 String: class {
 	// Avoid direct buffer access, as it breaks immutability.
 	_buffer: CharBuffer
-
 	size ::= _buffer size
 
 	init: func ~withBuffer (=_buffer)
-
-	init: func ~withCStr (s: CString) {
-		init(s, s length())
-	}
-
+	init: func ~withCStr (s: CString) { init(s, s length()) }
 	init: func ~withCStrAndLength (s: CString, length: Int) {
 		_buffer = CharBuffer new(s, length)
 	}
 	free: override func {
+		if (this _buffer mallocAddr == 0)
+			string_literal_free(this)
 		this _buffer free()
 		super()
 	}
 	length: func -> Int {
 		_buffer size
 	}
-
 	equals: final func (other: This) -> Bool {
 		result := false
 		if (this == null)
@@ -37,103 +39,78 @@ String: class {
 			result = _buffer equals(other _buffer)
 		result
 	}
-
-	clone: func -> This {
-		new(_buffer clone())
-	}
-
+	clone: func -> This { This new(_buffer clone()) }
 	substring: func ~tillEnd (start: Int) -> This { substring(start, size) }
-
 	substring: func (start, end: Int) -> This {
 		result := _buffer clone()
 		result substring(start, end)
 		result toString()
 	}
-
 	times: func (count: Int) -> This {
 		result := _buffer clone(size * count)
 		result times(count)
 		result toString()
 	}
-
 	append: func ~str (other: This) -> This {
 		if (!other) return this
 		result := _buffer clone(size + other size)
 		result append (other _buffer)
 		result toString()
 	}
-
 	append: func ~char (other: Char) -> This {
 		result := _buffer clone(size + 1)
 		result append(other)
 		result toString()
 	}
-
 	append: func ~cStr (other: CString) -> This {
 		l := other length()
 		result := _buffer clone(size + l)
 		result append(other, l)
 		result toString()
 	}
-
 	prepend: func ~str (other: This) -> This {
 		result := _buffer clone()
 		result prepend(other _buffer)
 		result toString()
 	}
-
 	prepend: func ~char (other: Char) -> This {
 		result := _buffer clone()
 		result prepend(other)
 		result toString()
 	}
-
 	empty: func -> Bool { _buffer empty() }
-
 	startsWith: func (s: This) -> Bool { _buffer startsWith (s _buffer) }
-
 	startsWith: func ~char (c: Char) -> Bool { _buffer startsWith(c) }
-
 	endsWith: func (s: This) -> Bool { _buffer endsWith (s _buffer) }
-
 	endsWith: func ~char (c: Char) -> Bool { _buffer endsWith(c) }
-
 	find: func (what: This, offset: Int, searchCaseSensitive := true) -> Int {
 		_buffer find(what _buffer, offset, searchCaseSensitive)
 	}
-
 	findAll: func (what: This, searchCaseSensitive := true) -> VectorList <Int> {
 		_buffer findAll(what _buffer, searchCaseSensitive)
 	}
-
 	replaceAll: func ~str (what, with: This, searchCaseSensitive := true) -> This {
 		result := _buffer clone()
 		result replaceAll (what _buffer, with _buffer, searchCaseSensitive)
 		result toString()
 	}
-
 	replaceAll: func ~char (oldie, kiddo: Char) -> This {
-		(_buffer clone()) replaceAll~char(oldie, kiddo). toString()
+		(_buffer clone()) replaceAll~char(oldie, kiddo) . toString()
 	}
-
 	map: func (f: Func (Char) -> Char) -> This {
 		(_buffer clone()) map(f). toString()
 	}
-
 	_bufVectorListToStrVectorList: func (x: VectorList<CharBuffer>) -> VectorList<This> {
 		result := VectorList<This> new(x count)
 		for (i in 0 .. x count) result add (x[i] toString())
 		result
 	}
-
 	toLower: func -> This {
 		(_buffer clone()) toLower(). toString()
 	}
-
 	toUpper: func -> This {
 		(_buffer clone()) toUpper(). toString()
 	}
-
 	capitalize: func -> This {
 		match (size) {
 			case 0 => this
@@ -142,105 +119,81 @@ String: class {
 				this[0 .. 1] toUpper() + this[1 .. -1]
 		}
 	}
-
 	indexOf: func ~char (c: Char, start: Int = 0) -> Int { _buffer indexOf(c, start) }
-
 	indexOf: func ~string (s: This, start: Int = 0) -> Int { _buffer indexOf(s _buffer, start) }
-
 	contains: func ~char (c: Char) -> Bool { _buffer contains(c) }
-
 	contains: func ~string (s: This) -> Bool { _buffer contains(s _buffer) }
-
 	trim: func ~pointer (s: Char*, sLength: Int) -> This {
 		result := _buffer clone()
 		result trim~pointer(s, sLength)
 		result toString()
 	}
-
 	trim: func ~string (s : This) -> This {
 		result := _buffer clone()
 		result trim~buf(s _buffer)
 		result toString()
 	}
-
 	trim: func ~char (c: Char) -> This {
 		result := _buffer clone()
 		result trim~char(c)
 		result toString()
 	}
-
 	trim: func ~whitespace -> This {
 		result := _buffer clone()
 		result trim~whitespace()
 		result toString()
 	}
-
 	trimLeft: func ~space -> This {
 		result := _buffer clone()
 		result trimLeft~space()
 		result toString()
 	}
-
 	trimLeft: func ~char (c: Char) -> This {
 		result := _buffer clone()
 		result trimLeft~char(c)
 		result toString()
 	}
-
 	trimLeft: func ~string (s: This) -> This {
 		result := _buffer clone()
 		result trimLeft~buf(s _buffer)
 		result toString()
 	}
-
 	trimLeft: func ~pointer (s: Char*, sLength: Int) -> This {
 		result := _buffer clone()
 		result trimLeft~pointer(s, sLength)
 		result toString()
 	}
-
 	trimRight: func ~space -> This {
 		result := _buffer clone()
 		result trimRight~space()
 		result toString()
 	}
-
 	trimRight: func ~char (c: Char) -> This {
 		result := _buffer clone()
 		result trimRight~char(c)
 		result toString()
 	}
-
 	trimRight: func ~string (s: This) -> This {
 		result := _buffer clone()
 		result trimRight~buf(s _buffer)
 		result toString()
 	}
-
 	trimRight: func ~pointer (s: Char*, sLength: Int) -> This {
 		result := _buffer clone()
 		result trimRight~pointer(s, sLength)
 		result toString()
 	}
-
 	reverse: func -> This {
 		result := _buffer clone()
 		result reverse()
 		result toString()
 	}
-
 	count: func (what: Char) -> Int { _buffer count (what) }
-
 	count: func ~string (what: This) -> Int { _buffer count~buf(what _buffer) }
-
 	lastIndexOf: func (c: Char) -> Int { _buffer lastIndexOf(c) }
-
 	print: func { _buffer print() }
-
 	println: func { if (_buffer != null) _buffer println() }
-
 	println: func ~withStream (stream: FStream) { if (_buffer != null) _buffer println(stream) }
-
 	toInt: func -> Int { _buffer toInt() }
 	toInt: func ~withBase (base: Int) -> Int { _buffer toInt~withBase(base) }
 	toLong: func -> Long { _buffer toLong() }
@@ -252,7 +205,6 @@ String: class {
 	toFloat: func -> Float { _buffer toFloat() }
 	toDouble: func -> Double { _buffer toDouble() }
 	toLDouble: func -> LDouble { _buffer toLDouble() }
-
 	cformat: final func ~str (...) -> This {
 		list: VaList
 		va_start(list, this)
@@ -267,32 +219,25 @@ String: class {
 
 		new(copy)
 	}
-
 	toCString: func -> CString { _buffer data as CString }
-
 	split: func ~withChar (c: Char, maxTokens: SSizeT) -> VectorList<This> {
 		_bufVectorListToStrVectorList(_buffer split(c, maxTokens))
 	}
-
 	split: func ~withStringWithoutmaxTokens (s: This) -> VectorList<This> {
 		_bufVectorListToStrVectorList(_buffer split(s _buffer, -1))
 	}
-
 	split: func ~withCharWithoutmaxTokens (c: Char) -> VectorList<This> {
 		bufferSplit := _buffer split(c)
 		result := _bufVectorListToStrVectorList(bufferSplit)
 		bufferSplit free()
 		result
 	}
-
 	split: func ~withStringWithEmpties (s: This, empties: Bool) -> VectorList<This> {
 		_bufVectorListToStrVectorList(_buffer split(s _buffer, empties))
 	}
-
 	split: func ~withCharWithEmpties (c: Char, empties: Bool) -> VectorList<This> {
 		_bufVectorListToStrVectorList(_buffer split(c, empties))
 	}
-
 	/**
 	 * Split a string to form a list of tokens delimited by `delimiter`
 	 *
@@ -304,6 +249,9 @@ String: class {
 	 */
 	split: func ~str (delimiter: This, maxTokens: SSizeT) -> VectorList<This> {
 		_bufVectorListToStrVectorList(_buffer split(delimiter _buffer, maxTokens))
+	}
+	free: static func ~all {
+		string_literal_free_all()
 	}
 }
 
@@ -340,31 +288,27 @@ operator << (left, right: String) -> String {
 	right free()
 	result
 }
-
 makeStringLiteral: func (str: CString, strLen: Int) -> String {
-	String new(CharBuffer new(str, strLen, true))
+	result := String new(CharBuffer new(str, strLen, true))
+	string_literal_new(result)
+	result
 }
-
 strVectorListFromCString: func (argc: Int, argv: Char**) -> VectorList<String> {
 	result := VectorList<String> new()
 	argc times(|i| result add(argv[i] as CString toString()))
 	result
 }
-
 strVectorListFromCString: func ~hack (argc: Int, argv: String*) -> VectorList<String> {
 	strVectorListFromCString(argc, argv as Char**)
 }
-
 strArrayFromCString: func (argc: Int, argv: Char**) -> String[] {
 	result := String[argc] new()
 	argc times(|i| result[i] = (argv[i] as CString toString()))
 	result
 }
-
 strArrayFromCString: func ~hack (argc: Int, argv: String*) -> String[] {
 	strArrayFromCString(argc, argv as Char**)
 }
-
 cStringPtrToStringPtr: func (cstr: CString*, len: Int) -> String* {
 	toRet: String* = calloc(len, Pointer size) // otherwise the pointers are stack-allocated
 	for (i in 0 .. len) {

--- a/source/system/string/string_literal.c
+++ b/source/system/string/string_literal.c
@@ -1,0 +1,43 @@
+#include "string_literal.h"
+#include <assert.h>
+#include <ooc/system/String-fwd.h>
+
+static String__String** _literals = 0;
+static size_t _literalsCount = 0;
+static size_t _literalsCapacity = 0;
+
+void string_literal_new(void* ptr) {
+	assert(ptr);
+	if (_literalsCount >= _literalsCapacity) {
+		const size_t newCapacity = _literalsCapacity + 32;
+		_literals = realloc(_literals, newCapacity * sizeof(String__String*));
+		assert(_literals);
+		_literalsCapacity = newCapacity;
+	}
+	_literals[_literalsCount++] = (String__String*)ptr;
+}
+void string_literal_free(void* ptr) {
+	size_t i;
+	assert(ptr);
+	String__String* string = (String__String*)ptr;
+	for (i=0 ; i<_literalsCount ; ++i) {
+		if (_literals[i] == string) {
+			_literals[i] = 0;
+			break;
+		}
+	}
+}
+void string_literal_free_all() {
+	if (_literals) {
+		size_t i;
+		for (i=0 ; i<_literalsCount ; ++i) {
+			if (_literals[i]) {
+				String__String_free(_literals[i]);
+			}
+		}
+		free(_literals);
+		_literalsCapacity = 0;
+		_literalsCount = 0;
+		_literals = 0;
+	}
+}

--- a/source/system/string/string_literal.h
+++ b/source/system/string/string_literal.h
@@ -1,0 +1,8 @@
+#ifndef __STRINGLITERAL_FIX_H__
+#define __STRINGLITERAL_FIX_H__
+
+extern void string_literal_new(void*);
+extern void string_literal_free(void*);
+extern void string_literal_free_all();
+
+#endif

--- a/system.use
+++ b/system.use
@@ -26,3 +26,5 @@ Imports: structs/Queue
 Imports: structs/Stack
 Imports: structs/Vector
 Imports: structs/VectorList
+Additionals: source/system/string/string_literal.h
+Additionals: source/system/string/string_literal.c


### PR DESCRIPTION
In order to fix this memory leak I needed to create a separate module
in plain C, just to prevent circular references to static variables
declared in `String` class.
What I mean is that it is (I think) impossible to fix this at ooc level,
as declaring the `string literal` arrays directly in `String` class causes
rock to generate references to `String__String__class()` when accessing them:
```ooc
String: class {
    _stringLiterals := static This* = null
    _stringLiteralsCount := static 0
...
}

makeStringLiteral: func (...) {
   // this line will cause `String__String__class()` access,
   // which will again call `makeStringLiteral` at some point
    if (String _stringLiteralsCount >= ...) {
        String _stringLiterals = realloc( ... ) // last realloc result always leaked
        ...
    }
}

```
This caused the `_stringLiterals` array to leak for some reason,
even if it was explicitly released at program exit.
I struggled to fix this at ooc level for some time, other idea was to use global variables
instead of class statics, but this is even worse as global variables are not initialized,
even when explicitly assigned:
```ooc
stringLiterals := static String* = null

String: class {...
```
generates following C code:
```C
// at file scope 'String.c'
static String__String* String__stringLiterals; // not initialized anywhere, contains garbage
...
```

In fact my first idea was just to use a static `VectorList` in `String` class, forget it, VectorList class init functions calls `makeStringLiteral` too.

So in the end I decided to write logically equavalent code but in plain C and
manage string literal memory in separate module referenced via extern functions. Of course it worked without problems.


tl;dr : I needed to create a C "plugin" for `String` in order to fix the leaked string literals

@fredrikbryntesson review
@marcusnaslund @fredrikbryntesson @thomasfanell  I know it would be the best to fix such things at ooc level, but believe me, I spent far too many hours trying to fix this problem in ooc. We already have hand-written C code for `Arrays`, so I think this one is not that bad. What do you think about this solution ?