### PR TITLE
Fixed "tolerance: nan" in some tests

### DIFF
--- a/source/unit/Constraints.ooc
+++ b/source/unit/Constraints.ooc
@@ -83,7 +83,7 @@ CompareConstraint: class extends Constraint {
 
 CompareWithinConstraint: class extends CompareConstraint {
 	actualType: Class
-	precision: LDouble
+	precision: LDouble = -1.0L
 	init: func (parent: ExpectModifier, .correct, .comparer, compareType := ComparisonType Within, =actualType) {
 		super(parent, correct, comparer, compareType)
 	}

--- a/source/unit/Modifiers.ooc
+++ b/source/unit/Modifiers.ooc
@@ -124,65 +124,65 @@ EqualModifier: class extends ExpectModifier {
 		f := func (value, c: Cell<Quaternion>) -> Bool { value get() == c get() }
 		CompareWithinConstraint new(this, Cell<Quaternion> new(correct), f, this withinType, Quaternion)
 	}
-	to: func ~floateuclidtransform (correct: FloatEuclidTransform) -> CompareWithinConstraint {
-		f := func (value, c: Cell<FloatEuclidTransform>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<FloatEuclidTransform> new(correct), f, this withinType, FloatEuclidTransform)
-	}
 	to: func ~floatrotation3d (correct: FloatRotation3D) -> CompareWithinConstraint {
 		f := func (value, c: Cell<FloatRotation3D>) -> Bool { value get() == c get() }
 		CompareWithinConstraint new(this, Cell<FloatRotation3D> new(correct), f, this withinType, FloatRotation3D)
 	}
-	to: func ~floattransform2d (correct: FloatTransform2D) -> CompareWithinConstraint {
+	to: func ~floateuclidtransform (correct: FloatEuclidTransform) -> CompareConstraint {
+		f := func (value, c: Cell<FloatEuclidTransform>) -> Bool { value get() == c get() }
+		CompareConstraint new(this, Cell<FloatEuclidTransform> new(correct), f, this comparisonType)
+	}
+	to: func ~floattransform2d (correct: FloatTransform2D) -> CompareConstraint {
 		f := func (value, c: Cell<FloatTransform2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<FloatTransform2D> new(correct), f, this withinType, FloatTransform2D)
+		CompareConstraint new(this, Cell<FloatTransform2D> new(correct), f, this comparisonType)
 	}
-	to: func ~floattransform3d (correct: FloatTransform3D) -> CompareWithinConstraint {
+	to: func ~floattransform3d (correct: FloatTransform3D) -> CompareConstraint {
 		f := func (value, c: Cell<FloatTransform3D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<FloatTransform3D> new(correct), f, this withinType, FloatTransform3D)
+		CompareConstraint new(this, Cell<FloatTransform3D> new(correct), f, this comparisonType)
 	}
-	to: func ~intvector2d (correct: IntVector2D) -> CompareWithinConstraint {
+	to: func ~intvector2d (correct: IntVector2D) -> CompareConstraint {
 		f := func (value, c: Cell<IntVector2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<IntVector2D> new(correct), f, this withinType, IntVector2D)
+		CompareConstraint new(this, Cell<IntVector2D> new(correct), f, this comparisonType)
 	}
-	to: func ~intvector3d (correct: IntVector3D) -> CompareWithinConstraint {
+	to: func ~intvector3d (correct: IntVector3D) -> CompareConstraint {
 		f := func (value, c: Cell<IntVector3D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<IntVector3D> new(correct), f, this withinType, IntVector3D)
+		CompareConstraint new(this, Cell<IntVector3D> new(correct), f, this comparisonType)
 	}
-	to: func ~intpoint2d (correct: IntPoint2D) -> CompareWithinConstraint {
+	to: func ~intpoint2d (correct: IntPoint2D) -> CompareConstraint {
 		f := func (value, c: Cell<IntPoint2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<IntPoint2D> new(correct), f, this withinType, IntPoint2D)
+		CompareConstraint new(this, Cell<IntPoint2D> new(correct), f, this comparisonType)
 	}
-	to: func ~intpoint3d (correct: IntPoint3D) -> CompareWithinConstraint {
+	to: func ~intpoint3d (correct: IntPoint3D) -> CompareConstraint {
 		f := func (value, c: Cell<IntPoint3D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<IntPoint3D> new(correct), f, this withinType, IntPoint3D)
+		CompareConstraint new(this, Cell<IntPoint3D> new(correct), f, this comparisonType)
 	}
-	to: func ~floatcomplex (correct: FloatComplex) -> CompareWithinConstraint {
+	to: func ~floatcomplex (correct: FloatComplex) -> CompareConstraint {
 		f := func (value, c: Cell<FloatComplex>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<FloatComplex> new(correct), f, this withinType, FloatComplex)
+		CompareConstraint new(this, Cell<FloatComplex> new(correct), f, this comparisonType)
 	}
-	to: func ~floatmatrix (correct: FloatMatrix) -> CompareWithinConstraint {
+	to: func ~floatmatrix (correct: FloatMatrix) -> CompareConstraint {
 		f := func (value, c: Cell<FloatMatrix>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<FloatMatrix> new(correct), f, this withinType, FloatMatrix)
+		CompareConstraint new(this, Cell<FloatMatrix> new(correct), f, this comparisonType)
 	}
-	to: func ~inttransform2d (correct: IntTransform2D) -> CompareWithinConstraint {
+	to: func ~inttransform2d (correct: IntTransform2D) -> CompareConstraint {
 		f := func (value, c: Cell<IntTransform2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<IntTransform2D> new(correct), f, this withinType, IntTransform2D)
+		CompareConstraint new(this, Cell<IntTransform2D> new(correct), f, this comparisonType)
 	}
-	to: func ~floatbox2d (correct: FloatBox2D) -> CompareWithinConstraint {
+	to: func ~floatbox2d (correct: FloatBox2D) -> CompareConstraint {
 		f := func (value, c: Cell<FloatBox2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<FloatBox2D> new(correct), f, this withinType, FloatBox2D)
+		CompareConstraint new(this, Cell<FloatBox2D> new(correct), f, this comparisonType)
 	}
-	to: func ~intbox2d (correct: IntBox2D) -> CompareWithinConstraint {
+	to: func ~intbox2d (correct: IntBox2D) -> CompareConstraint {
 		f := func (value, c: Cell<IntBox2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<IntBox2D> new(correct), f, this withinType, IntBox2D)
+		CompareConstraint new(this, Cell<IntBox2D> new(correct), f, this comparisonType)
 	}
-	to: func ~floatshell2d (correct: FloatShell2D) -> CompareWithinConstraint {
+	to: func ~floatshell2d (correct: FloatShell2D) -> CompareConstraint {
 		f := func (value, c: Cell<FloatShell2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<FloatShell2D> new(correct), f, this withinType, FloatShell2D)
+		CompareConstraint new(this, Cell<FloatShell2D> new(correct), f, this comparisonType)
 	}
-	to: func ~intshell2d (correct: IntShell2D) -> CompareWithinConstraint {
+	to: func ~intshell2d (correct: IntShell2D) -> CompareConstraint {
 		f := func (value, c: Cell<IntShell2D>) -> Bool { value get() == c get() }
-		CompareWithinConstraint new(this, Cell<IntShell2D> new(correct), f, this withinType, IntShell2D)
+		CompareConstraint new(this, Cell<IntShell2D> new(correct), f, this comparisonType)
 	}
 }
 

--- a/test/geometry/FloatBox2DTest.ooc
+++ b/test/geometry/FloatBox2DTest.ooc
@@ -19,6 +19,9 @@ FloatBox2DTest: class extends Fixture {
 	init: func {
 		tolerance := 1.0e-5f
 		super("FloatBox2D")
+		this add("fixture", func {
+			expect(this box0, is equal to(this box0))
+		})
 		this add("equality", func {
 			box := FloatBox2D new()
 			expect(this box0 == this box0, is true)

--- a/test/geometry/FloatEuclidTransformTest.ooc
+++ b/test/geometry/FloatEuclidTransformTest.ooc
@@ -15,6 +15,9 @@ FloatEuclidTransformTest: class extends Fixture {
 	init: func {
 		tolerance := 1.0e-5f
 		super("FloatEuclidTransform")
+		this add("fixture", func {
+			expect(FloatEuclidTransform new(FloatVector3D new(0, 0, 0), FloatRotation3D identity), is equal to(FloatEuclidTransform new(FloatVector3D new(0, 0, 0), FloatRotation3D identity)))
+		})
 		this add("convolveCenter translations 1", func {
 			euclidTransforms := VectorList<FloatEuclidTransform> new(5)
 			kernel := FloatVectorList new(5)

--- a/test/geometry/FloatShell2DTest.ooc
+++ b/test/geometry/FloatShell2DTest.ooc
@@ -15,6 +15,9 @@ FloatShell2DTest: class extends Fixture {
 	init: func {
 		super("FloatShell2D")
 		tolerance := 0.0001f
+		this add("fixture", func {
+			expect(FloatShell2D new(1.0f, 2.0f, 3.0f, 4.0f), is equal to(FloatShell2D new(1.0f, 2.0f, 3.0f, 4.0f)))
+		})
 		this add("Size and position", func {
 			shell := FloatShell2D new(1.0f, 2.0f, 3.0f, 4.0f)
 			expect(shell size x, is equal to(3.0f) within(tolerance))

--- a/test/geometry/FloatTransform2DTest.ooc
+++ b/test/geometry/FloatTransform2DTest.ooc
@@ -23,6 +23,9 @@ FloatTransform2DTest: class extends Fixture {
 	init: func {
 		tolerance := 1.0e-5f
 		super("FloatTransform2D")
+		this add("fixture", func {
+			expect(this transform0, is equal to(this transform0))
+		})
 		this add("equality", func {
 			transform := FloatTransform2D new()
 			expect(this transform0 == this transform0, is true)

--- a/test/geometry/FloatTransform3DTest.ooc
+++ b/test/geometry/FloatTransform3DTest.ooc
@@ -21,6 +21,9 @@ FloatTransform3DTest: class extends Fixture {
 	init: func {
 		tolerance := 1.0e-5f
 		super("FloatTransform3D")
+		this add("fixture", func {
+			expect(this transform0, is equal to(this transform0))
+		})
 		this add("equality", func {
 			transform := FloatTransform3D new()
 			expect(this transform0 == this transform0, is true)

--- a/test/geometry/IntBox2DTest.ooc
+++ b/test/geometry/IntBox2DTest.ooc
@@ -16,6 +16,9 @@ IntBox2DTest: class extends Fixture {
 	box2 := IntBox2D new (2, 1, 4, 3)
 	init: func {
 		super("IntBox2D")
+		this add("fixture", func {
+			expect(this box0, is equal to(this box0))
+		})
 		this add("equality", func {
 			box := IntBox2D new()
 			expect(this box0 == this box0, is true)

--- a/test/geometry/IntShell2DTest.ooc
+++ b/test/geometry/IntShell2DTest.ooc
@@ -14,6 +14,9 @@ use unit
 IntShell2DTest: class extends Fixture {
 	init: func {
 		super("IntShell2D")
+		this add("fixture", func {
+			expect(IntShell2D new(1, 2, 3, 4), is equal to(IntShell2D new(1, 2, 3, 4)))
+		})
 		this add("Size and position", func {
 			shell := IntShell2D new(1, 2, 3, 4)
 			expect(shell size x, is equal to(3))

--- a/test/geometry/IntTransform2DTest.ooc
+++ b/test/geometry/IntTransform2DTest.ooc
@@ -20,6 +20,9 @@ IntTransform2DTest: class extends Fixture {
 	size := IntVector2D new(10, 10)
 	init: func {
 		super("IntTransform2D")
+		this add("fixture", func {
+			expect(this transform0 * this transform1, is equal to(this transform2))
+		})
 		this add("equality", func {
 			transform := IntTransform2D new()
 			expect(this transform0 == this transform0, is true)

--- a/test/math/FloatComplexTest.ooc
+++ b/test/math/FloatComplexTest.ooc
@@ -27,6 +27,9 @@ FloatComplexTest: class extends Fixture {
 	init: func {
 		tolerance := 1.0e-5f
 		super("FloatComplex")
+		this add("fixture", func {
+			expect(this complexNumber0 + this complexNumber1, is equal to(this complexNumber2 real) within(tolerance))
+		})
 		this add("addition", func {
 			expect((this complexNumber0 + this complexNumber1) real, is equal to(this complexNumber2 real))
 			expect((this complexNumber0 + this complexNumber1) imaginary, is equal to(this complexNumber2 imaginary))

--- a/test/math/FloatMatrixTest.ooc
+++ b/test/math/FloatMatrixTest.ooc
@@ -18,6 +18,9 @@ FloatMatrixTest: class extends Fixture {
 	init: func {
 		tolerance := 1.0e-5f
 		super ("FloatMatrix")
+		this add("fixture", func {
+			expect(FloatMatrix identity(3) take(), is equal to(FloatMatrix identity(3) take()))
+		})
 		this add("identity", func {
 			this checkAllElements(FloatMatrix identity(3), [1.0f, 0, 0, 0, 1.0f, 0, 0, 0, 1.0f])
 		})


### PR DESCRIPTION
Turns out it was not a problem with the testing, but rather that `Fixture` tried to read `tolerance` even though it did not exist because `within()` was never called.

Also added tests for all types supported by `Fixture`.

Closes #1575 