### PR TITLE
Extended DrawState to YUV images.

### DIFF
--- a/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
@@ -45,6 +45,18 @@ GpuCanvasYuv420Semiplanar: class extends GpuCanvas {
 		super(this _target size, context, context defaultMap, IntTransform2D identity)
 		this _target uv canvas pen = Pen new(ColorRgba new(128, 128, 128, 128))
 	}
+	draw: override func ~DrawState (drawState: DrawState) {
+		drawStateY := drawState setTarget((drawState target as GpuYuv420Semiplanar) y)
+		drawStateUV := drawState setTarget((drawState target as GpuYuv420Semiplanar) uv)
+		if (!drawState viewport hasZeroArea)
+			drawStateUV viewport = drawState viewport / 2
+		if (drawState inputImage != null && drawState inputImage class == GpuYuv420Semiplanar) {
+			drawStateY inputImage = (drawState inputImage as GpuYuv420Semiplanar) y
+			drawStateUV inputImage = (drawState inputImage as GpuYuv420Semiplanar) uv
+		}
+		drawStateY draw()
+		drawStateUV draw()
+	}
 	draw: override func ~GpuImage (image: GpuImage, source: IntBox2D, destination: IntBox2D, map: Map) {
 		gpuImage := image as GpuYuv420Semiplanar
 		this _target y canvas draw(gpuImage y, source, destination, map)

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -115,6 +115,8 @@ IntBox2D: cover {
 	operator - (other: IntPoint2D) -> This { This new(this leftTop - other, this size) }
 	operator + (other: IntVector2D) -> This { This new(this leftTop, this size + other) }
 	operator - (other: IntVector2D) -> This { This new(this leftTop, this size - other) }
+	operator * (scale: Int) -> This { This new(this leftTop * scale, this size * scale) }
+	operator / (divisor: Int) -> This { This new(this leftTop / divisor, this size / divisor) }
 
 	parse: static func (input: Text) -> This {
 		parts := input split(',')


### PR DESCRIPTION
When drawing to YUV using DrawState, the canvas splits the calls into Y and UV. The conversion from YUV to UV is easier than in the old interface because most settings are stored in normalized coordinates.