### PR TITLE
do not test thread cancelation on android

### DIFF
--- a/test/concurrent/ThreadTest.ooc
+++ b/test/concurrent/ThreadTest.ooc
@@ -14,7 +14,7 @@ ThreadTest: class extends Fixture {
 	init: func {
 		super("Thread")
 		this add("starting thread", This _testStartingThread)
-		version (!windows) { this add("canceling thread", This _testCancelation) }
+		version (!windows && !android) { this add("canceling thread", This _testCancelation) }
 		this add("thread id", This _testThreadId)
 		this add("timed wait", This _timedJoin)
 	}


### PR DESCRIPTION
It always fail as `cancel` is not implemented for android
@marcusnaslund 