### PR TITLE
Using GlobalCleanup in tests

### DIFF
--- a/test/Tests.ooc
+++ b/test/Tests.ooc
@@ -12,5 +12,6 @@ use unit
 main: func {
 	result := Fixture testsFailed
 	Fixture printFailures()
+	GlobalCleanup run()
 	exit(result ? 1 : 0)
 }

--- a/test/base/ByteBufferTest.ooc
+++ b/test/base/ByteBufferTest.ooc
@@ -45,7 +45,6 @@ ByteBufferTest: class extends Fixture {
 			for (i in 0 .. 1024 / 8)
 				buffer pointer[i] = i
 			slice := buffer slice(10, 8)
-			buffer referenceCount decrease()
 			expect(slice size, is equal to(8))
 			expect(slice pointer[0] as Int, is equal to(10))
 			slice referenceCount decrease()
@@ -58,7 +57,6 @@ ByteBufferTest: class extends Fixture {
 			y referenceCount decrease()
 			expect(yuv referenceCount _count, is equal to(1))
 			uv referenceCount decrease()
-			yuv referenceCount decrease()
 		})
 	}
 }


### PR DESCRIPTION
Because of how the refcounter works, `buffer` is freed when the slices are freed, which lead to memory problems later when `ByteBuffer free~all()` was called. I've adapted the tests to account for this.

Fixes #1536 
Fixes #1519 

Peer review @sebastianbaginski ?