### PR TITLE
Added external/fcntl.ooc

### DIFF
--- a/source/io/native/PipeUnix.ooc
+++ b/source/io/native/PipeUnix.ooc
@@ -7,16 +7,9 @@
  */
 
 include sys/types, sys/stat
-include fcntl
 import ../Pipe
 
 version(unix || apple) {
-F_SETFL, F_GETFL: extern Int
-O_NONBLOCK: extern Int
-EAGAIN: extern Int
-
-fcntl: extern func (_FileDescriptor, Int, Int) -> Int
-
 _FileDescriptor: cover from Int {
 	write: extern (write) func (Pointer, Int) -> Int
 	read: extern (read) func (Pointer, Int) -> Int

--- a/source/net/berkeley.ooc
+++ b/source/net/berkeley.ooc
@@ -18,9 +18,6 @@ version (windows) {
 	include sys/select
 	include arpa/inet
 	include netdb | (__USE_POSIX)
-	version(!android) {
-		include sys/fcntl
-	}
 }
 
 SockAddr: cover from struct sockaddr {
@@ -138,7 +135,6 @@ htonl: extern func (hostlong: UInt) -> UInt
 htons: extern func (hostshort: UShort) -> UShort
 ntohl: extern func (netlong: UInt) -> UInt
 ntohs: extern func (netshort: UShort) -> UShort
-fcntl: extern func (descriptor, command, argument: Int) -> Int
 
 // getnameinfo constants
 NI_NAMEREQD: extern Int

--- a/source/system/IO.ooc
+++ b/source/system/IO.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-include stdio | (_POSIX_SOURCE), fcntl
+include stdio | (_POSIX_SOURCE)
 
 stdout, stderr, stdin: extern FStream
 

--- a/source/system/external/fcntl.ooc
+++ b/source/system/external/fcntl.ooc
@@ -1,0 +1,20 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+include fcntl
+
+version(!android) {
+	include sys/fcntl
+}
+
+F_SETFL: extern Int
+F_GETFL: extern Int
+O_NONBLOCK: extern Int
+EAGAIN: extern Int
+
+fcntl: extern func (Int, Int, Int) -> Int

--- a/system.use
+++ b/system.use
@@ -22,6 +22,7 @@ Imports: Text
 Imports: Time
 Imports: VarArgs
 Imports: external/errno
+Imports: external/fcntl
 Imports: external/pthread
 Imports: external/signal
 Imports: external/stdlib


### PR DESCRIPTION
This one was also useful. 

Peer review @sebastianbaginski ? Do you know the difference between `fcntl.h` and `sys/fcntl.h`?