### PR TITLE
Added new class WaitLock

### DIFF
--- a/concurrent.use
+++ b/concurrent.use
@@ -11,3 +11,4 @@ Imports: RecycleBin
 Imports: WorkerThread
 Imports: Thread
 Imports: WaitCondition
+Imports: WaitLock

--- a/source/concurrent/SynchronizedQueue.ooc
+++ b/source/concurrent/SynchronizedQueue.ooc
@@ -48,11 +48,11 @@ SynchronizedQueue: class <T> extends Queue<T> {
 }
 
 BlockedQueue: class <T> extends SynchronizedQueue<T> {
-	_waitLock : WaitLock
+	_waitLock: WaitLock
 	_canceled := false
 	init: func {
 		super()
-		this _waitLock = WaitLock new(_mutex)
+		this _waitLock = WaitLock new(this _mutex)
 	}
 	free: override func {
 		this _waitLock free()
@@ -62,13 +62,10 @@ BlockedQueue: class <T> extends SynchronizedQueue<T> {
 		super(item)
 		this _waitLock wake()
 	}
-	cancel: func {
-		this _waitLock with(|| this _canceled = true)
-		this _waitLock wakeAll()
-	}
+	cancel: func { this _waitLock with(|| this _canceled = true) . wakeAll() }
 	wait: func (isOk := null as Bool*) -> T {
 		result: T = null
-		this _waitLock lockWhen(|| !this empty || this _canceled)
+		this _waitLock lockWhen(func -> Bool { !this empty || this _canceled })
 		if (this _canceled) {
 			if (isOk)
 				isOk@ = false

--- a/source/concurrent/SynchronizedQueue.ooc
+++ b/source/concurrent/SynchronizedQueue.ooc
@@ -48,34 +48,33 @@ SynchronizedQueue: class <T> extends Queue<T> {
 }
 
 BlockedQueue: class <T> extends SynchronizedQueue<T> {
-	_populated := WaitCondition new()
+	_waitLock : WaitLock
 	_canceled := false
-	init: func { super() }
+	init: func {
+		super()
+		this _waitLock = WaitLock new(_mutex)
+	}
 	free: override func {
-		this _populated free()
+		this _waitLock free()
 		super()
 	}
 	enqueue: override func (item: T) {
 		super(item)
-		this _populated signal()
+		this _waitLock wake()
 	}
 	cancel: func {
-		this _mutex lock()
-		this _canceled = true
-		this _mutex unlock()
-		this _populated broadcast()
+		this _waitLock with(|| this _canceled = true)
+		this _waitLock wakeAll()
 	}
 	wait: func (isOk := null as Bool*) -> T {
 		result: T = null
-		this _mutex lock()
-		while (this empty && !this _canceled)
-			this _populated wait(this _mutex)
+		this _waitLock lockWhen(|| !this empty || this _canceled)
 		if (this _canceled) {
 			if (isOk)
 				isOk@ = false
 		} else
 			result = this _backend dequeue(result)
-		this _mutex unlock()
+		this _waitLock unlock()
 		result
 	}
 }

--- a/source/concurrent/WaitLock.ooc
+++ b/source/concurrent/WaitLock.ooc
@@ -1,0 +1,53 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+use concurrent
+
+WaitLock: class {
+	_waitCondition := WaitCondition new()
+	_mutex : Mutex
+	_ownsMutex : Bool
+	init: func {
+		this _mutex = Mutex new()
+		this _ownsMutex = true
+	}
+	init: func ~WithMutex (mutex: Mutex)
+	{
+		this _mutex = mutex
+		this _ownsMutex = false
+	}
+	free: override func {
+		if(this _ownsMutex) {
+			this _mutex free()
+			this _mutex = null
+		}
+		this _waitCondition free()
+		this _waitCondition = null
+		super()
+	}
+	lock: func { this _mutex lock() }
+	unlock: func { this _mutex unlock() }
+	lockWhen: func (condition: Func -> Bool)
+	{
+		this lock()
+		while (!condition())
+			this _waitCondition wait(this _mutex)
+		(condition as Closure) free(Owner Receiver)
+	}
+	with: func (f: Func) {
+		this _mutex with(f)
+	}
+	wake: func -> Bool
+	{
+		this _waitCondition signal()
+	}
+	wakeAll: func -> Bool
+	{
+		this _waitCondition broadcast()
+	}
+}

--- a/test/concurrent/WaitLockTest.ooc
+++ b/test/concurrent/WaitLockTest.ooc
@@ -1,0 +1,113 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+use concurrent
+use unit
+
+WaitLockTest: class extends Fixture {
+	init: func {
+		super("WithLock")
+		this add("_testWithMutexOwnership", This _testWithMutexOwnership)
+		this add("_testWithoutMutexOwnership", This _testWithoutMutexOwnership)
+		this add("_testWakeWithFailingCondition", This _testWakeWithFailingCondition)
+		this add("_testWakeWithPassingCondition", This _testWakeWithPassingCondition)
+	}
+	_testWithMutexOwnership: static func {
+		waitLock := WaitLock new()
+		waitLock free()
+	}
+	_testWithoutMutexOwnership: static func {
+		mutex := Mutex new()
+		waitLock := WaitLock new(mutex)
+		waitLock free()
+		mutex free()
+	}
+	_testWakeWithFailingCondition: static func {
+		timesTriggered := 0
+		timesTriggeredRef := timesTriggered&
+		waitLock := WaitLock new()
+		waitingThread := Thread new(||
+			waitLock lockWhen(||
+				timesTriggeredRef@ = timesTriggeredRef@ + 1
+				false
+			)
+			waitLock unlock()
+			expect(false)
+		)
+		testThread := Thread new(||
+
+			while (true) {
+				waitLock lock()
+				if(timesTriggeredRef@ >= 1)
+					break
+				waitLock unlock()
+				Thread yield()
+			}
+			expect(timesTriggeredRef@ == 1)
+			waitLock unlock()
+
+			waitLock wake()
+			expect(!waitingThread wait(0.05))
+			waitLock lock()
+			expect(timesTriggeredRef@ == 2)
+			waitLock unlock()
+		)
+		testThread start()
+		waitingThread start()
+		expect(testThread wait(0.1))
+		testThread free()
+		waitingThread cancel()
+		expect(waitingThread wait(0.1))
+		waitingThread free()
+		waitLock free()
+	}
+	_testWakeWithPassingCondition: static func {
+		timesTriggered := 0
+		timesTriggeredRef := timesTriggered&
+		waitLock := WaitLock new()
+		waitingThread := Thread new(||
+			waitLock lockWhen(||
+				timesTriggeredRef@ = timesTriggeredRef@ + 1
+				timesTriggeredRef@ == 2
+			)
+			waitLock unlock()
+		)
+		testThread := Thread new(||
+			while (true) {
+				waitLock lock()
+				if(timesTriggeredRef@ >= 1)
+					break
+				waitLock unlock()
+				Thread yield()
+			}
+			expect(timesTriggeredRef@ == 1)
+			waitLock unlock()
+			waitLock wake()
+			while (true) {
+				waitLock lock()
+				if(timesTriggeredRef@ >= 2)
+					break
+				waitLock unlock()
+				Thread yield()
+			}
+			expect(timesTriggeredRef@ == 2)
+			waitLock unlock()
+			while(!waitingThread wait(0.05))
+				Thread yield()
+		)
+		testThread start()
+		waitingThread start()
+		expect(testThread wait(0.1))
+		testThread free()
+		expect(!waitingThread alive())
+		waitingThread free()
+		waitLock free()
+	}
+}
+
+WaitLockTest new() run() . free()

--- a/test/concurrent/WaitLockTest.ooc
+++ b/test/concurrent/WaitLockTest.ooc
@@ -11,7 +11,7 @@ use unit
 
 WaitLockTest: class extends Fixture {
 	init: func {
-		super("WithLock")
+		super("WaitLock")
 		this add("_testWithMutexOwnership", This _testWithMutexOwnership)
 		this add("_testWithoutMutexOwnership", This _testWithoutMutexOwnership)
 		this add("_testWakeWithFailingCondition", This _testWakeWithFailingCondition)
@@ -32,25 +32,23 @@ WaitLockTest: class extends Fixture {
 		timesTriggeredRef := timesTriggered&
 		waitLock := WaitLock new()
 		waitingThread := Thread new(||
-			waitLock lockWhen(||
+			waitLock lockWhen(func -> Bool {
 				timesTriggeredRef@ = timesTriggeredRef@ + 1
 				false
-			)
+			})
 			waitLock unlock()
 			expect(false)
 		)
 		testThread := Thread new(||
-
 			while (true) {
 				waitLock lock()
-				if(timesTriggeredRef@ >= 1)
+				if (timesTriggeredRef@ >= 1)
 					break
 				waitLock unlock()
 				Thread yield()
 			}
 			expect(timesTriggeredRef@ == 1)
 			waitLock unlock()
-
 			waitLock wake()
 			expect(!waitingThread wait(0.05))
 			waitLock lock()
@@ -71,16 +69,16 @@ WaitLockTest: class extends Fixture {
 		timesTriggeredRef := timesTriggered&
 		waitLock := WaitLock new()
 		waitingThread := Thread new(||
-			waitLock lockWhen(||
+			waitLock lockWhen(func -> Bool {
 				timesTriggeredRef@ = timesTriggeredRef@ + 1
 				timesTriggeredRef@ == 2
-			)
+			})
 			waitLock unlock()
 		)
 		testThread := Thread new(||
 			while (true) {
 				waitLock lock()
-				if(timesTriggeredRef@ >= 1)
+				if (timesTriggeredRef@ >= 1)
 					break
 				waitLock unlock()
 				Thread yield()
@@ -90,14 +88,14 @@ WaitLockTest: class extends Fixture {
 			waitLock wake()
 			while (true) {
 				waitLock lock()
-				if(timesTriggeredRef@ >= 2)
+				if (timesTriggeredRef@ >= 2)
 					break
 				waitLock unlock()
 				Thread yield()
 			}
 			expect(timesTriggeredRef@ == 2)
 			waitLock unlock()
-			while(!waitingThread wait(0.05))
+			while (!waitingThread wait(0.05))
 				Thread yield()
 		)
 		testThread start()


### PR DESCRIPTION
part of #1043
@emilwestergren @marcusnaslund 

Suggestion on merging  WaitCondition and WaitLock to the same class since WaitCondition cannot exist without a mutex and WaitLock is a combination of a Waitcondition and a Mutex.

Doing this does will however limit the useage of the functionality in WaitCondition. For example in the case where we hwve multiple threads waiting for the same signal but have separate mutexes since they do not share resources with eachother. By merging the two classes we will lose the N to N mapping possibility between WaitCondition and Mutex and will ot be able to interact with WaitCondition on a lower level.

According to man for pthread_cond_wait you should not use the same mutex for multiple conditions

"The effect of using more than one mutex for concurrent pthread_cond_wait() or pthread_cond_timedwait() operations on the same condition variable is undefined; that is, a condition variable becomes bound to a unique mutex when a thread waits on the condition variable, and this (dynamic) binding ends when the wait returns."

So in reality on Unix you will have a N to 1 mapping between WaitCondition and Mutex which is what the New WaitLock class fullfills with the overloaded constructor where you can supply a Mutex

The decision was to create a new class