### PR TITLE
Perspective fix

### DIFF
--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -27,6 +27,7 @@ DrawState: cover {
 	viewport := IntBox2D new(0, 0, 0, 0)
 	_destinationNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	_sourceNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
+	_focalLengthNormalized := 0.0f // Relative to image width
 	init: func@ ~default
 	init: func@ ~target (=target)
 	setTarget: func (target: Image) -> This {
@@ -45,6 +46,18 @@ DrawState: cover {
 		this opacity = opacity
 		this
 	}
+	setFocalLength: func ~Int (focalLength: Float, imageSize: IntVector2D) -> This {
+		this setFocalLength(focalLength, imageSize toFloatVector2D())
+	}
+	setFocalLength: func ~Float (focalLength: Float, imageSize: FloatVector2D) -> This {
+		this _focalLengthNormalized = focalLength / imageSize x
+		this
+	}
+	setFocalLengthNormalized: func (focalLength: Float) -> This {
+		this _focalLengthNormalized = focalLength
+		this
+	}
+	getFocalLengthNormalized: func -> Float { this _focalLengthNormalized }
 	// Local region
 	setViewport: func (viewport: IntBox2D) -> This {
 		this viewport = viewport

--- a/source/draw/gpu/GpuCanvas.ooc
+++ b/source/draw/gpu/GpuCanvas.ooc
@@ -45,20 +45,20 @@ GpuCanvas: abstract class extends Canvas {
 			}
 			else
 				this _projection = FloatTransform3D createScaling(2.0f / this size x, -(this _coordinateTransform e as Float) * 2.0f / this size y, 1.0f)
-			this _model = this _createModelTransform(IntBox2D new(this size))
+			this _model = this _createModelTransform(IntBox2D new(this size), this _focalLength)
 		}
 	}
 	init: func (size: IntVector2D, =_context, =_defaultMap, =_coordinateTransform) { super(size) }
-	_createModelTransform: func ~LocalInt (box: IntBox2D) -> FloatTransform3D {
-		this _createModelTransform(box toFloatBox2D())
+	_createModelTransform: func ~LocalInt (box: IntBox2D, focalLength: Float) -> FloatTransform3D {
+		this _createModelTransform(box toFloatBox2D(), focalLength)
 	}
-	_createModelTransform: func ~LocalFloat (box: FloatBox2D) -> FloatTransform3D {
+	_createModelTransform: func ~LocalFloat (box: FloatBox2D, focalLength: Float) -> FloatTransform3D {
 		toReference := FloatTransform3D createTranslation((box size x - this size x) / 2, (this size y - box size y) / 2, 0.0f)
-		translation := this _toLocal * FloatTransform3D createTranslation(box leftTop x, box leftTop y, this focalLength) * this _toLocal
+		translation := this _toLocal * FloatTransform3D createTranslation(box leftTop x, box leftTop y, focalLength) * this _toLocal
 		translation * toReference * FloatTransform3D createScaling(box size x / 2.0f, box size y / 2.0f, 1.0f)
 	}
-	_createModelTransformNormalized: func (imageSize: IntVector2D, box: FloatBox2D) -> FloatTransform3D {
-		this _createModelTransform(box * imageSize toFloatVector2D())
+	_createModelTransformNormalized: func (imageSize: IntVector2D, box: FloatBox2D, focalLength: Float) -> FloatTransform3D {
+		this _createModelTransform(box * imageSize toFloatVector2D(), focalLength)
 	}
 	_getDefaultMap: virtual func (image: Image) -> Map { this _defaultMap }
 	clear: func { this fill() }

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -23,17 +23,18 @@ OpenGLCanvas: class extends OpenGLSurface {
 		gpuMap: Map = drawState map as Map ?? (drawState mesh ? this context meshShader as Map : this context defaultMap as Map)
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
 		this context backend setViewport(viewport)
-		focalLengthPixels := drawState getFocalLengthNormalized() * this size x
+		focalLengthPerWidth := drawState getFocalLengthNormalized()
+		aspectRatio := (this size x as Float) / (this size y as Float)
 		gpuMap view = _toLocal * drawState getTransformNormalized() normalizedToReference(this size) * _toLocal
-		if (focalLengthPixels > 0.0f) {
-			a := 2.0f * focalLengthPixels / this size x
-			f := -(this _coordinateTransform e as Float) * 2.0f * focalLengthPixels / this size y
+		if (focalLengthPerWidth > 0.0f) {
+			a := 2.0f * focalLengthPerWidth
+			f := -(this _coordinateTransform e as Float) * 2.0f * focalLengthPerWidth * aspectRatio
 			k := (this _farPlane + this _nearPlane) / (this _farPlane - this _nearPlane)
 			o := 2.0f * this _farPlane * this _nearPlane / (this _farPlane - this _nearPlane)
 			gpuMap projection = FloatTransform3D new(a, 0.0f, 0.0f, 0.0f, 0.0f, f, 0.0f, 0.0f, 0.0f, 0.0f, k, -1.0f, 0.0f, 0.0f, o, 0.0f)
 		} else
 			gpuMap projection = FloatTransform3D createScaling(2.0f / this size x, -(this _coordinateTransform e as Float) * 2.0f / this size y, 1.0f)
-		gpuMap model = this _createModelTransformNormalized(this size, drawState getDestinationNormalized(), focalLengthPixels)
+		gpuMap model = this _createModelTransformNormalized(this size, drawState getDestinationNormalized(), focalLengthPerWidth * this size x)
 		gpuMap textureTransform = This _createTextureTransform(drawState getSourceNormalized())
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -23,16 +23,17 @@ OpenGLCanvas: class extends OpenGLSurface {
 		gpuMap: Map = drawState map as Map ?? (drawState mesh ? this context meshShader as Map : this context defaultMap as Map)
 		viewport := (drawState viewport hasZeroArea) ? IntBox2D new(this size) : drawState viewport
 		this context backend setViewport(viewport)
+		focalLengthPixels := drawState getFocalLengthNormalized() * this size x
 		gpuMap view = _toLocal * drawState getTransformNormalized() normalizedToReference(this size) * _toLocal
-		if (this _focalLength > 0.0f) {
-			a := 2.0f * this _focalLength / this size x
-			f := -(this _coordinateTransform e as Float) * 2.0f * this _focalLength / this size y
+		if (focalLengthPixels > 0.0f) {
+			a := 2.0f * focalLengthPixels / this size x
+			f := -(this _coordinateTransform e as Float) * 2.0f * focalLengthPixels / this size y
 			k := (this _farPlane + this _nearPlane) / (this _farPlane - this _nearPlane)
 			o := 2.0f * this _farPlane * this _nearPlane / (this _farPlane - this _nearPlane)
 			gpuMap projection = FloatTransform3D new(a, 0.0f, 0.0f, 0.0f, 0.0f, f, 0.0f, 0.0f, 0.0f, 0.0f, k, -1.0f, 0.0f, 0.0f, o, 0.0f)
 		} else
 			gpuMap projection = FloatTransform3D createScaling(2.0f / this size x, -(this _coordinateTransform e as Float) * 2.0f / this size y, 1.0f)
-		gpuMap model = this _createModelTransformNormalized(this size, drawState getDestinationNormalized())
+		gpuMap model = this _createModelTransformNormalized(this size, drawState getDestinationNormalized(), focalLengthPixels)
 		gpuMap textureTransform = This _createTextureTransform(drawState getSourceNormalized())
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)

--- a/source/draw/gpu/opengl/OpenGLSurface.ooc
+++ b/source/draw/gpu/opengl/OpenGLSurface.ooc
@@ -34,7 +34,7 @@ OpenGLSurface: abstract class extends GpuCanvas {
 		this _unbind()
 	}
 	draw: override func ~WithoutBind (destination: IntBox2D, map: Map) {
-		map model = this _createModelTransform(destination)
+		map model = this _createModelTransform(destination, this _focalLength)
 		map view = this _view
 		map projection = this _projection
 		map use(null)


### PR DESCRIPTION
DrawState now handles focalLength and stores it in normalized coordinates so that it will automatically adapt when drawing to YUV images. This will obsolete `focalLength` in canvas so that you do not have side effects.