### PR TITLE
Removed pen from canvas.

### DIFF
--- a/source/draw/Canvas.ooc
+++ b/source/draw/Canvas.ooc
@@ -21,10 +21,8 @@ InterpolationMode: enum {
 
 Canvas: abstract class {
 	_size: IntVector2D
-	_pen := Pen new()
 	_transform := FloatTransform3D identity
 	size ::= this _size
-	pen: Pen { get { this _pen } set(value) { this _pen = value } }
 	viewport: IntBox2D { get set }
 	blend: Bool { get set }
 	opacity: Float { get set }
@@ -38,28 +36,33 @@ Canvas: abstract class {
 		this opacity = 1.0f
 		this interpolationMode = InterpolationMode Fast
 	}
-	drawPoint: virtual func (position: FloatPoint2D) {
+	drawPoint: virtual func ~white (position: FloatPoint2D) { this drawPoint(position, Pen new(ColorRgba white)) }
+	drawPoint: virtual func ~explicit (position: FloatPoint2D, pen: Pen) {
 		list := VectorList<FloatPoint2D> new()
 		list add(position)
-		this drawPoints(list)
+		this drawPoints(list, pen)
 		list free()
 	}
-	drawLine: virtual func (start, end: FloatPoint2D) {
+	drawLine: virtual func ~white (start, end: FloatPoint2D) { this drawLine(start, end, Pen new(ColorRgba white)) }
+	drawLine: virtual func ~explicit (start, end: FloatPoint2D, pen: Pen) {
 		list := VectorList<FloatPoint2D> new()
 		list add(start) . add(end)
-		this drawLines(list)
+		this drawLines(list, pen)
 		list free()
 	}
-	drawPoints: abstract func (pointList: VectorList<FloatPoint2D>)
-	drawLines: abstract func (lines: VectorList<FloatPoint2D>)
-	drawBox: virtual func (box: FloatBox2D) {
+	drawPoints: func ~white (pointList: VectorList<FloatPoint2D>) { this drawPoints(pointList, Pen new(ColorRgba white)) }
+	drawPoints: abstract func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen)
+	drawLines: func ~white (pointList: VectorList<FloatPoint2D>) { this drawLines(pointList, Pen new(ColorRgba white)) }
+	drawLines: abstract func ~explicit (lines: VectorList<FloatPoint2D>, pen: Pen)
+	drawBox: virtual func ~white (box: FloatBox2D) { this drawBox(box, Pen new(ColorRgba white)) }
+	drawBox: virtual func ~explicit (box: FloatBox2D, pen: Pen) {
 		positions := VectorList<FloatPoint2D> new()
 		positions add(box leftTop)
 		positions add(box rightTop)
 		positions add(box rightBottom)
 		positions add(box leftBottom)
 		positions add(box leftTop)
-		this drawLines(positions)
+		this drawLines(positions, pen)
 		positions free()
 	}
 	fill: abstract func (color: ColorRgba)

--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -7,7 +7,6 @@
  */
 
 use geometry
-import Pen
 import Image
 import Map
 import Mesh

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -21,25 +21,25 @@ RasterCanvas: abstract class extends Canvas {
 	init: func (=_target) { super(this _target size) }
 	fill: override func (color: ColorRgba) { raise("RasterCanvas fill unimplemented!") }
 	draw: override func ~ImageSourceDestination (image: Image, source, destination: IntBox2D) { Debug error("RasterCanvas draw~ImageSourceDestination unimplemented!") }
-	drawPoint: override func (point: FloatPoint2D) { this _drawPoint(point x as Int, point y as Int) }
-	_drawPoint: abstract func (x, y: Int)
-	drawPoints: override func (pointList: VectorList<FloatPoint2D>) {
+	drawPoint: override func ~explicit (point: FloatPoint2D, pen: Pen) { this _drawPoint(point x as Int, point y as Int, pen) }
+	_drawPoint: abstract func (x, y: Int, pen: Pen)
+	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
 		for (i in 0 .. pointList count)
-			this drawPoint(pointList[i])
+			this drawPoint(pointList[i], pen)
 	}
-	_drawLine: func (start, end: IntPoint2D) {
+	_drawLine: func (start, end: IntPoint2D, pen: Pen) {
 		if (start y == end y) {
 			startX := start x minimum(end x)
 			endX := start x maximum(end x)
 			for (x in startX .. endX + 1)
-				this _drawPoint(x, start y)
+				this _drawPoint(x, start y, pen)
 		} else if (start x == end x) {
 			startY := start y minimum(end y)
 			endY := start y maximum(end y)
 			for (y in startY .. endY + 1)
-				this _drawPoint(start x, y)
+				this _drawPoint(start x, y, pen)
 		} else {
-			originalPen := this pen
+			originalPen := pen
 			originalAlpha := originalPen alphaAsFloat
 			slope := (end y - start y) as Float / (end x - start x) as Float
 			startX := start x minimum(end x)
@@ -48,20 +48,19 @@ RasterCanvas: abstract class extends Canvas {
 				idealY := slope * (x - start x) + start y
 				floor := idealY floor()
 				weight := (idealY - floor) abs()
-				this pen setAlpha(originalAlpha * (1.0f - weight))
-				this _drawPoint(x, floor)
-				this pen setAlpha(originalAlpha * weight)
-				this _drawPoint(x, floor + 1)
+				pen setAlpha(originalAlpha * (1.0f - weight))
+				this _drawPoint(x, floor, pen)
+				pen setAlpha(originalAlpha * weight)
+				this _drawPoint(x, floor + 1, pen)
 			}
-			this pen = originalPen
 		}
 	}
-	drawLines: override func (lines: VectorList<FloatPoint2D>) {
+	drawLines: override func ~explicit (lines: VectorList<FloatPoint2D>, pen: Pen) {
 		if (lines count > 1)
 			for (i in 0 .. lines count - 1) {
 				start := IntPoint2D new(lines[i] x, lines[i] y)
 				end := IntPoint2D new(lines[i + 1] x, lines[i + 1] y)
-				this _drawLine(start, end)
+				this _drawLine(start, end, pen)
 			}
 	}
 	_map: func (point: IntPoint2D) -> IntPoint2D {

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -14,15 +14,16 @@ import RasterImage
 import StbImage
 import Image, FloatImage
 import Color
+import Pen
 import Canvas, RasterCanvas
 
 RasterMonochromeCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterMonochrome
 	init: func (image: RasterMonochrome) { super(image) }
-	_drawPoint: override func (x, y: Int) {
+	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
 		if (this target isValidIn(position x, position y))
-			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toMonochrome())
+			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toMonochrome())
 	}
 	draw: override func ~ImageSourceDestination (image: Image, source, destination: IntBox2D) {
 		monochrome: RasterMonochrome = null

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -15,15 +15,16 @@ import io/File
 import StbImage
 import Image
 import Color
+import Pen
 import Canvas, RasterCanvas
 
 RasterRgbCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterRgb
 	init: func (image: RasterRgb) { super(image) }
-	_drawPoint: override func (x, y: Int) {
+	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
 		if (this target isValidIn(position x, position y))
-			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toRgb())
+			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toRgb())
 	}
 	draw: override func ~ImageSourceDestination (image: Image, source, destination: IntBox2D) {
 		rgb: RasterRgb = null

--- a/source/draw/RasterRgba.ooc
+++ b/source/draw/RasterRgba.ooc
@@ -14,15 +14,16 @@ import io/File
 import StbImage
 import Image
 import Color
+import Pen
 import Canvas, RasterCanvas
 
 RasterRgbaCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterRgba
 	init: func (image: RasterRgba) { super(image) }
-	_drawPoint: override func (x, y: Int) {
+	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
 		if (this target isValidIn(position x, position y))
-			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color)
+			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color)
 	}
 }
 

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -14,15 +14,16 @@ import RasterRgb
 import StbImage
 import Image
 import Color
+import Pen
 import Canvas, RasterCanvas
 
 RasterUvCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterUv
 	init: func (image: RasterUv) { super(image) }
-	_drawPoint: override func (x, y: Int) {
+	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
 		if (this target isValidIn(position x, position y))
-			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toUv())
+			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toUv())
 	}
 	draw: override func ~ImageSourceDestination (image: Image, source, destination: IntBox2D) {
 		uv: RasterUv = null

--- a/source/draw/RasterYuv420Planar.ooc
+++ b/source/draw/RasterYuv420Planar.ooc
@@ -14,15 +14,16 @@ import RasterYuvPlanar
 import RasterMonochrome
 import Image
 import Color
+import Pen
 import Canvas, RasterCanvas
 
 RasterYuv420PlanarCanvas: class extends RasterCanvas {
 	target ::= this _target as RasterYuv420Planar
 	init: func (image: RasterYuv420Planar) { super(image) }
-	_drawPoint: override func (x, y: Int) {
+	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
 		if (this target isValidIn(position x, position y))
-			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toYuv())
+			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toYuv())
 	}
 }
 

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -15,6 +15,7 @@ import RasterMonochrome
 import RasterUv
 import Image
 import Color
