### PR TITLE
run tests only if Tests file is generated

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -40,7 +40,10 @@ do
 done
 echo "Main: ./test/Tests.ooc" >> "$TESTS_USE_FILE"
 rm -f .libs/tests-linux64.*
-rock -q +-Wall $ARGS $FLAGS $FEATURES $TESTS_USE_FILE && ./Tests
+rock -q +-Wall $ARGS $FLAGS $FEATURES $TESTS_USE_FILE
+if [[ $? -eq 0 && -f ./Tests ]]; then
+	./Tests
+fi
 if [[ !( $? == 0 ) ]]
 then
 	exit 1


### PR DESCRIPTION
I run with --driver=dummy option which only generates the C sources, without compiling them.
./Tests binary is not generated in this case, so we need to check if it exists before trying to run it.
@fredrikbryntesson review