### PR TITLE
Added equal to() support for remaining geometry+math types

### DIFF
--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -190,3 +190,7 @@ FloatBox2D: cover {
 		This new(FloatPoint2D linearInterpolation(a leftTop, b leftTop, ratio), FloatVector2D linearInterpolation(a size, b size, ratio))
 	}
 }
+
+extend Cell<FloatBox2D> {
+	toText: func ~floatbox2d -> Text { (this val as FloatBox2D) toText() }
+}

--- a/source/geometry/FloatShell2D.ooc
+++ b/source/geometry/FloatShell2D.ooc
@@ -55,3 +55,7 @@ FloatShell2D: cover {
 		result
 	}
 }
+
+extend Cell<FloatShell2D> {
+	toText: func ~floatshell2d -> Text { (this val as FloatShell2D) toText() }
+}

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -156,3 +156,7 @@ IntBox2D: cover {
 		This new(xMinimum, yMinimum, xMaximum - xMinimum, yMaximum - yMinimum)
 	}
 }
+
+extend Cell<IntBox2D> {
+	toText: func ~intbox2d -> Text { (this val as IntBox2D) toText() }
+}

--- a/source/geometry/IntShell2D.ooc
+++ b/source/geometry/IntShell2D.ooc
@@ -54,3 +54,7 @@ IntShell2D: cover {
 		result
 	}
 }
+
+extend Cell<IntShell2D> {
+	toText: func ~intshell2d -> Text { (this val as IntShell2D) toText() }
+}

--- a/source/geometry/IntTransform2D.ooc
+++ b/source/geometry/IntTransform2D.ooc
@@ -158,3 +158,7 @@ IntTransform2D: cover {
 	createReflectionX: static func -> This { This new(-1, 0, 0, 1, 0, 0) }
 	createReflectionY: static func -> This { This new(1, 0, 0, -1, 0, 0) }
 }
+
+extend Cell<IntTransform2D> {
+	toText: func ~inttransform2d -> Text { (this val as IntTransform2D) toText() }
+}

--- a/source/math/FloatComplex.ooc
+++ b/source/math/FloatComplex.ooc
@@ -51,3 +51,7 @@ FloatComplex: cover {
 }
 operator * (left: Float, right: FloatComplex) -> FloatComplex { FloatComplex new(left * right real, left * right imaginary) }
 operator / (left: Float, right: FloatComplex) -> FloatComplex { (left * right conjugate) / (right absoluteValue pow(2)) }
+
+extend Cell<FloatComplex> {
+	toText: func ~floatcomplex -> Text { (this val as FloatComplex) toText() }
+}

--- a/source/math/FloatMatrix.ooc
+++ b/source/math/FloatMatrix.ooc
@@ -466,3 +466,7 @@ FloatMatrix: cover {
 	}
 }
 operator * (left: Float, right: FloatMatrix) -> FloatMatrix { right * left }
+
+extend Cell<FloatMatrix> {
+	toText: func ~floatmatrix -> Text { (this val as FloatMatrix) toText() }
+}

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -115,6 +115,13 @@ Fixture: abstract class {
 			case IntVector3D => (expectedText, testedText) = (expectedValue toText~intvector3d(), testedValue toText~intvector3d())
 			case IntPoint2D => (expectedText, testedText) = (expectedValue toText~intpoint2d(), testedValue toText~intpoint2d())
 			case IntPoint3D => (expectedText, testedText) = (expectedValue toText~intpoint3d(), testedValue toText~intpoint3d())
+			case FloatComplex => (expectedText, testedText) = (expectedValue toText~floatcomplex(), testedValue toText~floatcomplex())
+			case FloatMatrix => (expectedText, testedText) = (expectedValue toText~floatmatrix(), testedValue toText~floatmatrix())
+			case IntTransform2D => (expectedText, testedText) = (expectedValue toText~inttransform2d(), testedValue toText~inttransform2d())
+			case FloatBox2D => (expectedText, testedText) = (expectedValue toText~floatbox2d(), testedValue toText~floatbox2d())
+			case IntBox2D => (expectedText, testedText) = (expectedValue toText~intbox2d(), testedValue toText~intbox2d())
+			case FloatShell2D => (expectedText, testedText) = (expectedValue toText~floatshell2d(), testedValue toText~floatshell2d())
+			case IntShell2D => (expectedText, testedText) = (expectedValue toText~intshell2d(), testedValue toText~intshell2d())
 			case => (expectedText, testedText) = (expectedValue toText(), testedValue toText())
 		}
 		result append(expectedText) . append(t"was") . append(testedText)
