### PR TITLE
Safety

### DIFF
--- a/source/draw/Canvas.ooc
+++ b/source/draw/Canvas.ooc
@@ -62,7 +62,7 @@ Canvas: abstract class {
 		positions free()
 	}
 	fill: abstract func
-	draw: virtual func ~DrawState (drawState: DrawState) { Debug error("draw~DrawState unimplemented!") }
+	draw: virtual func ~DrawState (drawState: DrawState) { Debug error("draw~DrawState unimplemented for class " + this class name + "!") }
 	draw: abstract func ~ImageSourceDestination (image: Image, source, destination: IntBox2D)
 	draw: func ~ImageDestination (image: Image, destination: IntBox2D) { this draw(image, IntBox2D new(image size), destination) }
 	draw: func ~Image (image: Image) { this draw(image, IntBox2D new(image size)) }

--- a/source/draw/Map.ooc
+++ b/source/draw/Map.ooc
@@ -68,7 +68,7 @@ Map: abstract class {
 		this _bindings free()
 		super()
 	}
-	use: virtual func
+	use: virtual func (forbiddenInput: Pointer)
 	add: func <T> (key: String, value: T) {
 		if (T inheritsFrom(Object))
 			this _bindings add(key, value as Object, false)

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -40,7 +40,7 @@ OpenGLCanvas: class extends OpenGLSurface {
 			this context backend enableBlend(false)
 		if (drawState inputImage)
 			gpuMap add("texture0", drawState inputImage)
-		gpuMap use()
+		gpuMap use(this _target)
 		this _bind()
 		this context drawQuad()
 		this _unbind()

--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -77,7 +77,7 @@ OpenGLContext: class extends GpuContext {
 		positions := pointList pointer as Float*
 		this _linesShader projection = projection
 		this _linesShader add("color", pen color normalized)
-		this _linesShader use()
+		this _linesShader use(null)
 		this _renderer drawLines(positions, pointList count, 2, pen width)
 	}
 	drawPoints: func (pointList: VectorList<FloatPoint2D>, projection: FloatTransform3D, pen: Pen) {
@@ -85,7 +85,7 @@ OpenGLContext: class extends GpuContext {
 		this _pointsShader add("color", pen color normalized)
 		this _pointsShader add("pointSize", pen width)
 		this _pointsShader projection = projection
-		this _pointsShader use()
+		this _pointsShader use(null)
 		this _renderer drawPoints(positions, pointList count, 2)
 	}
 	recycle: virtual func (image: OpenGLPacked) {

--- a/source/draw/gpu/opengl/OpenGLMap.ooc
+++ b/source/draw/gpu/opengl/OpenGLMap.ooc
@@ -47,7 +47,7 @@ OpenGLMap: class extends Map {
 		this _program free()
 		super()
 	}
-	use: override func {
+	use: override func (forbiddenInput: Pointer) {
 		this _currentProgram use()
 		textureCount := 0
 		action := func (key: String, value: Object) {
@@ -78,6 +78,9 @@ OpenGLMap: class extends Map {
 			} else
 				match (value) {
 					case image: OpenGLPacked =>
+						version(safe)
+							if (forbiddenInput != null && (forbiddenInput as Pointer) == (image as Pointer))
+								raise("Input image " + key + " is also the target.")
 						image backend bind(textureCount)
 						program setUniform(key, textureCount)
 						textureCount += 1
@@ -100,20 +103,20 @@ OpenGLMap: class extends Map {
 }
 OpenGLMapMesh: class extends OpenGLMap {
 	init: func (context: OpenGLContext) { super(This vertexSource, This fragmentSource, context) }
-	use: override func {
+	use: override func (forbiddenInput: Pointer) {
 		this add("projection", this projection)
-		super()
+		super(forbiddenInput)
 	}
 	vertexSource: static String = slurp("shaders/mesh.vert")
 	fragmentSource: static String = slurp("shaders/mesh.frag")
 }
 OpenGLMapTransform: class extends OpenGLMap {
 	init: func (fragmentSource: String, context: OpenGLContext) { super(This vertexSource, fragmentSource, context) }
-	use: override func {
+	use: override func (forbiddenInput: Pointer) {
 		finalTransform := this projection * this view * this model
 		this add("transform", finalTransform)
 		this add("textureTransform", this textureTransform)
-		super()
+		super(forbiddenInput)
 	}
 	vertexSource: static String = slurp("shaders/transform.vert")
 }

--- a/source/draw/gpu/opengl/OpenGLSurface.ooc
+++ b/source/draw/gpu/opengl/OpenGLSurface.ooc
@@ -37,7 +37,7 @@ OpenGLSurface: abstract class extends GpuCanvas {
 		map model = this _createModelTransform(destination)
 		map view = this _view
 		map projection = this _projection
-		map use()
+		map use(null)
 		f := func { this context drawQuad() }
 		this draw(f)
 		(f as Closure) free()
@@ -60,7 +60,7 @@ OpenGLSurface: abstract class extends GpuCanvas {
 		f := func {
 			this context meshShader add("texture0", image)
 			this context meshShader projection = this _projection
-			this context meshShader use()
+			this context meshShader use(null)
 			mesh draw()
 		}
 		this draw(f)


### PR DESCRIPTION
Since the full safety feature takes too long time, I made a lightweight safety feature to begin with.

* Giving more relevant information when drawing with DrawState to an unsupported target.
* Implemented a safety feature from https://github.com/magic-lang/ooc-kean/issues/1427. This check is not compatible with the legacy calls becuase they are in `OpenGLSurface` but using it as a canvas without access to `_target`.