+import Pen
 import RasterRgb
 import StbImage
 import io/File
@@ -26,10 +27,10 @@ import Canvas, RasterCanvas
 RasterYuv420SemiplanarCanvas: class extends RasterCanvas {
 	target ::= this _target as RasterYuv420Semiplanar
 	init: func (image: RasterYuv420Semiplanar) { super(image) }
-	_drawPoint: override func (x, y: Int) {
+	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
 		if (this target isValidIn(position x, position y))
-			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toYuv())
+			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toYuv())
 	}
 }
 

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -13,6 +13,7 @@ import RasterImage
 import RasterMonochrome
 import Image
 import Color
+import Pen
 import RasterRgb
 import StbImage
 import io/File
@@ -24,10 +25,10 @@ import Canvas, RasterCanvas
 RasterYuv422SemipackedCanvas: class extends RasterPackedCanvas {
 	target ::= this _target as RasterYuv422Semipacked
 	init: func (image: RasterYuv422Semipacked) { super(image) }
-	_drawPoint: override func (x, y: Int) {
+	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
 		if (this target isValidIn(position x, position y))
-			this target[position x, position y] = this target[position x, position y] blend(this pen alphaAsFloat, this pen color toYuv())
+			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toYuv())
 	}
 }
 

--- a/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
@@ -31,19 +31,8 @@ GpuCanvasYuv420Semiplanar: class extends GpuCanvas {
 			this _target uv canvas focalLength = value / 2
 		}
 	}
