### PR TITLE
Moved system/io/native files to system/native

### DIFF
--- a/source/system/io/FileWriter.ooc
+++ b/source/system/io/FileWriter.ooc
@@ -7,7 +7,7 @@
  */
 
 import io/[Writer, File]
-import io/native/FileUnix
+import native/FileUnix
 
 FileWriter: class extends Writer {
 	file: FStream

--- a/source/system/native/FileUnix.ooc
+++ b/source/system/native/FileUnix.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-import ../File
+import io/File
 include dirent
 
 /*

--- a/source/system/native/FileWin32.ooc
+++ b/source/system/native/FileWin32.ooc
@@ -8,7 +8,7 @@
 
 import os/win32
 import structs/VectorList
-import ../File
+import io/File
 
 version(windows) {
 	include windows | (_WIN32_WINNT=0x0500)


### PR DESCRIPTION
Makes more sense since we now already have `system/native` and `system` should be *one* namespace, not a group of namespaces like in the old SDK.

Peer review @fredrikbryntesson ?