### PR TITLE
Added tests for LDouble, LLong and ULLong

### DIFF
--- a/test/unit/DoubleTest.ooc
+++ b/test/unit/DoubleTest.ooc
@@ -26,6 +26,8 @@ DoubleTest: class extends Fixture {
 		this add("0.0 is equal to -0.0", func { expect(0.0, is equal to(-0.0)) })
 		this add("0.0 is less than 0.00000001", func { expect(0.0, is less than(0.00000001)) })
 		this add("0.0 is greater than -0.00000001", func { expect(0.0, is greater than(-0.00000001)) })
+		this add("100.0L is greater than 99.9L", func { expect(100.0L, is greater than(99.9L)) })
+		this add("-123.4L is less than -123.3L", func { expect(-123.4L, is less than(123.3L)) })
 	}
 }
 

--- a/test/unit/LLongTest.ooc
+++ b/test/unit/LLongTest.ooc
@@ -1,0 +1,25 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+use unit
+
+LLongTest: class extends Fixture {
+	init: func {
+		super("LLong, ULLong")
+
+		this add("1_000_000_000 is equal to 1_000_000_000", func { expect(1_000_000_000LL, is equal to(1_000_000_000LL)) })
+		this add("-1_000_000_001 is less than 1_000_000_000", func { expect(-1_000_000_001LL, is less than(-1_000_000_000LL)) })
+		this add("100_000_000_000 is greater than 99_999_999_999", func { expect(100_000_000_000LL, is greater than(99_999_999_999LL)) })
+
+		this add("1_000_000_000U is equal to 1_000_000_000U", func { expect(1_000_000_000ULL, is equal to(1_000_000_000ULL)) })
+		this add("1_000_000_000U is less than 1_000_000_001U", func { expect(1_000_000_000ULL, is less than(1_000_000_001ULL)) })
+		this add("100_000_000_000U is greater than 99_999_999_999U", func { expect(100_000_000_000ULL, is greater than(99_999_999_999ULL)) })
+	}
+}
+
+LLongTest new() run() . free()


### PR DESCRIPTION
We should have had these ever since we redefined the numeric types, but better late than never. This is also useful to make sure the unit test framework works with all types.

Peer review @sebastianbaginski ?