### PR TITLE
Cleaned up among external C dependencies

### DIFF
--- a/source/concurrent/Thread.ooc
+++ b/source/concurrent/Thread.ooc
@@ -64,8 +64,6 @@ version (unix || apple) {
 }
 
 version (windows) {
-	include windows
-
 	ThreadId: cover from DWORD {
 		equals: func (other: This) -> Bool {
 			this == other

--- a/source/concurrent/native/ConditionWin32.ooc
+++ b/source/concurrent/native/ConditionWin32.ooc
@@ -10,14 +10,6 @@ version(windows) {
 import ../[WaitCondition, Thread]
 import native/MutexWin32
 
-include windows
-
-CreateEvent: extern func (...) -> Handle
-SetEvent: extern func (Handle) -> Bool
-CloseHandle: extern func (Handle) -> Bool
-Infinite: extern (INFINITE) Long
-WaitSuccess: extern (WAIT_OBJECT_0) Long
-
 ConditionWin32: class extends WaitCondition {
 	_mutex := Mutex new()
 	_waitingEvents := VectorList<Handle> new()
@@ -45,7 +37,7 @@ ConditionWin32: class extends WaitCondition {
 		this _waitingEvents add(eventId)
 		this _mutex unlock()
 		mutex unlock()
-		(WaitForSingleObject(eventId, Infinite) == WaitSuccess)
+		(WaitForSingleObject(eventId, INFINITE) == WaitSuccess)
 	}
 	signal: override func -> Bool {
 		result := false

--- a/source/concurrent/native/ThreadUnix.ooc
+++ b/source/concurrent/native/ThreadUnix.ooc
@@ -8,8 +8,6 @@
 
 import ../Thread
 
-include unistd | (_POSIX_C_SOURCE=200809L)
-
 version(unix || apple) {
 ThreadUnix: class extends Thread {
 	pthread: PThread

--- a/source/concurrent/native/ThreadWin32.ooc
+++ b/source/concurrent/native/ThreadWin32.ooc
@@ -65,24 +65,4 @@ ThreadWin32: class extends Thread {
 		SwitchToThread()
 	}
 }
-
-/* C interface */
-
-include windows
-
-// CreateThread causes memory leaks, see:
-// http://stackoverflow.com/questions/331536/, and
-// http://support.microsoft.com/kb/104641/en-us
-// CreateThread: extern func (...) -> Handle
-
-_beginthreadex: extern func (security: Pointer, stackSize: UInt, startAddress, arglist: Pointer, initflag: UInt, thrdaddr: UInt*) -> Handle
-GetCurrentThread: extern func -> Handle
-GetCurrentThreadId: extern func -> UInt
-WaitForSingleObject: extern func (...) -> Long
-SwitchToThread: extern func -> Bool
-TerminateThread: extern func (...) -> Bool
-
-INFINITE: extern Long
-WAIT_OBJECT_0: extern Long
-WAIT_TIMEOUT: extern Long
 }

--- a/source/io/native/PipeUnix.ooc
+++ b/source/io/native/PipeUnix.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-include sys/types, sys/stat, unistd
+include sys/types, sys/stat
 include fcntl
 import ../Pipe
 

--- a/source/io/native/PipeWin32.ooc
+++ b/source/io/native/PipeWin32.ooc
@@ -77,21 +77,4 @@ PipeWin32: class extends Pipe {
 		SetNamedPipeHandleState(handle, flags&, null, null)
 	}
 }
-
-include windows
-
-CreatePipe: extern func (readPipe: Handle*, writePipe: Handle*, lpPipeAttributes: Pointer, nSize: Long) -> Bool
-ReadFile: extern func (hFile: Handle, buffer: Pointer, numberOfBytesToRead: Long, numberOfBytesRead: Long*, lpOverlapped: Pointer) -> Bool
-WriteFile: extern func (hFile: Handle, buffer: Pointer, numberOfBytesToWrite: Long, numberOfBytesWritten: Long*, lpOverlapped: Pointer) -> Bool
-CloseHandle: extern func (handle: Handle) -> Bool
-SetNamedPipeHandleState: extern func (handle: Handle, mode: Long*, maxCollectionCount: Long*, collectDataTimeout: Long*)
-
-PIPE_WAIT, PIPE_NOWAIT: extern ULong
-ERROR_NO_DATA: extern Long
-
-SecurityAttributes: cover from SECURITY_ATTRIBUTES {
-	length: extern (nLength) Int
-	inheritHandle: extern (bInheritHandle) Bool
-	securityDescriptor: extern (lpSecurityDescriptor) Pointer
-}
 }

--- a/source/io/native/ProcessWin32.ooc
+++ b/source/io/native/ProcessWin32.ooc
@@ -10,8 +10,6 @@ import ../Process
 import PipeWin32
 
 version(windows) {
-include windows
-
 ProcessWin32: class extends Process {
 	si: StartupInfo
 	pi: ProcessInformation
@@ -122,59 +120,4 @@ ProcessWin32: class extends Process {
 	terminate: override func { "please implement me! ProcessWin32 terminate" println() }
 	kill: override func { "please implement me! ProcessWin32 kill" println() }
 }
-
-// extern functions
-ZeroMemory: extern func (Pointer, SizeT)
-CreateProcess: extern func (CString, CString, Pointer, Pointer, Bool, Long, Pointer, CString, Pointer, Pointer) -> Bool
-WaitForSingleObject: extern func (Handle, Long) -> Int
-GetExitCodeProcess: extern func (Handle, ULong*) -> Int
-CloseHandle: extern func (Handle)
-SetHandleInformation: extern func (Handle, Long, Long) -> Bool
-HANDLE_FLAG_INHERIT: extern Long
-HANDLE_FLAG_PROTECT_FROM_CLOSE: extern Long
-WAIT_ABANDONED, WAIT_OBJECT_0, WAIT_TIMEOUT, WAIT_FAILED: extern Int
-
-// covers
-StartupInfo: cover from STARTUPINFO {
-	structSize: extern (cb) Long
-	reserved: extern (lpReserved) CString*
-	desktop: extern (lpDesktop) CString*
-	title: extern (lpTitle) CString*
-	x: extern (dwX) Long
-	y: extern (dwY) Long
-	xSize: extern (dwXSize) Long
-	ySize: extern (dwYSize) Long
-	xCountChars: extern (dwXCountChars) Long
-	yCountChars: extern (dwYCountChars) Long
-	flags: extern (dwFlags) Long
-	showWindow: extern (wShowWindow) Int
-	cbReserved2: extern Int
-	lpReserved2: extern Char* // LPBYTE
-	stdInput : extern (hStdInput) Handle
-	stdOutput: extern (hStdOutput) Handle
-	stdError : extern (hStdError) Handle
-}
-
-StartFlags: cover {
-	ForceOnFeedback : extern (STARTF_FORCEONFEEDBACK) static Long
-	ForceOffFeedback: extern (STARTF_FORCEOFFFEEDBACK) static Long
-	PreventPinning : extern (STARTF_PREVENTPINNING) static Long
-	RunFullScreen: extern (STARTF_RUNFULLSCREEN) static Long
-	TitleIsAppID: extern (STARTF_TITLEISAPPID) static Long
-	TitleIsLinkName: extern (STARTF_TITLEISLINKNAME) static Long
-	UseCountChars: extern (STARTF_USECOUNTCHARS) static Long
-	UseFillAttribute: extern (STARTF_USEFILLATTRIBUTE) static Long
-	UseHotKey: extern (STARTF_USEHOTKEY) static Long
-	UsePosition: extern (STARTF_USEPOSITION) static Long
-	UseShowWindow: extern (STARTF_USESHOWWINDOW) static Long
-	UseSize: extern (STARTF_USESIZE) static Long
-	UseStdHandles: extern (STARTF_USESTDHANDLES) static Long
-}
-
-ProcessInformation: cover from PROCESS_INFORMATION {
-	process: extern (hProcess) Handle
-	thread: extern (hThread) Handle
-	pid: extern (dwProcessId) Long
-}
-INFINITE: extern Long
 }

--- a/source/net/berkeley.ooc
+++ b/source/net/berkeley.ooc
@@ -8,7 +8,6 @@
 
 include stdio
 include sys/types
-include unistd | (__USE_BSD)
 
 version (windows) {
 	include winsock2

--- a/source/system/Exception.ooc
+++ b/source/system/Exception.ooc
@@ -10,14 +10,6 @@ import Backtrace
 
 include setjmp, errno, stdint
 
-version(windows) {
-	include windows
-
-	DebugBreak: extern func
-	RaiseException: extern func (ULong, ULong, ULong, Pointer)
-	IsDebuggerPresent: extern func -> Pointer
-}
-
 JmpBuf: cover from jmp_buf {
 	setJmp: extern (setjmp) func -> Int
 	longJmp: extern (longjmp) func (value: Int)
@@ -302,10 +294,6 @@ _setupHandlers()
 
 /* ------ C interface ------ */
 
-include stdlib
-
-abort: extern func
-
 version ((linux || apple) && !android) {
 	include signal
 
@@ -313,36 +301,4 @@ version ((linux || apple) && !android) {
 
 	SIGHUP, SIGINT, SIGILL, SIGTRAP, SIGABRT, SIGFPE, SIGBUS,
 	SIGSEGV, SIGSYS, SIGPIPE, SIGALRM, SIGTERM: extern Int
-}
-
-version (windows) {
-	// Windows exception handling functions
-	include windows
-
-	SetUnhandledExceptionFilter: extern func (handler: Pointer) -> Pointer
-
-	EXCEPTION_EXECUTE_HANDLER: extern Int
-
-	EXCEPTION_POINTERS: extern cover {
-		ExceptionRecord: EXCEPTION_RECORD*
-		ContextRecord: CONTEXT*
-	}
-
-	CONTEXT: extern cover
-
-	EXCEPTION_RECORD: extern cover {
-		ExceptionCode: DWORD
-	}
-
-	// exception codes
-	EXCEPTION_ACCESS_VIOLATION, EXCEPTION_ARRAY_BOUNDS_EXCEEDED,
-	EXCEPTION_BREAKPOINT, EXCEPTION_DATATYPE_MISALIGNMENT,
-	EXCEPTION_FLT_DENORMAL_OPERAND, EXCEPTION_FLT_DIVIDE_BY_ZERO,
-	EXCEPTION_FLT_INEXACT_RESULT, EXCEPTION_FLT_INVALID_OPERATION,
-	EXCEPTION_FLT_OVERFLOW, EXCEPTION_FLT_STACK_CHECK, EXCEPTION_FLT_UNDERFLOW,
-	EXCEPTION_ILLEGAL_INSTRUCTION, EXCEPTION_IN_PAGE_ERROR,
-	EXCEPTION_INT_DIVIDE_BY_ZERO, EXCEPTION_INT_OVERFLOW,
-	EXCEPTION_INVALID_DISPOSITION, EXCEPTION_NONCONTINUABLE_EXCEPTION,
-	EXCEPTION_PRIV_INSTRUCTION, EXCEPTION_SINGLE_STEP,
-	EXCEPTION_STACK_OVERFLOW: extern DWORD
 }

--- a/source/system/IO.ooc
+++ b/source/system/IO.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-include stdio | (_POSIX_SOURCE), fcntl, unistd
+include stdio | (_POSIX_SOURCE), fcntl
 
 stdout, stderr, stdin: extern FStream
 

--- a/source/system/Time.ooc
+++ b/source/system/Time.ooc
@@ -7,31 +7,13 @@
  */
 
 version(linux) {
-	include unistd | (__USE_BSD, _BSD_SOURCE, _DEFAULT_SOURCE)
 	include sys/time | (__USE_BSD, _BSD_SOURCE, _DEFAULT_SOURCE)
 	include time | (__USE_BSD, _BSD_SOURCE, _DEFAULT_SOURCE)
 } else {
-	include unistd, sys/time
-}
-version(windows) {
-	include windows
+	include sys/time
 }
 
-version(windows) {
-	SystemTime: cover from SYSTEMTIME {
-		wYear, wMonth, wDayOfWeek, wDay, wHour, wMinute, wSecond, wMilliseconds : extern UShort
-	}
-
-	GetLocalTime: extern func (SystemTime*)
-	QueryPerformanceCounter: extern func (LargeInteger*)
-	QueryPerformanceFrequency: extern func (LargeInteger*)
-	Sleep: extern func (UInt)
-
-	LocaleId: cover from LCID
-	LOCALE_USER_DEFAULT: extern LocaleId
-	GetTimeFormat: extern func (LocaleId, Long, SystemTime*, CString, CString, Int) -> Int
-	GetDateFormat: extern func (LocaleId, Long, SystemTime*, CString, CString, Int) -> Int
-} else {
+version(!windows) {
 	TimeT: cover from time_t
 	TimeZone: cover from struct timezone
 	TMStruct: cover from struct tm {
@@ -45,7 +27,6 @@ version(windows) {
 	time: extern proto func (TimeT*) -> TimeT
 	localtime: extern func (TimeT*) -> TMStruct*
 	gettimeofday: extern func (TimeVal*, TimeZone*) -> Int
-	usleep: extern func (UInt)
 	_asctime: extern (asctime) func (TMStruct*) -> CString
 
 	// An `asctime` wrapper that copies the result to a new string. Otherwise, it would be overwritten in later calls.

--- a/source/system/external/stdlib.ooc
+++ b/source/system/external/stdlib.ooc
@@ -13,3 +13,4 @@ EXIT_FAILURE: extern Int
 
 exit: extern func (Int)
 atexit: extern func (Pointer)
+abort: extern func

--- a/source/system/external/unistd.ooc
+++ b/source/system/external/unistd.ooc
@@ -6,7 +6,13 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-include unistd | (__USE_GNU)
+version (linux) {
+	include unistd | (__USE_BSD, _BSD_SOURCE, _DEFAULT_SOURCE)
+} else {
+	include unistd
+}
+
+_SC_NPROCESSORS_ONLN: extern Int
 
 chdir: extern func (CString) -> Int
 dup2: extern func (Int, Int) -> Int
@@ -19,3 +25,5 @@ getpid: extern func -> UInt
 pipe: extern func (arg: Int*) -> Int
 isatty: extern func (fd: Int) -> Int
 gethostname: extern func (localSystemName: CString, localSystemNameLength: SizeT) -> Int
+sysconf: extern func (Int) -> Long
+usleep: extern func (UInt)

--- a/source/system/external/windows.ooc
+++ b/source/system/external/windows.ooc
@@ -7,12 +7,35 @@
  */
 
 version(windows) {
-include windows
+include windows | (_WIN32_WINNT=0x0500)
+
+COMPUTER_NAME_FORMAT: enum {
+	NET_BIOS = 0
+	DNS_HOSTNAME
+	DNS_DOMAIN
+	DNS_FULLY_QUALIFIED
+	PHYSICAL_NET_BIOS
+	PHYSICAL_DNS_HOSTNAME
+	PHYSICAL_DNS_DOMAIN
+	PHYSICAL_DNS_FULLY_QUALIFIED
+	MAX
+}
 
 ERROR_HANDLE_EOF: extern Int
 FORMAT_MESSAGE_FROM_SYSTEM: extern Long
 FORMAT_MESSAGE_IGNORE_INSERTS: extern Long
 FORMAT_MESSAGE_ARGUMENT_ARRAY: extern Long
+WaitSuccess: extern (WAIT_OBJECT_0) Long
+INFINITE: extern Long
+WAIT_OBJECT_0: extern Long
+WAIT_TIMEOUT: extern Long
+PIPE_WAIT, PIPE_NOWAIT: extern ULong
+ERROR_NO_DATA: extern Long
+HANDLE_FLAG_PROTECT_FROM_CLOSE: extern Long
+WAIT_ABANDONED, WAIT_OBJECT_0, WAIT_TIMEOUT, WAIT_FAILED: extern Int
+HANDLE_FLAG_INHERIT: extern Long
+PATHCCH_MAX_CCH: extern SizeT
+LOCALE_USER_DEFAULT: extern LocaleId
 
 BYTE: extern cover from Byte
 WORD: extern cover from Int
@@ -22,6 +45,27 @@ MAKEWORD: extern func (low, high: BYTE) -> WORD
 LocaleId: cover from LCID
 Handle: cover from HANDLE
 INVALID_HANDLE_VALUE: extern Handle
+EXCEPTION_EXECUTE_HANDLER: extern Int
+
+EXCEPTION_ACCESS_VIOLATION, EXCEPTION_ARRAY_BOUNDS_EXCEEDED,
+EXCEPTION_BREAKPOINT, EXCEPTION_DATATYPE_MISALIGNMENT,
+EXCEPTION_FLT_DENORMAL_OPERAND, EXCEPTION_FLT_DIVIDE_BY_ZERO,
+EXCEPTION_FLT_INEXACT_RESULT, EXCEPTION_FLT_INVALID_OPERATION,
+EXCEPTION_FLT_OVERFLOW, EXCEPTION_FLT_STACK_CHECK, EXCEPTION_FLT_UNDERFLOW,
+EXCEPTION_ILLEGAL_INSTRUCTION, EXCEPTION_IN_PAGE_ERROR,
+EXCEPTION_INT_DIVIDE_BY_ZERO, EXCEPTION_INT_OVERFLOW,
+EXCEPTION_INVALID_DISPOSITION, EXCEPTION_NONCONTINUABLE_EXCEPTION,
+EXCEPTION_PRIV_INSTRUCTION, EXCEPTION_SINGLE_STEP,
+EXCEPTION_STACK_OVERFLOW: extern DWORD
+
+FILE_ATTRIBUTE_DIRECTORY,
+FILE_ATTRIBUTE_REPARSE_POINT,
+FILE_ATTRIBUTE_NORMAL,
+INVALID_FILE_ATTRIBUTES: extern Long
+
+SystemInfo: cover from SYSTEM_INFO {
+	numberOfProcessors: extern (dwNumberOfProcessors) UInt
+}
 
 LargeInteger: cover from LARGE_INTEGER {
 	lowPart: extern (LowPart) Long
@@ -35,13 +79,139 @@ ULargeInteger: cover from ULARGE_INTEGER {
 	quadPart: extern (QuadPart) LLong
 }
 
+SecurityAttributes: cover from SECURITY_ATTRIBUTES {
+	length: extern (nLength) Int
+	inheritHandle: extern (bInheritHandle) Bool
+	securityDescriptor: extern (lpSecurityDescriptor) Pointer
+}
+
+EXCEPTION_POINTERS: extern cover {
+		ExceptionRecord: EXCEPTION_RECORD*
+		ContextRecord: CONTEXT*
+	}
+
+CONTEXT: extern cover
+HModule: cover from HMODULE
+
+EXCEPTION_RECORD: extern cover {
+	ExceptionCode: DWORD
+}
+
+FindData: cover from WIN32_FIND_DATA {
+	attr: extern (dwFileAttributes) Long // DWORD
+	fileSizeLow: extern (nFileSizeLow) Long // DWORD
+	fileSizeHigh: extern (nFileSizeHigh) Long // DWORD
+	creationTime: extern (ftCreationTime) FileTime
+	lastAccessTime: extern (ftLastAccessTime) FileTime
+	lastWriteTime: extern (ftLastWriteTime) FileTime
+	fileName: extern (cFileName) CString
+}
+
+StartupInfo: cover from STARTUPINFO {
+	structSize: extern (cb) Long
+	reserved: extern (lpReserved) CString*
+	desktop: extern (lpDesktop) CString*
+	title: extern (lpTitle) CString*
+	x: extern (dwX) Long
+	y: extern (dwY) Long
+	xSize: extern (dwXSize) Long
+	ySize: extern (dwYSize) Long
+	xCountChars: extern (dwXCountChars) Long
+	yCountChars: extern (dwYCountChars) Long
+	flags: extern (dwFlags) Long
+	showWindow: extern (wShowWindow) Int
+	cbReserved2: extern Int
+	lpReserved2: extern Char* // LPBYTE
+	stdInput : extern (hStdInput) Handle
+	stdOutput: extern (hStdOutput) Handle
+	stdError : extern (hStdError) Handle
+}
+
+StartFlags: cover {
+	ForceOnFeedback : extern (STARTF_FORCEONFEEDBACK) static Long
+	ForceOffFeedback: extern (STARTF_FORCEOFFFEEDBACK) static Long
+	PreventPinning : extern (STARTF_PREVENTPINNING) static Long
+	RunFullScreen: extern (STARTF_RUNFULLSCREEN) static Long
+	TitleIsAppID: extern (STARTF_TITLEISAPPID) static Long
+	TitleIsLinkName: extern (STARTF_TITLEISLINKNAME) static Long
+	UseCountChars: extern (STARTF_USECOUNTCHARS) static Long
+	UseFillAttribute: extern (STARTF_USEFILLATTRIBUTE) static Long
+	UseHotKey: extern (STARTF_USEHOTKEY) static Long
+	UsePosition: extern (STARTF_USEPOSITION) static Long
+	UseShowWindow: extern (STARTF_USESHOWWINDOW) static Long
+	UseSize: extern (STARTF_USESIZE) static Long
+	UseStdHandles: extern (STARTF_USESTDHANDLES) static Long
+}
+
+ProcessInformation: cover from PROCESS_INFORMATION {
+	process: extern (hProcess) Handle
+	thread: extern (hThread) Handle
+	pid: extern (dwProcessId) Long
+}
+
+SystemTime: cover from SYSTEMTIME {
+	wYear, wMonth, wDayOfWeek, wDay, wHour, wMinute, wSecond, wMilliseconds: extern UShort
+}
+
 WindowsException: class extends Exception {
 	init: func (.origin, err: Long) { super(origin, GetWindowsErrorMessage(err)) }
 	init: func ~withMsg (.origin, err: Long, message: String) { super(origin, "%s: %s" format(message, GetWindowsErrorMessage(err))) }
 }
 
+CreateMutex: extern func (Pointer, Bool, Pointer) -> Handle
+ReleaseMutex: extern func (Handle)
+WaitForSingleObject: extern func (...) -> Long
+
+LoadLibraryA: extern func (path: CString) -> HModule
+GetProcAddress: extern func (module: HModule, name: CString) -> Pointer
+FreeLibrary: extern func (module: HModule) -> Bool
+
+GetTimeFormat: extern func (LocaleId, Long, SystemTime*, CString, CString, Int) -> Int
+GetDateFormat: extern func (LocaleId, Long, SystemTime*, CString, CString, Int) -> Int
+GetLocalTime: extern func (SystemTime*)
+QueryPerformanceCounter: extern func (LargeInteger*)
+QueryPerformanceFrequency: extern func (LargeInteger*)
+Sleep: extern func (UInt)
+
 GetLastError: extern func -> Int
 FormatMessage: extern func (dwFlags: DWORD, lpSource: Pointer, dwMessageId: DWORD, dwLanguageId: DWORD, lpBuffer: LPTSTR, nSize: DWORD, ...) -> DWORD
+GetSystemInfo: extern func (SystemInfo*)
+GetComputerNameEx: extern func (COMPUTER_NAME_FORMAT, CString, UInt*)
+CreateEvent: extern func (...) -> Handle
+SetEvent: extern func (Handle) -> Bool
+
+_beginthreadex: extern func (security: Pointer, stackSize: UInt, startAddress, arglist: Pointer, initflag: UInt, thrdaddr: UInt*) -> Handle
+GetCurrentThread: extern func -> Handle
+GetCurrentThreadId: extern func -> UInt
+SwitchToThread: extern func -> Bool
+TerminateThread: extern func (...) -> Bool
+
+CreatePipe: extern func (readPipe: Handle*, writePipe: Handle*, lpPipeAttributes: Pointer, nSize: Long) -> Bool
+ReadFile: extern func (hFile: Handle, buffer: Pointer, numberOfBytesToRead: Long, numberOfBytesRead: Long*, lpOverlapped: Pointer) -> Bool
+WriteFile: extern func (hFile: Handle, buffer: Pointer, numberOfBytesToWrite: Long, numberOfBytesWritten: Long*, lpOverlapped: Pointer) -> Bool
+CloseHandle: extern func (handle: Handle) -> Bool
+SetNamedPipeHandleState: extern func (handle: Handle, mode: Long*, maxCollectionCount: Long*, collectDataTimeout: Long*)
+
+ZeroMemory: extern func (Pointer, SizeT)
+CreateProcess: extern func (CString, CString, Pointer, Pointer, Bool, Long, Pointer, CString, Pointer, Pointer) -> Bool
+GetExitCodeProcess: extern func (Handle, ULong*) -> Int
+SetHandleInformation: extern func (Handle, Long, Long) -> Bool
+
+DebugBreak: extern func
+RaiseException: extern func (ULong, ULong, ULong, Pointer)
+IsDebuggerPresent: extern func -> Pointer
+SetUnhandledExceptionFilter: extern func (handler: Pointer) -> Pointer
+
+FindFirstFile: extern (FindFirstFileA) func (CString, FindData*) -> Handle
+FindNextFile: extern func (Handle, FindData*) -> Bool
+FindClose: extern func (Handle)
+GetFileAttributes: extern func (CString) -> ULong
+CreateDirectory: extern func (CString, Pointer) -> Bool
+GetCurrentDirectory: extern func (ULong, Pointer) -> Int
+GetFullPathName: extern func (CString, ULong, CString, CString) -> ULong
+GetLongPathName: extern func (CString, CString, ULong) -> ULong
+DeleteFile: extern func (CString) -> Bool
+RemoveDirectory: extern func (CString) -> Bool
 
 GetWindowsErrorMessage: func (err: DWORD) -> String {
 	BUF_SIZE := 256

--- a/source/system/native/FileUnix.ooc
+++ b/source/system/native/FileUnix.ooc
@@ -31,10 +31,10 @@ telldir: extern func (DIR*) -> Long
 realpath: extern func (path, resolved: CString) -> CString
 
 version (linux) {
-	include unistd | (__USE_BSD), sys/stat | (__USE_BSD), sys/types | (__USE_BSD), stdlib | (__USE_BSD), limits
+	include sys/stat | (__USE_BSD), sys/types | (__USE_BSD), stdlib | (__USE_BSD), limits
 }
 version (!linux) {
-	include unistd, sys/stat, sys/types, stdlib
+	include sys/stat, sys/types, stdlib
 }
 
 version (unix || apple) {

--- a/source/system/native/FileWin32.ooc
+++ b/source/system/native/FileWin32.ooc
@@ -10,53 +10,9 @@ import structs/VectorList
 import io/File
 
 version(windows) {
-	include windows | (_WIN32_WINNT=0x0500)
-
-	// separators
 	File separator = '\\'
 	File pathDelimiter = ';'
 
-	PATHCCH_MAX_CCH: extern SizeT
-
-	/*
-	 * apparently on windows, every stat operation is a find
-	 * This makes sense, since most fs(es) on Win32 are case-insensitive
-	 */
-	FindData: cover from WIN32_FIND_DATA {
-		attr: extern (dwFileAttributes) Long // DWORD
-		fileSizeLow: extern (nFileSizeLow) Long // DWORD
-		fileSizeHigh: extern (nFileSizeHigh) Long // DWORD
-		creationTime: extern (ftCreationTime) FileTime
-		lastAccessTime: extern (ftLastAccessTime) FileTime
-		lastWriteTime: extern (ftLastWriteTime) FileTime
-		fileName: extern (cFileName) CString
-	}
-
-	/*
-	 * file attributes (incomplete list)
-	 */
-	FILE_ATTRIBUTE_DIRECTORY,
-	FILE_ATTRIBUTE_REPARSE_POINT,
-	FILE_ATTRIBUTE_NORMAL,
-	INVALID_FILE_ATTRIBUTES: extern Long // DWORD
-
-	/*
-	 * file-related functions from Win32
-	 */
-	FindFirstFile: extern (FindFirstFileA) func (CString, FindData*) -> Handle
-	FindNextFile: extern func (Handle, FindData*) -> Bool
-	FindClose: extern func (Handle)
-	GetFileAttributes: extern func (CString) -> ULong
-	CreateDirectory: extern func (CString, Pointer) -> Bool
-	GetCurrentDirectory: extern func (ULong, Pointer) -> Int
-	GetFullPathName: extern func (CString, ULong, CString, CString) -> ULong
-	GetLongPathName: extern func (CString, CString, ULong) -> ULong
-	DeleteFile: extern func (CString) -> Bool
-	RemoveDirectory: extern func (CString) -> Bool
-
-	/*
-	 * remove implementation
-	 */
 	_remove: unmangled func (file: File) -> Bool {
 		if (file dir())
 			return RemoveDirectory(file path)

--- a/source/system/native/MutexUnix.ooc
+++ b/source/system/native/MutexUnix.ooc
@@ -10,7 +10,6 @@ import ../Mutex
 
 version(unix || apple) {
 	include pthread | (_XOPEN_SOURCE=500)
-	include unistd
 
 	PThreadMutex: cover from pthread_mutex_t
 	PThreadMutexAttr: cover from pthread_mutexattr_t

--- a/source/system/native/MutexWin32.ooc
+++ b/source/system/native/MutexWin32.ooc
@@ -9,15 +9,6 @@
 import ../Mutex
 
 version(windows) {
-include windows
-
-CreateMutex: extern func (Pointer, Bool, Pointer) -> Handle
-ReleaseMutex: extern func (Handle)
-CloseHandle: extern func (Handle)
-
-WaitForSingleObject: extern func (...) -> Long
-INFINITE: extern Long
-
 MutexWin32: class extends Mutex {
 	_backend: Handle
 	init: func {

--- a/source/system/os/Dynlib.ooc
+++ b/source/system/os/Dynlib.ooc
@@ -46,13 +46,6 @@ Dynlib: abstract class {
 }
 
 version (windows) {
-	include windows
-
-	HModule: cover from HMODULE
-	LoadLibraryA: extern func (path: CString) -> HModule
-	GetProcAddress: extern func (module: HModule, name: CString) -> Pointer
-	FreeLibrary: extern func (module: HModule) -> Bool
-
 	DynlibWin32: class extends Dynlib {
 		handle: HModule
 		init: func (=path) {

--- a/source/system/os/System.ooc
+++ b/source/system/os/System.ooc
@@ -6,35 +6,6 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-version(windows) {
-	include windows | (_WIN32_WINNT=0x0500)
-
-	SystemInfo: cover from SYSTEM_INFO {
-		numberOfProcessors: extern (dwNumberOfProcessors) UInt
-	}
-
-	COMPUTER_NAME_FORMAT: enum {
-		NET_BIOS = 0
-		DNS_HOSTNAME
-		DNS_DOMAIN
-		DNS_FULLY_QUALIFIED
-		PHYSICAL_NET_BIOS
-		PHYSICAL_DNS_HOSTNAME
-		PHYSICAL_DNS_DOMAIN
-		PHYSICAL_DNS_FULLY_QUALIFIED
-		MAX
-	}
-
-	GetSystemInfo: extern func (SystemInfo*)
-	GetComputerNameEx: extern func (COMPUTER_NAME_FORMAT, CString, UInt*)
-}
-
-version(linux || apple) {
-	include unistd
-	sysconf: extern func (Int) -> Long
-	_SC_NPROCESSORS_ONLN: extern Int
-}
-
 System: class {
 	numProcessors: static func -> Int {
 		result := 1

--- a/source/ui/win32/include/win32.ooc
+++ b/source/ui/win32/include/win32.ooc
@@ -7,7 +7,7 @@
  */
 
 version(windows) {
-include windows, stdint
+include stdint
 
 LPSTR: cover from Char*
 LPMSG: cover from Msg*


### PR DESCRIPTION
The current system is a mess. We define external things several times all over the place (we had four  `INFINTE` and one `Infinite` from `windows.h`, and we had several extern functions defined in several places, sometimes differently!). For some reason, rock is OK with all that.

This mainly fixes includes of `windows.h` and some `unistd.h` and `stdlib.h`.

No code added or rewritten, just moved around, and some duplicates deleted.