### PR TITLE
Added support for extending equal to() operator with geometry/math covers

### DIFF
--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -84,3 +84,7 @@ operator * (left: Float, right: FloatVector2D) -> FloatVector2D { FloatVector2D 
 operator / (left: Float, right: FloatVector2D) -> FloatVector2D { FloatVector2D new(left / right x, left / right y) }
 operator * (left: Int, right: FloatVector2D) -> FloatVector2D { FloatVector2D new(left * right x, left * right y) }
 operator / (left: Int, right: FloatVector2D) -> FloatVector2D { FloatVector2D new(left / right x, left / right y) }
+
+extend Cell<FloatVector2D> {
+	toText: func ~floatvector2d -> Text { (this val as FloatVector2D) toText() }
+}

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -8,6 +8,8 @@
 
 use base
 use collections
+use geometry
+use math
 import Constraints
 import Modifiers
 
@@ -84,32 +86,26 @@ Fixture: abstract class {
 	}
 	createCompareFailureMessage: func (failure: TestFailedException) -> Text {
 		constraint := failure constraint as CompareConstraint
-		testedValue := failure value as Cell
-		expectedValue := constraint correct as Cell
+		(testedValue, expectedValue) := (failure value as Cell, constraint correct as Cell)
 		result := TextBuilder new(t"  ->")
 		result append(Text new(failure message))
 		result append(t": expected")
 		match (constraint type) {
-			case ComparisonType Equal =>
-				result append(t"equal to")
-			case ComparisonType NotEqual =>
-				result append(t"not equal to")
-			case ComparisonType LessThan =>
-				result append(t"less than")
-			case ComparisonType GreaterThan =>
-				result append(t"greater than")
-			case ComparisonType LessOrEqual =>
-				result append(t"less than or equal to")
-			case ComparisonType GreaterOrEqual =>
-				result append(t"greater than or equal to")
-			case ComparisonType Within =>
-				result append(t"equal to")
-			case ComparisonType NotWithin =>
-				result append(t"not equal to")
+			case ComparisonType Equal => result append(t"equal to")
+			case ComparisonType NotEqual => result append(t"not equal to")
+			case ComparisonType LessThan => result append(t"less than")
+			case ComparisonType GreaterThan => result append(t"greater than")
+			case ComparisonType LessOrEqual => result append(t"less than or equal to")
+			case ComparisonType GreaterOrEqual => result append(t"greater than or equal to")
+			case ComparisonType Within => result append(t"equal to")
+			case ComparisonType NotWithin => result append(t"not equal to")
 		}
-		result append(expectedValue toText())
-		result append(t"was")
-		result append(testedValue toText())
+		expectedText, testedText: Text
+		match (expectedValue T) {
+			case FloatVector2D => (expectedText, testedText) = (expectedValue toText~floatvector2d(), testedValue toText~floatvector2d())
+			case => (expectedText, testedText) = (expectedValue toText(), testedValue toText())
+		}
+		result append(expectedText) . append(t"was") . append(testedText)
 		if (constraint type == ComparisonType Within)
 			result append(Text new(" [tolerance: %.8f]" formatDouble((constraint parent as CompareWithinConstraint) precision)))
 		result join(' ')
@@ -160,6 +156,8 @@ Fixture: abstract class {
 	expect: static func ~ldouble (value: LDouble, constraint: Constraint) { This expect(Cell new(value), constraint) }
 	expect: static func ~llong (value: LLong, constraint: Constraint) { This expect(Cell new(value), constraint) }
 	expect: static func ~ullong (value: ULLong, constraint: Constraint) { This expect(Cell new(value), constraint) }
+
+	expect: static func ~floatvector2d (value: FloatVector2D, constraint: Constraint) { This expect(Cell new(value), constraint) }
 }
 
 TestFailedException: class extends Exception {

--- a/source/unit/Modifiers.ooc
+++ b/source/unit/Modifiers.ooc
@@ -6,6 +6,8 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+use geometry
+use math
 import Constraints
 
 ExpectModifier: abstract class {
@@ -84,23 +86,27 @@ EqualModifier: class extends ExpectModifier {
 	}
 	to: func ~float (correct: Float) -> CompareWithinConstraint {
 		f := func (value, c: Cell<Float>) -> Bool { value get() equals(c get()) }
-		CompareWithinConstraint new(this, Cell<Float> new(correct), f, this withinType)
+		CompareWithinConstraint new(this, Cell<Float> new(correct), f, this withinType, Float)
 	}
 	to: func ~double (correct: Double) -> CompareWithinConstraint {
 		f := func (value, c: Cell<Double>) -> Bool { value get() equals(c get()) }
-		CompareWithinConstraint new(this, Cell<Double> new(correct), f, this withinType)
+		CompareWithinConstraint new(this, Cell<Double> new(correct), f, this withinType, Double)
 	}
 	to: func ~ldouble (correct: LDouble) -> CompareWithinConstraint {
 		f := func (value, c: Cell<LDouble>) -> Bool { value get() equals(c get()) }
-		CompareWithinConstraint new(this, Cell<LDouble> new(correct), f, this withinType)
+		CompareWithinConstraint new(this, Cell<LDouble> new(correct), f, this withinType, LDouble)
 	}
 	to: func ~llong (correct: LLong) -> CompareWithinConstraint {
 		f := func (value, c: Cell<LLong>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<LLong> new(correct), f, this withinType)
+		CompareWithinConstraint new(this, Cell<LLong> new(correct), f, this withinType, LLong)
 	}
 	to: func ~ullong (correct: ULLong) -> CompareWithinConstraint {
 		f := func (value, c: Cell<ULLong>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<ULLong> new(correct), f, this withinType)
+		CompareWithinConstraint new(this, Cell<ULLong> new(correct), f, this withinType, ULLong)
+	}
+	to: func ~floatvector2d (correct: FloatVector2D) -> CompareWithinConstraint {
+		f := func (value, c: Cell<FloatVector2D>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<FloatVector2D> new(correct), f, this withinType, FloatVector2D)
 	}
 }
 

--- a/test/geometry/FloatVector2DTest.ooc
+++ b/test/geometry/FloatVector2DTest.ooc
@@ -26,6 +26,9 @@ FloatVector2DTest: class extends Fixture {
 			expect(point == point, is true)
 			expect(point == this vector0, is false)
 		})
+		this add("fixture", func {
+			expect(this vector0 + this vector1, is equal to(this vector2) within(this precision))
+		})
 		this add("addition", func {
 			expect((this vector0 + this vector1) x, is equal to(this vector2 x))
 			expect((this vector0 + this vector1) y, is equal to(this vector2 y))


### PR DESCRIPTION
Required some re-structuring of `CompareWithinConstraint` since we have to match on the compared type and not on the tolerance type. Otherwise we'd have to do something like

```ooc
expect(vector1, is equal to(vector2) within(FloatVector2D new(0.00001f, 0.00001f))
``` 
instead of
```ooc
expect(vector1, is equal to(vector2) within(0.00001f))
```

The new system also makes it very easy to add new types.

A future PR will take care of remaining types in #1500 ... for now this is a good starting step.