### PR TITLE
Reverted parentheses in version blocks

### DIFF
--- a/test/concurrent/ThreadTest.ooc
+++ b/test/concurrent/ThreadTest.ooc
@@ -14,7 +14,7 @@ ThreadTest: class extends Fixture {
 	init: func {
 		super("Thread")
 		this add("starting thread", This _testStartingThread)
-		version ((!windows) && (!android)) { this add("canceling thread", This _testCancelation) }
+		version (!windows && !android) { this add("canceling thread", This _testCancelation) }
 		this add("thread id", This _testThreadId)
 		this add("timed wait", This _timedJoin)
 	}


### PR DESCRIPTION
Reverting your change @sebastianbaginski as it's not needed in the new rock version. Please test to make sure this actually parses correctly now.