### PR TITLE
More cleanup and bug fix in Fixture

### DIFF
--- a/source/unit/Constraints.ooc
+++ b/source/unit/Constraints.ooc
@@ -14,9 +14,9 @@ ComparisonType: enum {
 	Equal
 	NotEqual
 	LessThan
-	LessThanOrEqual // TODO: Implement
+	LessOrEqual
 	GreaterThan
-	GreaterThanOrEqual // TODO: Implement
+	GreaterOrEqual
 	Within
 	NotWithin
 }
@@ -29,7 +29,9 @@ IsConstraints: class extends ExpectModifier {
 	equal ::= EqualModifier new(this)
 	notEqual ::= EqualModifier new(this, ComparisonType NotEqual)
 	less ::= LessModifier new(this)
+	lessOrEqual ::= LessModifier new(this, true)
 	greater ::= GreaterModifier new(this)
+	greaterOrEqual ::= GreaterModifier new(this, true)
 	init: func
 }
 
@@ -85,18 +87,18 @@ CompareWithinConstraint: class extends CompareConstraint {
 	within: func ~float (precision: Float) -> CompareConstraint {
 		this precision = precision as LDouble
 		this comparer = func (value, correct: Object) -> Bool { this testChild(value) }
-		f := func (value, correct: Object) -> Bool { (value as Cell<Float> get() - correct as Cell<Float> get()) abs() < precision }
+		f := func (value, correct: Cell<Float>) -> Bool { correct get() equals(value get(), precision) }
 		CompareConstraint new(this, Cell<Float> new(this correct as Cell<Float> get()), f, this type)
 	}
 	within: func ~double (precision: Double) -> CompareConstraint {
 		this precision = precision as Double
 		this comparer = func (value, correct: Object) -> Bool { this testChild(value) }
-		f := func (value, correct: Object) -> Bool { (value as Cell<Double> get() - correct as Cell<Double> get()) abs() < precision }
+		f := func (value, correct: Cell<Double>) -> Bool { correct get() equals(value get(), precision) }
 		CompareConstraint new(this, Cell<Double> new(this correct as Cell<Double> get()), f, this type)
 	}
 	within: func ~ldouble (=precision) -> CompareConstraint {
 		this comparer = func (value, correct: Object) -> Bool { this testChild(value) }
-		f := func (value, correct: Object) -> Bool { (value as Cell<LDouble> get() - correct as Cell<LDouble> get()) abs() < precision }
+		f := func (value, correct: Cell<LDouble>) -> Bool { correct get() equals(value get(), precision) }
 		CompareConstraint new(this, Cell<LDouble> new(this correct as Cell<LDouble> get()), f, this type)
 	}
 	test: override func (value: Object) -> Bool {

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -63,9 +63,17 @@ Fixture: abstract class {
 			for (i in 0 .. failures count) {
 				f := failures[i]
 				if (f constraint instanceOf(CompareConstraint) && f value instanceOf(Cell))
-					(this createFailureMessage(f) toString()) println()
+					This _print(this createCompareFailureMessage(f) + t"\n")
+				else if (f constraint instanceOf(NullConstraint))
+					This _print(Text new("  -> %s : expected null was %p\n" format(f message, f value&)))
+				else if (f constraint instanceOf(NotNullConstraint))
+					This _print(Text new("  -> %s : expected not null was null\n" format(f message)))
+				else if (f constraint instanceOf(TrueConstraint))
+					This _print(Text new("  -> %s : expected true was false\n" format(f message)))
+				else if (f constraint instanceOf(FalseConstraint))
+					This _print(Text new("  -> %s : expected false was true\n" format(f message)))
 				else
-					This _print(t"  -> '%s' (expect: %i)\n" format(f message, f expect))
+					This _print(t"  -> %s (expect: %i)\n" format(f message, f expect))
 				f free()
 			}
 			This _testsFailed = true
@@ -74,11 +82,11 @@ Fixture: abstract class {
 		timer free()
 		result
 	}
-	createFailureMessage: func (failure: TestFailedException) -> Text {
+	createCompareFailureMessage: func (failure: TestFailedException) -> Text {
 		constraint := failure constraint as CompareConstraint
 		testedValue := failure value as Cell
 		expectedValue := constraint correct as Cell
-		result := TextBuilder new(t"  -> ")
+		result := TextBuilder new(t"  ->")
 		result append(Text new(failure message))
 		result append(t": expected")
 		match (constraint type) {
@@ -90,6 +98,10 @@ Fixture: abstract class {
 				result append(t"less than")
 			case ComparisonType GreaterThan =>
 				result append(t"greater than")
+			case ComparisonType LessOrEqual =>
+				result append(t"less than or equal to")
+			case ComparisonType GreaterOrEqual =>
+				result append(t"greater than or equal to")
 			case ComparisonType Within =>
 				result append(t"equal to")
 			case ComparisonType NotWithin =>

--- a/source/unit/Modifiers.ooc
+++ b/source/unit/Modifiers.ooc
@@ -51,143 +51,155 @@ EqualModifier: class extends ExpectModifier {
 		CompareConstraint new(this, correct, f, this comparisonType)
 	}
 	to: func ~char (correct: Char) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Char> get() == c as Cell<Char> get() }
+		f := func (value, c: Cell<Char>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<Char> new(correct), f, this comparisonType)
 	}
 	to: func ~text (correct: Text) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Text> get() == c as Cell<Text> get() }
+		f := func (value, c: Cell<Text>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<Text> new(correct), f, this comparisonType)
 	}
 	to: func ~boolean (correct: Bool) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Bool> get() == c as Cell<Bool> get() }
+		f := func (value, c: Cell<Bool>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<Bool> new(correct), f, this comparisonType)
 	}
 	to: func ~int (correct: Int) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Int> get() == c as Cell<Int> get() }
