### PR TITLE
Context bugfix

### DIFF
--- a/source/draw/gpu/opengl/backend/egl/egl.ooc
+++ b/source/draw/gpu/opengl/backend/egl/egl.ooc
@@ -174,7 +174,7 @@ PFNEGLDESTROYIMAGEKHRPROC_OOC: cover from PFNEGLDESTROYIMAGEKHRPROC
 
 eglMakeCurrent: extern func (display, draw, read, context: Pointer) -> UInt
 eglDestroyContext: extern func (display, context: Pointer) -> UInt
-eglDestroySurface: extern func (display, surface: Pointer)
+eglDestroySurface: extern func (display, surface: Pointer) -> UInt
 eglGetDisplay: extern func (nativeDisplay: Pointer) -> Pointer
 eglInitialize: extern func (display: Pointer, major: Int*, minor: Int*) -> UInt
 eglBindAPI: extern func (api: UInt) -> UInt
@@ -184,6 +184,6 @@ eglCreatePbufferSurface: extern func (display: Pointer, config: Pointer, attridL
 eglCreateContext: extern func (display: Pointer, config: Pointer, sharedContext: Pointer, attribList: Int*) -> Pointer
 eglGetConfigAttrib: extern func (display: Pointer, config: Pointer, attribute: Int, value: Int*) -> UInt
 eglSwapBuffers: extern func (display, surface: Pointer)
-eglTerminate: extern func (display: Pointer) -> Pointer
+eglTerminate: extern func (display: Pointer) -> UInt
 eglGetError: extern func -> UInt
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
@@ -18,6 +18,7 @@ Gles3Context: class extends GLContext {
 	_eglContext: Pointer
 	_eglSurface: Pointer
 	_contextCount := static 0
+	_mutex := static Mutex new()
 	init: func
 	free: override func {
 		status := eglMakeCurrent(this _eglDisplay, null, null, null)
@@ -34,7 +35,7 @@ Gles3Context: class extends GLContext {
 			if (status != EGL_TRUE)
 				Debug print("eglTerminate failed with error code %d" format(status))
 		}
-		This _contextCount -= 1
+		This _mutex with(|| This _contextCount -= 1)
 		super()
 	}
 	makeCurrent: override func -> Bool {
@@ -72,7 +73,7 @@ Gles3Context: class extends GLContext {
 		contextAttribs := [
 			EGL_CONTEXT_CLIENT_VERSION, 3,
 			EGL_NONE] as Int*
-		This _contextCount += 1
+		This _mutex with(|| This _contextCount += 1)
 		this _eglContext = eglCreateContext(this _eglDisplay, config, shared, contextAttribs)
 		if (this _eglContext == null) {
 			"Failed to create OpenGL ES 3 context, trying with OpenGL ES 2 instead" println()

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
@@ -20,10 +20,18 @@ Gles3Context: class extends GLContext {
 
 	init: func
 	free: override func {
-		eglMakeCurrent(this _eglDisplay, null, null, null)
-		eglDestroyContext(this _eglDisplay, this _eglContext)
-		eglDestroySurface(this _eglDisplay, this _eglSurface)
-		eglTerminate(this _eglDisplay)
+		status := eglMakeCurrent(this _eglDisplay, null, null, null)
+		if (status != EGL_TRUE)
+			Debug print("eglMakeCurrent failed with error code %d" format(status))
+		status = eglDestroyContext(this _eglDisplay, this _eglContext)
+		if (status != EGL_TRUE)
+			Debug print("eglDestroyContext failed with error code %d" format(status))
+		status = eglDestroySurface(this _eglDisplay, this _eglSurface)
+		if (status != EGL_TRUE)
+			Debug print("eglDestroySurface failed with error code %d" format(status))
+		status = eglTerminate(this _eglDisplay)
+		if (status != EGL_TRUE)
+			Debug print("eglTerminate failed with error code %d" format(status))
 		super()
 	}
 	makeCurrent: override func -> Bool {

--- a/test/draw/gpu/GpuContextTest.ooc
+++ b/test/draw/gpu/GpuContextTest.ooc
@@ -17,13 +17,13 @@ use concurrent
 GpuContextTest: class extends Fixture {
 	init: func {
 		super("OpenGLContext")
-		childThread := WorkerThread new()
 		this add("create context", func {
 			context := OpenGLContext new()
 			expect(context != null)
 			context free()
 		})
 		this add("shared context", func {
+			childThread := WorkerThread new()
 			mother := OpenGLContext new()
 			child: OpenGLContext
 			childThread wait(|| child = OpenGLContext new(mother))
@@ -39,10 +39,21 @@ GpuContextTest: class extends Fixture {
 			expect(motherRaster distance(childRaster), is equal to(0.0f))
 			motherRaster free()
 			childRaster free()
-			child free()
+			childThread wait(|| child free())
 			sharedImage free()
 			mother free()
 			childThread free()
+		})
+		this add("multiple contexts", func {
+			thread := WorkerThread new()
+			context1 := OpenGLContext new()
+			context2: OpenGLContext
+			thread wait(|| context2 = OpenGLContext new())
+			expect(context1 != null)
+			expect(context2 != null)
+			context1 free()
+			thread wait(|| context2 free())
+			thread free()
 		})
 	}
 }


### PR DESCRIPTION
Even though it **should** be legit for several contexts to call `eglTerminate(display)`, this causes a seg fault on some drivers. I solved this by counting the number of created contexts and only terminating when the last context is freed. Not a beautiful solution but it does the job.

@marcusnaslund peer review