@@ -182,6 +189,13 @@ Fixture: abstract class {
 	expect: static func ~intvector3d (value: IntVector3D, constraint: Constraint) { This expect(Cell new(value), constraint) }
 	expect: static func ~intpoint2d (value: IntPoint2D, constraint: Constraint) { This expect(Cell new(value), constraint) }
 	expect: static func ~intpoint3d (value: IntPoint3D, constraint: Constraint) { This expect(Cell new(value), constraint) }
+	expect: static func ~floatcomplex (value: FloatComplex, constraint: Constraint) { This expect(Cell new(value), constraint) }
+	expect: static func ~floatmatrix (value: FloatMatrix, constraint: Constraint) { This expect(Cell new(value), constraint) }
+	expect: static func ~inttransform2d (value: IntTransform2D, constraint: Constraint) { This expect(Cell new(value), constraint) }
+	expect: static func ~floatbox2d (value: FloatBox2D, constraint: Constraint) { This expect(Cell new(value), constraint) }
+	expect: static func ~intbox2d (value: IntBox2D, constraint: Constraint) { This expect(Cell new(value), constraint) }
+	expect: static func ~floatshell2d (value: FloatShell2D, constraint: Constraint) { This expect(Cell new(value), constraint) }
+	expect: static func ~intshell2d (value: IntShell2D, constraint: Constraint) { This expect(Cell new(value), constraint) }
 }
 
 TestFailedException: class extends Exception {

--- a/source/unit/Modifiers.ooc
+++ b/source/unit/Modifiers.ooc
@@ -156,6 +156,34 @@ EqualModifier: class extends ExpectModifier {
 		f := func (value, c: Cell<IntPoint3D>) -> Bool { value get() == c get() }
 		CompareWithinConstraint new(this, Cell<IntPoint3D> new(correct), f, this withinType, IntPoint3D)
 	}
+	to: func ~floatcomplex (correct: FloatComplex) -> CompareWithinConstraint {
+		f := func (value, c: Cell<FloatComplex>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<FloatComplex> new(correct), f, this withinType, FloatComplex)
+	}
+	to: func ~floatmatrix (correct: FloatMatrix) -> CompareWithinConstraint {
+		f := func (value, c: Cell<FloatMatrix>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<FloatMatrix> new(correct), f, this withinType, FloatMatrix)
+	}
+	to: func ~inttransform2d (correct: IntTransform2D) -> CompareWithinConstraint {
+		f := func (value, c: Cell<IntTransform2D>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<IntTransform2D> new(correct), f, this withinType, IntTransform2D)
+	}
+	to: func ~floatbox2d (correct: FloatBox2D) -> CompareWithinConstraint {
+		f := func (value, c: Cell<FloatBox2D>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<FloatBox2D> new(correct), f, this withinType, FloatBox2D)
+	}
+	to: func ~intbox2d (correct: IntBox2D) -> CompareWithinConstraint {
+		f := func (value, c: Cell<IntBox2D>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<IntBox2D> new(correct), f, this withinType, IntBox2D)
+	}
+	to: func ~floatshell2d (correct: FloatShell2D) -> CompareWithinConstraint {
+		f := func (value, c: Cell<FloatShell2D>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<FloatShell2D> new(correct), f, this withinType, FloatShell2D)
+	}
+	to: func ~intshell2d (correct: IntShell2D) -> CompareWithinConstraint {
+		f := func (value, c: Cell<IntShell2D>) -> Bool { value get() == c get() }
+		CompareWithinConstraint new(this, Cell<IntShell2D> new(correct), f, this withinType, IntShell2D)
+	}
 }
 
 LessModifier: class extends ExpectModifier {


### PR DESCRIPTION
Depends on #1510 and #1517 

Fixes #1500 by adding support for the remaining seven types.