### PR TITLE
Reorganized the Timer classes

### DIFF
--- a/source/base/Profiler.ooc
+++ b/source/base/Profiler.ooc
@@ -14,7 +14,7 @@ import Timer
 
 Profiler: class {
 	_name: String
-	_timer := Timer new()
+	_timer := WallTimer new()
 	init: func (=_name) { This _profilers add(this) }
 	free: override func {
 		for (i in 0 .. This _profilers count)

--- a/source/base/Timer.ooc
+++ b/source/base/Timer.ooc
@@ -9,7 +9,7 @@
 clock: extern func -> LLong
 CLOCKS_PER_SEC: extern const LLong
 
-Timer: class {
+Timer: abstract class {
 	_startTime: Double
 	_endTime: Double
 	_result: Double
@@ -18,18 +18,13 @@ Timer: class {
 	_min: Double
 	_max: Double
 	_average: Double
+
 	init: func {
 		this _min = INFINITY
 		this _max = 0.0
 	}
-	// Note: On Windows, there is only millisecond precision
-	start: virtual func { this _startTime = (Time runTimeMicro() as Double) }
-	stop: virtual func -> Double {
-		this _endTime = (Time runTimeMicro() as Double)
-		this _result = this _endTime - this _startTime
-		this _update()
-		this _result
-	}
+	start: abstract func
+	stop: abstract func -> Double
 	_update: virtual func {
 		if (this _result < this _min)
 			this _min = this _result
@@ -50,7 +45,18 @@ Timer: class {
 	}
 }
 
-ClockTimer: class extends Timer {
+WallTimer: class extends Timer {
+	init: func { super() }
+	start: override func { this _startTime = (Time runTimeMicro() as Double) } // Note: Only millisecond precision on Win32
+	stop: override func -> Double {
+		this _endTime = (Time runTimeMicro() as Double)
+		this _result = this _endTime - this _startTime
+		this _update()
+		this _result
+	}
+}
+
+CpuTimer: class extends Timer {
 	init: func { super() }
 	start: override func { this _startTime = (clock() as Double) }
 	stop: override func -> Double {

--- a/source/concurrent/ThreadPool.ooc
+++ b/source/concurrent/ThreadPool.ooc
@@ -98,7 +98,7 @@ _TaskPromise: class extends Promise {
 	}
 	wait: override func -> Bool { this _task wait() }
 	wait: override func ~timeout (time: TimeSpan) -> Bool {
-		timer := ClockTimer new() . start()
+		timer := CpuTimer new() . start()
 		seconds := time toSeconds()
 		status := false
 		while (timer stop() / 1000.0 < seconds && !status) {
@@ -124,7 +124,7 @@ _TaskFuture: class <T> extends Future<T> {
 	}
 	wait: override func -> Bool { this _task wait() }
 	wait: override func ~timeout (time: TimeSpan) -> Bool {
-		timer := ClockTimer new() . start()
+		timer := CpuTimer new() . start()
 		seconds := time toSeconds()
 		status := false
 		while (timer stop() / 1000.0 < seconds && !status) {

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -39,7 +39,7 @@ Fixture: abstract class {
 		result := true
 		dateString := DateTime now toText(t"%hh:%mm:%ss ") + Text new(this name) + t" "
 		This _print(dateString)
-		timer := Timer new() . start()
+		timer := WallTimer new() . start()
 		for (i in 0 .. this tests count) {
 			test := tests[i]
 			This _expectCount = 0

--- a/test/base/TimerTest.ooc
+++ b/test/base/TimerTest.ooc
@@ -10,35 +10,38 @@ use base
 use unit
 
 TimerTest: class extends Fixture {
-	timer := Timer new()
-	clockTimer := ClockTimer new()
+	wallTimer := WallTimer new()
+	cpuTimer := CpuTimer new()
 
 	init: func {
-		super("Timer")
-		this add("basic use of Timer", func {
-			fast := this timerTestFunction(1_000)
-			slow := this timerTestFunction(10_000_000)
+		super("WallTimer")
+		this add("basic use of WallTimer", func {
+			fast := this wallTimerTestFunction(1_000)
+			slow := this wallTimerTestFunction(10_000_000)
 			expect(slow > fast, is true)
 		})
-		this add("basic use of ClockTimer", func {
-			fast := this clockTimerTestFunction(1_000)
-			slow := this clockTimerTestFunction(10_000_000)
+		this add("basic use of CpuTimer", func {
+			fast := this cpuTimerTestFunction(1_000)
+			slow := this cpuTimerTestFunction(10_000_000)
 			expect(slow > fast, is true)
 		})
 	}
-
-	timerTestFunction: func (loopLength: Int) -> Double {
+	wallTimerTestFunction: func (loopLength: Int) -> Double {
 		sum := 0
-		this timer start()
+		this wallTimer start()
 		for (i in 0 .. loopLength) { sum = (sum + i) % 10 }
-		this timer stop()
+		this wallTimer stop()
 	}
-
-	clockTimerTestFunction: func (loopLength: Int) -> Double {
+	cpuTimerTestFunction: func (loopLength: Int) -> Double {
 		sum := 0
-		this clockTimer start()
+		this cpuTimer start()
 		for (i in 0 .. loopLength) { sum = (sum + i) % 10 }
-		this clockTimer stop()
+		this cpuTimer stop()
+	}
+	free: override func {
+		this wallTimer free()
+		this cpuTimer free()
+		super()
 	}
 }
 


### PR DESCRIPTION
Fixes #1415 

Instead of `Timer` and `ClockTimer`, there is now an abstract `Timer` class from which `WallTimer` and `CpuTimer` are derived. What do you think about this @sebastianbaginski @fredrikbryntesson @thomasfanell ?