### PR TITLE
Bug fixes in GlobalCleanup

### DIFF
--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -55,7 +55,7 @@ ByteBuffer: class {
 	free: static func ~all { _RecyclableByteBuffer _free~all() }
 }
 
-GlobalCleanup register(|| ByteBuffer free~all())
+GlobalCleanup register(|| ByteBuffer free~all(), true)
 
 _SlicedByteBuffer: class extends ByteBuffer {
 	_parent: ByteBuffer

--- a/source/system/Memory.ooc
+++ b/source/system/Memory.ooc
@@ -25,22 +25,24 @@ alloca: extern func (SizeT) -> Pointer
 
 // Used for executing any/all cleanup (free~all) functions before program exit
 GlobalCleanup: class {
-	_functionPointers: static Stack<Closure> = null
+	_functionPointers: static VectorList<Closure> = null
 	init: func
-	register: static func (pointer: Func) {
+	register: static func (pointer: Func, last := false) {
 		if (This _functionPointers == null)
-			This _functionPointers = Stack<Closure> new()
-		This _functionPointers push(pointer as Closure)
+			This _functionPointers = VectorList<Closure> new()
+		if (last)
+			This _functionPointers insert(0, pointer as Closure)
+		else
+			This _functionPointers add(pointer as Closure)
 	}
 	run: static func {
 		if (This _functionPointers != null) {
-			while (!This _functionPointers isEmpty) {
-				next := This _functionPointers pop()
+			while (!This _functionPointers empty) {
+				next := This _functionPointers remove(This _functionPointers count - 1)
 				(next as Func)()
 				(next) free()
 			}
-			This _functionPointers free()
-			This _functionPointers = null
+			This clear()
 		}
 	}
 	clear: static func {
@@ -50,3 +52,6 @@ GlobalCleanup: class {
 		}
 	}
 }
+
+// Must be here because Mutex.ooc is loaded before Memory.ooc
+GlobalCleanup register(|| MutexGlobal free~all())

--- a/source/system/Mutex.ooc
+++ b/source/system/Mutex.ooc
@@ -56,8 +56,6 @@ MutexGlobal: class extends Mutex {
 	lock: override func { This _globalMutex lock() }
 	unlock: override func { This _globalMutex unlock() }
 	free: static func ~all { This _globalMutex free() }
-
-	GlobalCleanup register(|| This free~all())
 }
 
 // A recursive mutex can be locked several times in a row. unlock() should be called as many times to properly unlock it

--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -316,4 +316,4 @@ cStringPtrToStringPtr: func (cstr: CString*, len: Int) -> String* {
 	toRet
 }
 
-GlobalCleanup register(|| String free~all())
+GlobalCleanup register(|| String free~all(), true)


### PR DESCRIPTION
- Changed the data structure to a `VectorList` to allow for registering callbacks at the bottom, not just at the top.
- `String free~all()` and `ByteBuffer free~all()` is now put at the bottom
- `MutexGlobal free~all()` is now actually called, it was not before. Thank you rock.

Peer review @sebastianbaginski ?