### PR TITLE
Removed String leak suppression from test memcheck

### DIFF
--- a/tools/kean.supp
+++ b/tools/kean.supp
@@ -11,12 +11,6 @@
    fun:backend_gles3_Gles3FramebufferObject__Gles3FramebufferObject_clear
 }
 {
-   stringliteral
-   Memcheck:Leak
-   ...
-   fun:String__makeStringLiteral
-}
-{
    mapinit
    Memcheck:Leak
    ...


### PR DESCRIPTION
Stringliterals no longer leak and this is gone in the other project, so it should go away here too. Right @fredrikbryntesson ?