### PR TITLE
Not using exit handler in Fixture

### DIFF
--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -17,12 +17,7 @@ Fixture: abstract class {
 	name: String
 	tests := VectorList<Test> new(32, false)
 
-	init: func (=name) {
-		if (!This exitHandlerRegistered) {
-			This exitHandlerRegistered = true
-			atexit(This printFailures)
-		}
-	}
+	init: func (=name)
 	free: override func {
 		this tests free()
 		this name free()
@@ -133,7 +128,6 @@ Fixture: abstract class {
 	_testsFailed: static Bool
 	_expectCount: static Int = 0
 	totalTime: static Double
-	exitHandlerRegistered: static Bool
 	failureNames: static VectorList<String>
 	is ::= static IsConstraints new()
 	testsFailed: static Bool { get { This _testsFailed } }

--- a/test/Tests.ooc
+++ b/test/Tests.ooc
@@ -8,6 +8,9 @@
 
 use tests
 use unit
+
 main: func {
-	exit(Fixture testsFailed ? 1 : 0)
+	result := Fixture testsFailed
+	Fixture printFailures()
+	exit(result ? 1 : 0)
 }


### PR DESCRIPTION
Required for using `GlobalCleanup` in tests. Also, not having to use `atexit()` feels cleaner.

Peer review @sebastianbaginski ?