### PR TITLE
Modified the == operator in geometry and math

### DIFF
--- a/source/geometry/FloatEuclidTransform.ooc
+++ b/source/geometry/FloatEuclidTransform.ooc
@@ -41,7 +41,7 @@ FloatEuclidTransform: cover {
 	operator == (other: This) -> Bool {
 		this translation == other translation &&
 		this rotation == other rotation &&
-		this scaling == other scaling
+		this scaling equals(other scaling)
 	}
 
 	convolveCenter: static func (euclidTransforms: VectorList<This>, kernel: FloatVectorList) -> This {

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -53,8 +53,8 @@ FloatPoint2D: cover {
 	operator > (other: This) -> Bool { this x > other x && this y > other y }
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y }
-	operator == (other: This) -> Bool { this x == other x && this y == other y }
-	operator != (other: This) -> Bool { this x != other x || this y != other y }
+	operator == (other: This) -> Bool { this x equals(other x) && this y equals(other y) }
+	operator != (other: This) -> Bool { !(this == other) }
 	operator + (other: FloatVector2D) -> This { This new(this x + other x, this y + other y) }
 	operator - (other: FloatVector2D) -> This { This new(this x - other x, this y - other y) }
 	operator * (other: FloatVector2D) -> This { This new(this x * other x, this y * other y) }

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -57,8 +57,8 @@ FloatPoint3D: cover {
 	operator > (other: This) -> Bool { this x > other x && this y > other y && this z > other z }
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y && this z <= other z }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y && this z >= other z }
-	operator == (other: This) -> Bool { this x == other x && this y == other y && this z == other z }
-	operator != (other: This) -> Bool { this x != other x || this y != other y || this z != other z }
+	operator == (other: This) -> Bool { this x equals(other x) && this y equals(other y) && this z equals(other z) }
+	operator != (other: This) -> Bool { !(this == other) }
 	operator * (other: Float) -> This { This new(this x * other, this y * other, this z * other) }
 	operator / (other: Float) -> This { This new(this x / other, this y / other, this z / other) }
 

--- a/source/geometry/FloatShell2D.ooc
+++ b/source/geometry/FloatShell2D.ooc
@@ -44,7 +44,7 @@ FloatShell2D: cover {
 
 	operator + (other: This) -> This { This new(this left + other left, this right + other right, this top + other top, this bottom + other bottom) }
 	operator - (other: This) -> This { This new(this left - other left, this right - other right, this top - other top, this bottom - other bottom) }
-	operator == (other: This) -> Bool { this left == other left && this right == other right && this top == other top && this bottom == other bottom }
+	operator == (other: This) -> Bool { this left equals(other left) && this right equals(other right) && this top equals(other top) && this bottom equals(other bottom) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator / (other: Float) -> This { This new(this left / other, this right / other, this top / other, this bottom / other) }
 

--- a/source/geometry/FloatTransform2D.ooc
+++ b/source/geometry/FloatTransform2D.ooc
@@ -102,15 +102,15 @@ FloatTransform2D: cover {
 		)
 	}
 	operator == (other: This) -> Bool {
-		this a == other a &&
-		this b == other b &&
-		this c == other c &&
-		this d == other d &&
-		this e == other e &&
-		this f == other f &&
-		this g == other g &&
-		this h == other h &&
-		this i == other i
+		this a equals(other a) &&
+		this b equals(other b) &&
+		this c equals(other c) &&
+		this d equals(other d) &&
+		this e equals(other e) &&
+		this f equals(other f) &&
+		this g equals(other g) &&
+		this h equals(other h) &&
+		this i equals(other i)
 	}
 	operator != (other: This) -> Bool {
 		!(this == other)

--- a/source/geometry/FloatTransform3D.ooc
+++ b/source/geometry/FloatTransform3D.ooc
@@ -153,22 +153,22 @@ FloatTransform3D: cover {
 		)
 	}
 	operator == (other: This) -> Bool {
-		this a == other a &&
-		this b == other b &&
-		this c == other c &&
-		this d == other d &&
-		this e == other e &&
-		this f == other f &&
-		this g == other g &&
-		this h == other h &&
-		this i == other i &&
-		this j == other j &&
-		this k == other k &&
-		this l == other l &&
-		this m == other m &&
-		this n == other n &&
-		this o == other o &&
-		this p == other p
+		this a equals(other a) &&
+		this b equals(other b) &&
+		this c equals(other c) &&
+		this d equals(other d) &&
+		this e equals(other e) &&
+		this f equals(other f) &&
+		this g equals(other g) &&
+		this h equals(other h) &&
+		this i equals(other i) &&
+		this j equals(other j) &&
+		this k equals(other k) &&
+		this l equals(other l) &&
+		this m equals(other m) &&
+		this n equals(other n) &&
+		this o equals(other o) &&
+		this p equals(other p)
 	}
 	operator != (other: This) -> Bool {
 		!(this == other)

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -55,7 +55,7 @@ FloatVector2D: cover {
 	operator > (other: This) -> Bool { this x > other x && this y > other y }
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y }
-	operator == (other: This) -> Bool { this x == other x && this y == other y }
+	operator == (other: This) -> Bool { this x equals(other x) && this y equals(other y) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator + (other: FloatPoint2D) -> This { This new(this x + other x, this y + other y) }
 	operator - (other: FloatPoint2D) -> This { This new(this x - other x, this y - other y) }

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -62,7 +62,7 @@ FloatVector3D: cover {
 	operator > (other: This) -> Bool { this x > other x && this y > other y && this z > other z }
 	operator <= (other: This) -> Bool { this x <= other x && this y <= other y && this z <= other z }
 	operator >= (other: This) -> Bool { this x >= other x && this y >= other y && this z >= other z }
-	operator == (other: This) -> Bool { this x == other x && this y == other y && this z == other z }
+	operator == (other: This) -> Bool { this x equals(other x) && this y equals(other y) && this z equals(other z) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator * (other: Float) -> This { This new(this x * other, this y * other, this z * other) }
 	operator / (other: Float) -> This { This new(this x / other, this y / other, this z / other) }

--- a/source/math/FloatComplex.ooc
+++ b/source/math/FloatComplex.ooc
@@ -34,7 +34,7 @@ FloatComplex: cover {
 	operator - (other: This) -> This { This new(this real - other real, this imaginary - other imaginary) }
 	operator * (other: This) -> This { This new(this real * other real - this imaginary * other imaginary, this real * other imaginary + this imaginary * other real) }
 	operator / (other: This) -> This { (this * other conjugate) / (other absoluteValue pow(2)) }
-	operator == (other: This) -> Bool { this real == other real && this imaginary == other imaginary }
+	operator == (other: This) -> Bool { this real equals(other real) && this imaginary equals(other imaginary) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator * (other: Float) -> This { This new(other * this real, other * this imaginary) }
 	operator / (other: Float) -> This { This new(this real / other, this imaginary / other) }

--- a/source/math/FloatMatrix.ooc
+++ b/source/math/FloatMatrix.ooc
@@ -427,6 +427,20 @@ FloatMatrix: cover {
 		this free(Owner Receiver)
 		result
 	}
+	operator == (other: This) -> Bool {
+		result := true
+		for (x in 0 .. this width)
+			for (y in 0 .. this height)
+				if (!(this[x, y] equals(other[x, y]))) {
+					result = false
+					break
+				}
+		this free(Owner Receiver)
+		result
+	}
+	operator != (other: This) -> Bool {
+		!(this == other)
+	}
 	operator [] (x, y: Int) -> Float {
 		t := this take()
 		version (safe)

--- a/test/math/FloatMatrixTest.ooc
+++ b/test/math/FloatMatrixTest.ooc
@@ -18,20 +18,16 @@ FloatMatrixTest: class extends Fixture {
 
 	init: func {
 		super ("FloatMatrix")
-
 		this add("identity", func {
 			this checkAllElements(FloatMatrix identity(3), [1.0f, 0, 0, 0, 1.0f, 0, 0, 0, 1.0f])
 		})
-
 		this add("isSquare", func {
 			expect(this nonSquareMatrix isSquare, is false)
 			expect(this matrix isSquare, is true)
 		})
-
 		this add("order", func {
 			expect(this nonSquareMatrix order, is equal to(2))
 		})
-
 		this add("dimensions", func {
 			expect(this nonSquareMatrix width, is equal to(2))
 			expect(this nonSquareMatrix height, is equal to(3))
@@ -39,25 +35,20 @@ FloatMatrixTest: class extends Fixture {
 			expect(this nullMatrix height, is equal to (0))
 			expect(this nullMatrix isNull)
 		})
-
 		this add("elements", func {
 			this checkAllElements(this createMatrix(3, 3, [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f, 7.4f, -8.3f, 9.2f]), [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f, 7.4f, -8.3f, 9.2f])
 		})
-
 		this add("copy", func {
 			this checkAllElements(this createMatrix(3, 3, [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f, 7.4f, -8.3f, 9.2f]) copy(), [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f, 7.4f, -8.3f, 9.2f])
 			this checkAllElements(this createMatrix(2, 3, [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f]) copy(), [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f])
 		})
-
 		this add("trace", func {
 			expect(this createMatrix(3, 3, [1.0f, 0, 0, 0, 2.0f, 0, 0, 0, 3.0f]) trace(), is equal to(1.0f * 2.0f * 3.0f))
 		})
-
 		this add("transpose", func {
 			this checkAllElements(this createMatrix(3, 3, [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f, 7.4f, -8.3f, 9.2f]) transpose(), [1.0f, -4.0f, 7.4f, -2.0f, 5.0f, -8.3f, 3.0f, -6.5f, 9.2f])
 			this checkAllElements(this createMatrix(2, 3, [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f]) transpose(), [1.0f, -4.0f, -2.0f, 5.0f, 3.0f, -6.5f])
 		})
-
 		this add("swapRows", func {
 			m := this createMatrix(3, 3, [1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.5f, 7.4f, -8.3f, 9.2f]) take()
 			m swapRows(0, 1)
@@ -66,39 +57,33 @@ FloatMatrixTest: class extends Fixture {
 			m swapRows(0, 1)
 			this checkAllElements(m give(), [-2.0f, 1.0f, 3.0f, 5.0f, -4.0f, -6.5f])
 		})
-
 		this add("setVertical", func {
 			m := this createMatrix(3, 3, [0, 0, 0, 0, 0, 0, 0, 0, 0]) take()
 			m setVertical(1, 0, 1.0f, 2.0f, 3.0f)
 			this checkAllElements(m give(), [0, 0, 0, 1.0f, 2.0f, 3.0f, 0, 0, 0])
 		})
-
 		this add("multiplication", func {
 			a := this createMatrix(3, 3, [1.0f, 0, 0, 0, 0, 3.0f, 7.0f, 0, 0])
 			this checkAllElements(a * a, [1.0f, 0, 0, 21.0f, 0, 0, 7.0f, 0, 0])
 			b := this createMatrix(2, 3, [1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f])
 			this checkAllElements(b take() transpose() * b, [14.0f, 32.0f, 32.0f, 77.0f])
 		})
-
 		this add("multiplication (scalar)", func {
 			m := this createMatrix(3, 3, [1.0f, 0, 0, 0, 2.0f, 0, 0, 0, 3.0f])
 			this checkAllElements(2.0f * m, [2.0f, 0, 0, 0, 4.0f, 0, 0, 0, 6.0f])
 		})
-
 		this add("addition", func {
 			a := this createMatrix(3, 3, [1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f]) take()
 			b := this createMatrix(3, 3, [9.0f, 8.0f, 7.0f, 6.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f]) take()
 			this checkAllElements(a + b, [10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f])
 			this checkAllElements(a + b give() + a give(), [11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f, 17.0f, 18.0f, 19.0f])
 		})
-
 		this add("subtraction", func {
 			a := createMatrix(3, 3, [1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f]) take()
 			b := createMatrix(3, 3, [9.0f, 8.0f, 7.0f, 6.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f])
 			this checkAllElements(a - b, [-8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 2.0f, 4.0f, 6.0f, 8.0f])
 			this checkAllElements(a - a give(), [0, 0, 0, 0, 0, 0, 0, 0, 0])
 		})
-
 		this add("solver (square)", func {
 			// Solve a * x = y
 			a := this createMatrix(5, 5, [1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 1.0f, 3.0f, 6.0f, 10.0f, 15.0f, 1.0f, 4.0f, 10.0f, 20.0f, 35.0f, 1.0f, 5.0f, 15.0f, 35.0f, 70.0f])
@@ -106,27 +91,23 @@ FloatMatrixTest: class extends Fixture {
 			x := a solve(y)
 			this checkAllElements(x, [-70.0f, 231.0f, -296.0f, 172.0f, -38.0f])
 		})
-
 		this add("solver (non-square)", func {
 			a := this createMatrix(2, 3, [2.0f, 0.0f, 4.0f, 2.0f, 4.0f, 6.0f])
 			y := this createMatrix(1, 3, [1.0f, -2.0f, 1.0f])
 			x := a solve(y)
 			this checkAllElements(x, [1.0f, -0.5f])
 		})
-
 		this add("solver (tridiagonal)", func {
 			a := this createMatrix(5, 5, [1.f, 2.f, 0.f, 0.f, 0.f, 2.f, 2.f, 3.f, 0.f, 0.f, 0.f, 3.f, 3.f, 4.f, 0.f, 0.f, 0.f, 4.f, 4.f, 5.f, 0.f, 0.f, 0.f, 5.f, 5.f])
 			y := this createMatrix(1, 5, [5.f, 15.f, 31.f, 53.f, 45.f])
 			x := a solveTridiagonal(y)
 			this checkAllElements(x, [1.f, 2.f, 3.f, 4.f, 5.f])
 		})
-
 		this add("set and get", func {
 			m := this createMatrix(3, 3, [1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f])
 			m take()[0, 0] = 42.0f
 			expect(m[0, 0], is equal to(42.0f) within(this precision))
 		})
-
 		this add("print columns", func {
 			a := this createMatrix(3, 3, [1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f])
 			column := a take() getColumn(1)
@@ -136,17 +117,14 @@ FloatMatrixTest: class extends Fixture {
 			expect(aString == "1.00, 4.00, 7.00; 2.00, 5.00, 8.00; 3.00, 6.00, 9.00; ")
 			columnString free(); aString free()
 		})
-
 		this add("adjugate", func {
 			m := this createMatrix(3, 3, [1.f, 5.f, 3.f, 7.f, 6.f, 8.f, 9.f, 2.f, 4.f])
 			this checkAllElements(m adjugate(), [8.f, -14.f, 22.f, 44.f, -23.f, 13.f, -40.f, 43.f, -29.f])
 		})
-
 		this add("cofactors", func {
 			m := this createMatrix(3, 3, [1.f, 5.f, 3.f, 7.f, 6.f, 8.f, 9.f, 2.f, 4.f])
 			this checkAllElements(m cofactors(), [8.f, 44.f, -40.f, -14.f, -23.f, 43.f, 22.f, 13.f, -29.f])
 		})
-
 		this add("determinant", func {
 			m := this createMatrix(3, 3, [1.f, 5.f, 3.f, 7.f, 6.f, 8.f, 9.f, 2.f, 4.f])
 			expect(m determinant(), is equal to(108.0f))
@@ -157,6 +135,17 @@ FloatMatrixTest: class extends Fixture {
 			expect(text, is equal to(t"1.00, 0.00, 0.00; 0.00, 1.00, 0.00; 0.00, 0.00, 1.00; "))
 			text free()
 			matrix free()
+		})
+		this add("equality", func {
+			m := this createMatrix(3, 3, [1.f, 5.f, 3.f, 7.f, 6.f, 8.f, 9.f, 2.f, 4.f])
+			n := this createMatrix(3, 3, [1.f, 5.f, 3.f, 7.f, 6.f, 8.f, 9.f, 2.f, 4.f])
+			o := this createMatrix(3, 3, [1.f, 5.f, 3.f, 4.f, 6.f, 8.f, 9.f, 2.f, 4.f])
+			expect(m == n, is true)
+			expect(m != o, is true)
+			expect(n == o, is false)
+			m free()
+			n free()
+			o free()
 		})
 	}
 


### PR DESCRIPTION
Fixes #1516 

Changed the use of `==` to use `equals()` when it's floating-point numbers. 

Also added `==` and `!=` operators for `FloatMatrix`.

Peer review @niklasborwell ?