-	pen: Pen {
-		get { this _pen }
-		set(value) {
-			this _pen = value
-			yuv := value color toYuv()
-			this _target y canvas pen = Pen new(ColorRgba new(yuv y, 0, 0, 255), value width)
-			this _target uv canvas pen = Pen new(ColorRgba new(yuv u, yuv v, 0, 255), value width)
-		}
-	}
-
 	init: func (=_target, context: GpuContext) {
 		super(this _target size, context, context defaultMap, IntTransform2D identity)
-		this _target uv canvas pen = Pen new(ColorRgba new(128, 128, 128, 128))
 	}
 	draw: override func ~DrawState (drawState: DrawState) {
 		drawStateY := drawState setTarget((drawState target as GpuYuv420Semiplanar) y)
@@ -67,15 +56,16 @@ GpuCanvasYuv420Semiplanar: class extends GpuCanvas {
 		this _target y canvas draw(gpuImage y, source, destination)
 		this _target uv canvas draw(gpuImage uv, IntBox2D new(source leftTop / 2, source size / 2), IntBox2D new(destination leftTop / 2, destination size / 2))
 	}
-	drawLines: override func (pointList: VectorList<FloatPoint2D>) {
-		this _target y canvas drawLines(pointList)
+	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
+		yuv := pen color toYuv()
+		this _target y canvas drawLines(pointList, Pen new(ColorRgba new(yuv y, 0, 0, 255), pen width))
 		uvLines := VectorList<FloatPoint2D> new()
 		for (i in 0 .. pointList count)
 			uvLines add(pointList[i] / 2.0f)
-		this _target uv canvas drawLines(uvLines)
+		this _target uv canvas drawLines(uvLines, Pen new(ColorRgba new(yuv u, yuv v, 0, 255), (pen width / 2.0f) + 0.5f))
 		uvLines free()
 	}
-	drawPoints: override func (pointList: VectorList<FloatPoint2D>) { this _target y canvas drawPoints(pointList) }
+	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { this _target y canvas drawPoints(pointList, pen) }
 	fill: override func (color: ColorRgba) {
 		yuv := color toYuv()
 		this _target y canvas fill(ColorRgba new(yuv y, 0, 0, 255))

--- a/source/draw/gpu/opengl/OpenGLSurface.ooc
+++ b/source/draw/gpu/opengl/OpenGLSurface.ooc
@@ -49,18 +49,18 @@ OpenGLSurface: abstract class extends GpuCanvas {
 		map textureTransform = This _createTextureTransform(image size, source)
 		this draw(destination, map)
 	}
-	drawLines: override func (pointList: VectorList<FloatPoint2D>) {
+	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
 		this _bind()
 		this context backend setViewport(this viewport)
 		this context backend enableBlend(false)
-		this context drawLines(pointList, this _projection * this _toLocal, this pen)
+		this context drawLines(pointList, this _projection * this _toLocal, pen)
 		this _unbind()
 	}
-	drawPoints: override func (pointList: VectorList<FloatPoint2D>) {
+	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
 		this _bind()
 		this context backend setViewport(this viewport)
 		this context backend enableBlend(false)
-		this context drawPoints(pointList, this _projection * this _toLocal, this pen)
+		this context drawPoints(pointList, this _projection * this _toLocal, pen)
 		this _unbind()
 	}
 	// Deprecated! Do not use.

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -38,11 +38,6 @@ OpenGLUv: class extends OpenGLPacked {
 		(packed canvas as OpenGLCanvas) readPixels(buffer)
 		packed free()
 	}
-	_createCanvas: override func -> GpuCanvas {
-		result := super()
-		result pen = Pen new(ColorRgba new(128, 128, 128, 128))
-		result
-	}
 	create: override func (size: IntVector2D) -> This { this context createUv(size) as This }
 	channelCount: static Int = 2
 }

--- a/test/draw/RasterCanvasTest.ooc
+++ b/test/draw/RasterCanvasTest.ooc
@@ -19,15 +19,15 @@ RasterCanvasTest: class extends Fixture {
 		this add("rgb", func {
 			output := "test/draw/output/RasterCanvas_Rgb.png"
 			image := RasterRgb open(this inputFlower)
-			image canvas pen = Pen new(ColorRgb new(0, 255, 0))
+			pen := Pen new(ColorRgb new(0, 255, 0))
 			halfWidth := image size x / 2
 			halfHeight := image size y / 2
 			start := FloatPoint2D new(-halfWidth, -halfHeight)
 			end := FloatPoint2D new(halfWidth, halfHeight)
-			image canvas drawLine(start, end)
+			image canvas drawLine(start, end, pen)
 			start = FloatPoint2D new(halfWidth, -halfHeight)
 			end = FloatPoint2D new(-halfWidth, halfHeight)
-			image canvas drawLine(start, end)
+			image canvas drawLine(start, end, pen)
 			image save(output)
 			original := RasterRgb open(this inputFlower)
 			//TODO: This doesn't test if correctly drawn, only if the image has been modified
@@ -39,10 +39,10 @@ RasterCanvasTest: class extends Fixture {
 		this add("rgba", func {
 			output := "test/draw/output/RasterCanvas_Rgba.png"
 			image := RasterRgba open(this inputFlower)
-			image canvas pen = Pen new(ColorRgb new(128, 0, 128))
+			pen := Pen new(ColorRgb new(128, 0, 128))
 			for (row in 0 .. image size y / 3)
 				for (column in 0 .. image size x / 3)
-					image canvas drawPoint(FloatPoint2D new(column * 3 - image size x / 2, row * 3 - image size y / 2))
+					image canvas drawPoint(FloatPoint2D new(column * 3 - image size x / 2, row * 3 - image size y / 2), pen)
 			image save(output)
 			original := RasterRgba open(this inputFlower)
 			//TODO: This doesn't test if correctly drawn, only if the image has been modified
@@ -55,9 +55,9 @@ RasterCanvasTest: class extends Fixture {
 			output := "test/draw/output/RasterCanvas_Yuv420.png"
 			image := RasterYuv420Semiplanar open(this inputFlower)
 			for (i in 0 .. 30) {
-				image canvas pen = Pen new(ColorRgb new((i % 3) * 80, (i % 5) * 50, (i % 10) * 25))
+				pen := Pen new(ColorRgb new((i % 3) * 80, (i % 5) * 50, (i % 10) * 25))
 				box := IntBox2D createAround(IntPoint2D new(0, 0), IntVector2D new(10 * i, 10 * i))
-				image canvas drawBox(FloatBox2D new(box))
+				image canvas drawBox(FloatBox2D new(box), pen)
 			}
 			image save(output)
 			original := RasterYuv420Semiplanar open(this inputFlower)
@@ -70,13 +70,13 @@ RasterCanvasTest: class extends Fixture {
 		this add("monochrome", func {
 			output := "test/draw/output/RasterCanvas_Monochrome.png"
 			image := RasterMonochrome open(this inputFlower)
-			image canvas pen = Pen new(ColorRgb new(255, 255, 255))
+			pen := Pen new(ColorRgb new(255, 255, 255))
 			shiftX := image size x / 2
 			shiftY := image size y / 2
 			for (i in 0 .. image size x / 10)
-				image canvas drawLine(FloatPoint2D new(i * 10 - shiftX, -shiftY), FloatPoint2D new(i * 10 - shiftX, shiftY))
+				image canvas drawLine(FloatPoint2D new(i * 10 - shiftX, -shiftY), FloatPoint2D new(i * 10 - shiftX, shiftY), pen)
 			for (i in 0 .. image size y / 10)
-				image canvas drawLine(FloatPoint2D new(-shiftX, i * 10 - shiftY), FloatPoint2D new(shiftX, i * 10 - shiftY))
+				image canvas drawLine(FloatPoint2D new(-shiftX, i * 10 - shiftY), FloatPoint2D new(shiftX, i * 10 - shiftY), pen)
 			image save(output)
 			original := RasterMonochrome open(this inputFlower)
 			//TODO: This doesn't test if correctly drawn, only if the image has been modified
@@ -88,14 +88,14 @@ RasterCanvasTest: class extends Fixture {
 		this add("monochrome with alpha", func {
 			output := "test/draw/output/RasterCanvas_MonochromeWithAlpha.png"
 			image := RasterMonochrome open(this inputFlower)
-			image canvas pen = Pen new(ColorRgba new(255, 255, 255, 100))
+			pen := Pen new(ColorRgba new(255, 255, 255, 100))
 			shiftX := image size x / 2
 			shiftY := image size y / 2
 			factor := 2
 			for (i in 0 .. image size x / factor)
-				image canvas drawLine(FloatPoint2D new(i * factor - shiftX, -shiftY), FloatPoint2D new(i * factor - shiftX, shiftY))
+				image canvas drawLine(FloatPoint2D new(i * factor - shiftX, -shiftY), FloatPoint2D new(i * factor - shiftX, shiftY), pen)
 			for (i in 0 .. image size y / factor)
-				image canvas drawLine(FloatPoint2D new(-shiftX, i * factor - shiftY), FloatPoint2D new(shiftX, i * factor - shiftY))
+				image canvas drawLine(FloatPoint2D new(-shiftX, i * factor - shiftY), FloatPoint2D new(shiftX, i * factor - shiftY), pen)
 			image save(output)
 			original := RasterMonochrome open(this inputFlower)
 			//TODO: This doesn't test if correctly drawn, only if the image has been modified


### PR DESCRIPTION
The pen is now given by argument to point and line drawing.
Not giving a pen will use a thin white pen by default.
This PR has to break backward compatibility because the previous behaviour was undefined and thereby causing flickering colors.