### PR TITLE
Added 'is within(...)' method to unit tests

### DIFF
--- a/source/system/Cell.ooc
+++ b/source/system/Cell.ooc
@@ -48,6 +48,8 @@ Cell: class <T> {
 			result = (this val as Double) toText()
 		else if (T inheritsFrom(LDouble))
 			result = (this val as LDouble) toText()
+		else if (T inheritsFrom(Range))
+			result = (this val as Range) toText()
 		else
 			raise("[Cell] toText() is not implemented on the specified type")
 		result

--- a/source/system/Numbers.ooc
+++ b/source/system/Numbers.ooc
@@ -114,6 +114,9 @@ LDouble: cover from long double {
 		string free()
 		result
 	}
+	in: func (range: Range) -> Bool {
+		this >= range min && this < range max
+	}
 }
 
 Double: cover from double extends LDouble {
@@ -142,5 +145,14 @@ Range: cover {
 		acc := f(this min, this min + 1)
 		for (i in this min + 2 .. this max) acc = f(acc, i)
 		acc
+	}
+	toString: func -> String {
+		"%d, %d" format(this min, this max)
+	}
+	toText: func -> Text {
+		string := this toString()
+		result := Text new(string) copy()
+		string free()
+		result
 	}
 }

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -69,6 +69,8 @@ Fixture: abstract class {
 					This _print(Text new("  -> %s : expected true was false\n" format(f message)))
 				else if (f constraint instanceOf(FalseConstraint))
 					This _print(Text new("  -> %s : expected false was true\n" format(f message)))
+				else if (f constraint instanceOf(RangeConstraint))
+					This _print(this createRangeFailureMessage(f) + t"\n")
 				else
 					This _print(t"  -> %s (expect: %i)\n" format(f message, f expect))
 				f free()
@@ -122,6 +124,20 @@ Fixture: abstract class {
 		result append(expectedText) . append(t"was") . append(testedText)
 		if (constraint type == ComparisonType Within)
 			result append(Text new(" [tolerance: %.8f]" formatDouble((constraint parent as CompareWithinConstraint) precision)))
+		result join(' ')
+	}
+	createRangeFailureMessage: func (failure: TestFailedException) -> Text {
+		constraint := failure constraint as RangeConstraint
+		testedValue := failure value as Cell
+		result := TextBuilder new(t"  ->")
+		result append(Text new(failure message))
+		result append(t": expected within")
+		match (constraint type) {
+			case 0 => result append(constraint intMin toText()) . append(t"and") . append(constraint intMax toText())
+			case 1 => result append(constraint floatMin toText()) . append(t"and") . append(constraint floatMax toText())
+		}
+		result append(t"was")
+		result append(testedValue toText())
 		result join(' ')
 	}
 

--- a/test/concurrent/SynchronizedQueueTest.ooc
+++ b/test/concurrent/SynchronizedQueueTest.ooc
@@ -85,7 +85,7 @@ SynchronizedQueueTest: class extends Fixture {
 		job = func {
 			for (i in 0 .. countPerThread) {
 				value := queue dequeue(Int minimumValue)
-				expect(value >= 0 && value < countPerThread)
+				expect(value, is within(0, countPerThread))
 			}
 		}
 		for (i in 0 .. numberOfThreads) {
@@ -124,7 +124,7 @@ SynchronizedQueueTest: class extends Fixture {
 			for (i in 0 .. countPerThread) {
 				value: Cell<Int>
 				value = queue dequeue(null)
-				expect(value get() >= 0 && value get() < countPerThread)
+				expect(value get(), is within(0, countPerThread))
 				value free()
 			}
 		}

--- a/test/math/FloatRandomGeneratorTest.ooc
+++ b/test/math/FloatRandomGeneratorTest.ooc
@@ -21,7 +21,7 @@ FloatRandomGeneratorTest: class extends Fixture {
 			for (i in 0 .. valuesCount) {
 				if (last == current)
 					countEqual += 1
-				expect(last >= 0.0f && last <= 1.0f)
+				expect(last, is within(0.f, 1.f))
 				last = current
 				current = generator next()
 			}
@@ -36,7 +36,7 @@ FloatRandomGeneratorTest: class extends Fixture {
 			generator = FloatUniformRandomGenerator new(15.0f, 20.0f)
 			for (i in 0 .. valuesCount) {
 				result := generator next()
-				expect(result >= 15.0f && result <= 20.0f)
+				expect(result, is within(15.0f, 20.0f))
 			}
 			numbers free()
 			generator free()


### PR DESCRIPTION
Instead of
```ooc
expect(myValue >= 4.f && myValue < 12.f)
```
it is now possible to do stuff like 
```ooc
expect(myValue, is within(4 .. 12))
```
which is cleaner and gives correct error messages if the test fails, for example:
```
  -> uniform : expected within 12 and 16 was 4.00
```

Also:
- added `toText` for `Range` although it wasn't needed in the final result, but it doesn't hurt to have.
- added the `ìn` method for float-point types as for integer types.

Peer review @sebastianbaginski ?