### PR TITLE
fix for building berkeley.ooc on android

### DIFF
--- a/source/net/berkeley.ooc
+++ b/source/net/berkeley.ooc
@@ -20,7 +20,9 @@ version (windows) {
 	include sys/select
 	include arpa/inet
 	include netdb | (__USE_POSIX)
-	include sys/fcntl
+	version(!android) {
+		include sys/fcntl
+	}
 }
 
 SockAddr: cover from struct sockaddr {


### PR DESCRIPTION
Trying to compile generated C code on android failed with error `fcntl.h not found`
@marcusnaslund 