+		f := func (value, c: Cell<Int>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<Int> new(correct), f, this comparisonType)
 	}
 	to: func ~uint (correct: UInt) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<UInt> get() == c as Cell<UInt> get() }
+		f := func (value, c: Cell<UInt>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<UInt> new(correct), f, this comparisonType)
 	}
 	to: func ~uint8 (correct: Byte) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Byte> get() == c as Cell<Byte> get() }
+		f := func (value, c: Cell<Byte>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<Byte> new(correct), f, this comparisonType)
 	}
 	to: func ~long (correct: Long) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Long> get() == c as Cell<Long> get() }
+		f := func (value, c: Cell<Long>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<Long> new(correct), f, this comparisonType)
 	}
 	to: func ~ulong (correct: ULong) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<ULong> get() == c as Cell<ULong> get() }
+		f := func (value, c: Cell<ULong>) -> Bool { value get() == c get() }
 		CompareConstraint new(this, Cell<ULong> new(correct), f, this comparisonType)
 	}
 	to: func ~float (correct: Float) -> CompareWithinConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Float> get() == c as Cell<Float> get() }
+		f := func (value, c: Cell<Float>) -> Bool { value get() equals(c get()) }
 		CompareWithinConstraint new(this, Cell<Float> new(correct), f, this withinType)
 	}
 	to: func ~double (correct: Double) -> CompareWithinConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<Double> get() == c as Cell<Double> get() }
+		f := func (value, c: Cell<Double>) -> Bool { value get() equals(c get()) }
 		CompareWithinConstraint new(this, Cell<Double> new(correct), f, this withinType)
 	}
 	to: func ~ldouble (correct: LDouble) -> CompareWithinConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<LDouble> get() == c as Cell<LDouble> get() }
+		f := func (value, c: Cell<LDouble>) -> Bool { value get() equals(c get()) }
 		CompareWithinConstraint new(this, Cell<LDouble> new(correct), f, this withinType)
 	}
 	to: func ~llong (correct: LLong) -> CompareWithinConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<LLong> get() == c as Cell<LLong> get() }
+		f := func (value, c: Cell<LLong>) -> Bool { value get() == c get() }
 		CompareWithinConstraint new(this, Cell<LLong> new(correct), f, this withinType)
 	}
 	to: func ~ullong (correct: ULLong) -> CompareWithinConstraint {
-		f := func (value, c: Object) -> Bool { value as Cell<ULLong> get() == c as Cell<ULLong> get() }
+		f := func (value, c: Cell<ULLong>) -> Bool { value get() == c get() }
 		CompareWithinConstraint new(this, Cell<ULLong> new(correct), f, this withinType)
 	}
 }
 
 LessModifier: class extends ExpectModifier {
-	init: func ~parent (parent: ExpectModifier) { super(parent) }
+	allowEquality: Bool
+	typeToPass: ComparisonType
+	init: func ~parent (parent: ExpectModifier, allowEquals := false) {
+		super(parent)
+		this allowEquality = allowEquals
+		this typeToPass = allowEquals ? ComparisonType LessOrEqual : ComparisonType LessThan
+	}
 	than: func ~object (right: Object) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value < c }
-		CompareConstraint new(this, right, f, ComparisonType LessThan)
+		f := func (value, c: Object) -> Bool { this allowEquality ? value <= c : value < c }
+		CompareConstraint new(this, right, f, this typeToPass)
 	}
 	than: func ~float (right: Float) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Float> get()) < (c as Cell<Float> get()) }
