### PR TITLE
Added blend modes to DrawState.

### DIFF
--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -17,12 +17,18 @@ import Mesh
 
 // See README.md about input arguments and coordinate systems
 
+BlendMode: enum {
+	Fill
+	Add
+}
+
 DrawState: cover {
 	target: Image = null
 	inputImage: Image = null
 	map: Map = null
 	mesh: Mesh = null
 	opacity := 1.0f
+	blendMode := BlendMode Fill
 	_transformNormalized := FloatTransform3D identity
 	viewport := IntBox2D new(0, 0, 0, 0)
 	_destinationNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
@@ -44,6 +50,10 @@ DrawState: cover {
 	}
 	setOpacity: func (opacity: Float) -> This {
 		this opacity = opacity
+		this
+	}
+	setBlendMode: func (blendMode: BlendMode) -> This {
+		this blendMode = blendMode
 		this
 	}
 	setFocalLength: func ~Int (focalLength: Float, imageSize: IntVector2D) -> This {

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -41,6 +41,8 @@ OpenGLCanvas: class extends OpenGLSurface {
 		gpuMap textureTransform = This _createTextureTransform(drawState getSourceNormalized())
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)
+		else if (drawState blendMode == BlendMode Add)
+			this context backend blend()
 		else
 			this context backend enableBlend(false)
 		if (drawState inputImage)


### PR DESCRIPTION
Hiding the old blend API so that the new version can be made later without breaking the API again. After this PR, half of the old draw functions in canvas can be removed. To remove the remaining draw calls in the OpenGL layer, Line and point drawing can take some minimal code from the old draw calls and packing can use DrawState. CPU drawing will not be using DrawState for a while.