### PR TITLE
Cleaned up pthread includes

### DIFF
--- a/source/concurrent/Thread.ooc
+++ b/source/concurrent/Thread.ooc
@@ -54,8 +54,8 @@ Thread: abstract class {
 }
 
 version (unix || apple) {
-	include pthread | (_POSIX_C_SOURCE=200809L)
-
+	// This should be in external/pthread.ooc but fails for unknown reason
+	include pthread | (_XOPEN_SOURCE=500, _POSIX_C_SOURCE=200809L)
 	ThreadId: cover from PThread {
 		equals: func (other: This) -> Bool {
 			pthread_equal(this as PThread, other as PThread) != 0

--- a/source/concurrent/native/ConditionUnix.ooc
+++ b/source/concurrent/native/ConditionUnix.ooc
@@ -7,16 +7,6 @@
  */
 
 version(unix || apple) {
-include pthread
-PThreadCond: cover from pthread_cond_t
-PThreadCondAttr: cover from pthread_condattr_t
-
-pthread_cond_init: extern func (cond: PThreadCond*, attr: PThreadCondAttr*) -> Int
-pthread_cond_signal: extern func (cond: PThreadCond*) -> Int
-pthread_cond_broadcast: extern func (cond: PThreadCond*) -> Int
-pthread_cond_wait: extern func (cond: PThreadCond*, mutex: PThreadMutex*) -> Int
-pthread_cond_destroy: extern func (cond: PThreadCond*) -> Int
-
 import ../WaitCondition
 import native/MutexUnix
 

--- a/source/concurrent/native/ThreadUnix.ooc
+++ b/source/concurrent/native/ThreadUnix.ooc
@@ -75,26 +75,18 @@ ThreadUnix: class extends Thread {
 }
 
 // C interface
-include pthread | (_POSIX_C_SOURCE=200809L)
 include sched
 
-PThread: cover from pthread_t
 TimeT: cover from time_t
 TimeSpec: cover from struct timespec {
 	tv_sec: extern TimeT
 	tv_nsec: extern Long
 }
+
+sched_yield: extern func -> Int
+
 version (!apple && !android) {
 	// Using proto here as defining '_GNU_SOURCE' seems to cause more trouble than anything else...
 	pthread_timedjoin_np: extern proto func (thread: PThread, retval: Pointer, abstime: TimeSpec*) -> Int
 }
-
-pthread_create: extern func (threadPointer: PThread*, attributePointer, startRoutine, userArgument: Pointer) -> Int
-pthread_join: extern func (thread: PThread, retval: Pointer*) -> Int
-pthread_kill: extern func (thread: PThread, signal: Int) -> Int
-pthread_self: extern func -> PThread
-pthread_cancel: extern func (thread: PThread) -> Int
-pthread_equal: extern func (thread0, thread1: PThread) -> Int
-pthread_detach: extern func (thread: PThread) -> Int
-sched_yield: extern func -> Int
 }

--- a/source/system/external/pthread.ooc
+++ b/source/system/external/pthread.ooc
@@ -1,0 +1,40 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+version (linux) {
+include pthread | (_XOPEN_SOURCE=500, _POSIX_C_SOURCE=200809L)
+
+PTHREAD_MUTEX_RECURSIVE: extern Int
+
+PThread: cover from pthread_t
+PThreadCond: cover from pthread_cond_t
+PThreadCondAttr: cover from pthread_condattr_t
+PThreadMutex: cover from pthread_mutex_t
+PThreadMutexAttr: cover from pthread_mutexattr_t
+
+pthread_cond_init: extern func (cond: PThreadCond*, attr: PThreadCondAttr*) -> Int
+pthread_cond_signal: extern func (cond: PThreadCond*) -> Int
+pthread_cond_broadcast: extern func (cond: PThreadCond*) -> Int
+pthread_cond_wait: extern func (cond: PThreadCond*, mutex: PThreadMutex*) -> Int
+pthread_cond_destroy: extern func (cond: PThreadCond*) -> Int
+
+pthread_mutex_lock: extern func (PThreadMutex*)
+pthread_mutex_unlock: extern func (PThreadMutex*)
+pthread_mutex_init: extern func (PThreadMutex*, PThreadMutexAttr*)
+pthread_mutex_destroy: extern func (PThreadMutex*)
+pthread_mutexattr_init: extern func (PThreadMutexAttr*)
+pthread_mutexattr_settype: extern func (PThreadMutexAttr*, Int)
+
+pthread_create: extern func (threadPointer: PThread*, attributePointer, startRoutine, userArgument: Pointer) -> Int
+pthread_join: extern func (thread: PThread, retval: Pointer*) -> Int
+pthread_kill: extern func (thread: PThread, signal: Int) -> Int
+pthread_self: extern func -> PThread
+pthread_cancel: extern func (thread: PThread) -> Int
+pthread_equal: extern func (thread0, thread1: PThread) -> Int
+pthread_detach: extern func (thread: PThread) -> Int
+}

--- a/source/system/native/MutexUnix.ooc
+++ b/source/system/native/MutexUnix.ooc
@@ -9,20 +9,6 @@
 import ../Mutex
 
 version(unix || apple) {
-	include pthread | (_XOPEN_SOURCE=500)
-
-	PThreadMutex: cover from pthread_mutex_t
-	PThreadMutexAttr: cover from pthread_mutexattr_t
-
-	pthread_mutex_lock: extern func (PThreadMutex*)
-	pthread_mutex_unlock: extern func (PThreadMutex*)
-	pthread_mutex_init: extern func (PThreadMutex*, PThreadMutexAttr*)
-	pthread_mutex_destroy: extern func (PThreadMutex*)
-	pthread_mutexattr_init: extern func (PThreadMutexAttr*)
-	pthread_mutexattr_settype: extern func (PThreadMutexAttr*, Int)
-
-	PTHREAD_MUTEX_RECURSIVE: extern Int
-
 	MutexUnix: class extends Mutex {
 		_backend: PThreadMutex
 		init: func {

--- a/system.use
+++ b/system.use
@@ -21,6 +21,7 @@ Imports: TextBuffer
 Imports: Text
 Imports: Time
 Imports: VarArgs
+Imports: external/pthread
 Imports: external/signal
 Imports: external/stdlib
 Imports: external/unistd


### PR DESCRIPTION
Resolves issues with all includes of `pthread`. We only had three different include statements. But no duplicated definitions, at least. :)