-		CompareConstraint new(this, Cell<Float> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<Float>) -> Bool { this allowEquality ? value get() lessOrEqual(c get()) : value get() lessThan(c get()) }
+		CompareConstraint new(this, Cell<Float> new(right), f, this typeToPass)
 	}
 	than: func ~double (right: Double) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Double> get()) < (c as Cell<Double> get()) }
-		CompareConstraint new(this, Cell<Double> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<Double>) -> Bool { this allowEquality ? value get() lessOrEqual(c get()) : value get() lessThan(c get()) }
+		CompareConstraint new(this, Cell<Double> new(right), f, this typeToPass)
 	}
 	than: func ~ldouble (right: LDouble) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<LDouble> get()) < (c as Cell<LDouble> get()) }
-		CompareConstraint new(this, Cell<LDouble> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<LDouble>) -> Bool { this allowEquality ? value get() lessOrEqual(c get()) : value get() lessThan(c get()) }
+		CompareConstraint new(this, Cell<LDouble> new(right), f, this typeToPass)
 	}
 	than: func ~int (right: Int) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Int> get()) < (c as Cell<Int> get()) }
-		CompareConstraint new(this, Cell<Int> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<Int>) -> Bool { this allowEquality ? value get() <= c get() : value get() < c get() }
+		CompareConstraint new(this, Cell<Int> new(right), f, this typeToPass)
 	}
 	than: func ~uint (right: UInt) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<UInt> get()) < (c as Cell<UInt> get()) }
-		CompareConstraint new(this, Cell<UInt> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<UInt>) -> Bool { this allowEquality ? value get() <= c get() : value get() < c get() }
+		CompareConstraint new(this, Cell<UInt> new(right), f, this typeToPass)
 	}
 	than: func ~long (right: Long) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Long> get()) < (c as Cell<Long> get()) }
-		CompareConstraint new(this, Cell<Long> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<Long>) -> Bool { this allowEquality ? value get() <= c get() : value get() < c get() }
+		CompareConstraint new(this, Cell<Long> new(right), f, this typeToPass)
 	}
 	than: func ~ulong (right: ULong) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<ULong> get()) < (c as Cell<ULong> get()) }
-		CompareConstraint new(this, Cell<ULong> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<ULong>) -> Bool { this allowEquality ? value get() <= c get() : value get() < c get() }
+		CompareConstraint new(this, Cell<ULong> new(right), f, this typeToPass)
 	}
 	than: func ~llong (right: LLong) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<LLong> get()) < (c as Cell<LLong> get()) }
-		CompareConstraint new(this, Cell<LLong> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<LLong>) -> Bool { this allowEquality ? value get() <= c get() : value get() < c get() }
+		CompareConstraint new(this, Cell<LLong> new(right), f, this typeToPass)
 	}
 	than: func ~ullong (right: ULLong) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<ULLong> get()) < (c as Cell<ULLong> get()) }
-		CompareConstraint new(this, Cell<ULLong> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<ULLong>) -> Bool { this allowEquality ? value get() <= c get() : value get() < c get() }
+		CompareConstraint new(this, Cell<ULLong> new(right), f, this typeToPass)
 	}
 }
 
 GreaterModifier: class extends ExpectModifier {
-	init: func ~parent (parent: ExpectModifier) { super(parent) }
+	allowEquality: Bool
+	typeToPass: ComparisonType
+	init: func ~parent (parent: ExpectModifier, allowEquals := false) {
+		super(parent)
+		this allowEquality = allowEquals
+		this typeToPass = allowEquals ? ComparisonType GreaterOrEqual : ComparisonType GreaterThan
+	}
 	than: func ~object (right: Object) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { value > c }
-		CompareConstraint new(this, right, f, ComparisonType GreaterThan)
+		f := func (value, c: Object) -> Bool { this allowEquality ? value >= c : value > c }
+		CompareConstraint new(this, right, f, this typeToPass)
 	}
 	than: func ~float (right: Float) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Float> get()) > (c as Cell<Float> get()) }
-		CompareConstraint new(this, Cell<Float> new(right), f, ComparisonType GreaterThan)
+		f := func (value, c: Cell<Float>) -> Bool { this allowEquality ? value get() greaterOrEqual(c get()) : value get() greaterThan(c get()) }
+		CompareConstraint new(this, Cell<Float> new(right), f, this typeToPass)
 	}
 	than: func ~double (right: Double) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Double> get()) > (c as Cell<Double> get()) }
-		CompareConstraint new(this, Cell<Double> new(right), f, ComparisonType GreaterThan)
+		f := func (value, c: Cell<Double>) -> Bool { this allowEquality ? value get() greaterOrEqual(c get()) : value get() greaterThan(c get()) }
+		CompareConstraint new(this, Cell<Double> new(right), f, this typeToPass)
 	}
 	than: func ~ldouble (right: LDouble) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<LDouble> get()) > (c as Cell<LDouble> get()) }
