### PR TITLE
Accepting more types of images in DrawState

### DIFF
--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -45,8 +45,23 @@ OpenGLCanvas: class extends OpenGLSurface {
 			this context backend blend()
 		else
 			this context backend enableBlend(false)
-		if (drawState inputImage)
-			gpuMap add("texture0", drawState inputImage)
+		tempImageA: GpuImage = null
+		tempImageB: GpuImage = null
+		if (drawState inputImage) {
+			if (drawState inputImage instanceOf(RasterYuv420Semiplanar)) {
+				tempImageA = this _context createImage((drawState inputImage as RasterYuv420Semiplanar) y)
+				tempImageB = this _context createImage((drawState inputImage as RasterYuv420Semiplanar) uv)
+				gpuMap add("texture0", tempImageA)
+				gpuMap add("texture1", tempImageB)
+			} else if (drawState inputImage instanceOf(RasterImage)) {
+				tempImageA = this _context createImage(drawState inputImage as RasterImage)
+				gpuMap add("texture0", tempImageA)
+			} else if (drawState inputImage instanceOf(GpuYuv420Semiplanar)) {
+				gpuMap add("texture0", (drawState inputImage as GpuYuv420Semiplanar) y)
+				gpuMap add("texture1", (drawState inputImage as GpuYuv420Semiplanar) uv)
+			} else
+				gpuMap add("texture0", drawState inputImage)
+		}
 		gpuMap use(this _target)
 		this _bind()
 		if (drawState mesh)
@@ -54,6 +69,10 @@ OpenGLCanvas: class extends OpenGLSurface {
 		else
 			this context drawQuad()
 		this _unbind()
+		if (tempImageA)
+			tempImageA free()
+		if (tempImageB)
+			tempImageB free()
 	}
 	init: func (=_target, context: OpenGLContext) {
 		super(this _target size, context, context defaultMap, IntTransform2D identity)

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -48,19 +48,21 @@ OpenGLCanvas: class extends OpenGLSurface {
 		tempImageA: GpuImage = null
 		tempImageB: GpuImage = null
 		if (drawState inputImage) {
-			if (drawState inputImage instanceOf(RasterYuv420Semiplanar)) {
-				tempImageA = this _context createImage((drawState inputImage as RasterYuv420Semiplanar) y)
-				tempImageB = this _context createImage((drawState inputImage as RasterYuv420Semiplanar) uv)
-				gpuMap add("texture0", tempImageA)
-				gpuMap add("texture1", tempImageB)
-			} else if (drawState inputImage instanceOf(RasterImage)) {
-				tempImageA = this _context createImage(drawState inputImage as RasterImage)
-				gpuMap add("texture0", tempImageA)
-			} else if (drawState inputImage instanceOf(GpuYuv420Semiplanar)) {
-				gpuMap add("texture0", (drawState inputImage as GpuYuv420Semiplanar) y)
-				gpuMap add("texture1", (drawState inputImage as GpuYuv420Semiplanar) uv)
-			} else
-				gpuMap add("texture0", drawState inputImage)
+			match (drawState inputImage) {
+				case (image: RasterYuv420Semiplanar) =>
+					tempImageA = this _context createImage(image y)
+					tempImageB = this _context createImage(image uv)
+					gpuMap add("texture0", tempImageA)
+					gpuMap add("texture1", tempImageB)
+				case (image: RasterImage) =>
+					tempImageA = this _context createImage(image)
+					gpuMap add("texture0", tempImageA)
+				case (image: GpuYuv420Semiplanar) =>
+					gpuMap add("texture0", image y)
+					gpuMap add("texture1", image uv)
+				case (image: GpuImage) =>
+					gpuMap add("texture0", image)
+			}
 		}
 		gpuMap use(this _target)
 		this _bind()


### PR DESCRIPTION
Added functionality to do everything that the old draw API could do but without the messy inheritance layers. Both YUV and CPU images are accepted when assigning an image to inputImage in DrawState. Rendering a CPU image is only for testing purposes since uploading to GPU each time is very slow. Explicit binding directly to the shader will still only accept planar GPU images.