-		CompareConstraint new(this, Cell<LDouble> new(right), f, ComparisonType GreaterThan)
+		f := func (value, c: Cell<LDouble>) -> Bool { this allowEquality ? value get() greaterOrEqual(c get()) : value get() greaterThan(c get()) }
+		CompareConstraint new(this, Cell<LDouble> new(right), f, this typeToPass)
 	}
 	than: func ~int (right: Int) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Int> get()) > (c as Cell<Int> get()) }
-		CompareConstraint new(this, Cell<Int> new(right), f, ComparisonType GreaterThan)
+		f := func (value, c: Cell<Int>) -> Bool { this allowEquality ? value get() >= c get() : value get() > c get() }
+		CompareConstraint new(this, Cell<Int> new(right), f, this typeToPass)
 	}
 	than: func ~uint (right: UInt) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<UInt> get()) > (c as Cell<UInt> get()) }
-		CompareConstraint new(this, Cell<UInt> new(right), f, ComparisonType GreaterThan)
+		f := func (value, c: Cell<UInt>) -> Bool { this allowEquality ? value get() >= c get() : value get() > c get() }
+		CompareConstraint new(this, Cell<UInt> new(right), f, this typeToPass)
 	}
 	than: func ~long (right: Long) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<Long> get()) > (c as Cell<Long> get()) }
-		CompareConstraint new(this, Cell<Long> new(right), f, ComparisonType GreaterThan)
+		f := func (value, c: Cell<Long>) -> Bool { this allowEquality ? value get() >= c get() : value get() > c get() }
+		CompareConstraint new(this, Cell<Long> new(right), f, this typeToPass)
 	}
 	than: func ~ulong (right: ULong) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<ULong> get()) > (c as Cell<ULong> get()) }
-		CompareConstraint new(this, Cell<ULong> new(right), f, ComparisonType GreaterThan)
+		f := func (value, c: Cell<ULong>) -> Bool { this allowEquality ? value get() >= c get() : value get() > c get() }
+		CompareConstraint new(this, Cell<ULong> new(right), f, this typeToPass)
 	}
 	than: func ~llong (right: LLong) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<LLong> get()) > (c as Cell<LLong> get()) }
-		CompareConstraint new(this, Cell<LLong> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<LLong>) -> Bool { this allowEquality ? value get() >= c get() : value get() > c get() }
+		CompareConstraint new(this, Cell<LLong> new(right), f, this typeToPass)
 	}
 	than: func ~ullong (right: ULLong) -> CompareConstraint {
-		f := func (value, c: Object) -> Bool { (value as Cell<ULLong> get()) > (c as Cell<ULLong> get()) }
-		CompareConstraint new(this, Cell<ULLong> new(right), f, ComparisonType LessThan)
+		f := func (value, c: Cell<ULLong>) -> Bool { this allowEquality ? value get() >= c get() : value get() > c get() }
+		CompareConstraint new(this, Cell<ULLong> new(right), f, this typeToPass)
 	}
 }

--- a/test/unit/FloatTest.ooc
+++ b/test/unit/FloatTest.ooc
@@ -24,8 +24,10 @@ FloatTest: class extends Fixture {
 		this add("-13.37 is not equal to -13.38 within 0.001", func { expect(-13.37f, is notEqual to(-13.38f) within(0.001f)) })
 		this add("0.0 is not equal to 4.2", func { expect(0.0f, is notEqual to(4.2f)) })
 		this add("0.0 is equal to -0.0", func { expect(0.0f, is equal to(-0.0f)) })
-		this add("0.0 is less than 0.00000001", func { expect(0.0f, is less than(0.00000001f)) })
-		this add("0.0 is greater than -0.00000001", func { expect(0.0f, is greater than(-0.00000001f)) })
+		this add("0.0 is less than 0.00000001", func { expect(0.0f, is less than(0.000001f)) })
+		this add("0.0 is greater than -0.00000001", func { expect(0.0f, is greater than(-0.000001f)) })
+		this add("7.0 is greater or equal than 7.0", func { expect(7.0f, is greaterOrEqual than(7.0f)) })
+		this add("7.0 is less or equal than 7.0", func { expect(7.0f, is lessOrEqual than(7.0f)) })
 	}
 }
 


### PR DESCRIPTION
Fixes #539 

- [x] Adds nice error messages for when `is null`, `is notNull`, `is true`, `is false` are used
- [x] Even more cleanup of code
- [x] Now uses `equals()` instead of `==` by default when comparing floating point types
- [x] Implemented `greaterOrEqual` and `lessOrEqual` keywords