### PR TITLE
Cleaned up unit test framework

### DIFF
--- a/source/unit/Constraints.ooc
+++ b/source/unit/Constraints.ooc
@@ -23,61 +23,50 @@ ComparisonType: enum {
 	NotWithin
 }
 
-IsConstraints: class extends ExpectModifier {
-	true ::= TrueConstraint new(this)
-	false ::= FalseConstraint new(this)
-	Null ::= NullConstraint new(this)
-	notNull ::= NotNullConstraint new(this)
-	equal ::= EqualModifier new(this)
-	notEqual ::= EqualModifier new(this, ComparisonType NotEqual)
-	less ::= LessModifier new(this)
-	lessOrEqual ::= LessModifier new(this, true)
-	greater ::= GreaterModifier new(this)
-	greaterOrEqual ::= GreaterModifier new(this, true)
+is: abstract class {
+	true ::= static TrueConstraint new()
+	false ::= static FalseConstraint new()
+	Null ::= static NullConstraint new()
+	notNull ::= static NotNullConstraint new()
+	equal ::= static EqualModifier new()
+	notEqual ::= static EqualModifier new(ComparisonType NotEqual)
+	less ::= static LessModifier new()
+	lessOrEqual ::= static LessModifier new(ComparisonType LessOrEqual)
+	greater ::= static GreaterModifier new()
+	greaterOrEqual ::= static GreaterModifier new(ComparisonType GreaterOrEqual)
+	within: static func ~range (range: Range) -> RangeConstraint { RangeConstraint new(range min, range max) }
+	within: static func ~int (min, max: Int) -> RangeConstraint { RangeConstraint new(min, max) }
+	within: static func ~float (min, max: Float) -> RangeConstraint { RangeConstraint new(min, max) }
+}
+
+TrueConstraint: class extends ExpectModifier {
 	init: func
-	within: func ~range (range: Range) -> RangeConstraint { RangeConstraint new(this, range) }
-	within: func ~int (min, max: Int) -> RangeConstraint { RangeConstraint new(this, min, max) }
-	within: func ~float (min, max: Float) -> RangeConstraint { RangeConstraint new(this, min, max) }
-}
-
-Constraint: abstract class extends ExpectModifier {
-	init: func ~parent (parent: ExpectModifier) { super(parent) }
-}
-
-TrueConstraint: class extends Constraint {
-	init: func ~parent (parent: ExpectModifier) { super(parent) }
 	test: override func (value: Object) -> Bool { value as Cell<Bool> get() }
 }
 
-FalseConstraint: class extends Constraint {
-	init: func ~parent (parent: ExpectModifier) { super(parent) }
+FalseConstraint: class extends ExpectModifier {
+	init: func
 	test: override func (value: Object) -> Bool { !value as Cell<Bool> get() }
 }
 
-NullConstraint: class extends Constraint {
-	init: func ~parent (parent: ExpectModifier) { super(parent) }
+NullConstraint: class extends ExpectModifier {
+	init: func
 	test: override func (value: Object) -> Bool { value == null }
 }
 
-NotNullConstraint: class extends Constraint {
-	init: func ~parent (parent: ExpectModifier) { super(parent) }
+NotNullConstraint: class extends ExpectModifier {
+	init: func
 	test: override func (value: Object) -> Bool { value != null }
 }
 
-RangeConstraint: class extends Constraint {
+RangeConstraint: class extends ExpectModifier {
 	type := -1
 	intMin, intMax: Int
 	floatMin, floatMax: Float
-	init: func ~range (parent: ExpectModifier, range: Range) {
-		super(parent)
-		(this intMin, this intMax, this type) = (range min, range max, 0)
-	}
-	init: func ~int (parent: ExpectModifier, min, max: Int) {
-		super(parent)
+	init: func ~int (min, max: Int) {
 		(this intMin, this intMax, this type) = (min, max, 0)
 	}
-	init: func ~float (parent: ExpectModifier, min, max: Float) {
-		super(parent)
+	init: func ~float (min, max: Float) {
 		(this floatMin, this floatMax, this type) = (min, max, 1)
 	}
 	test: override func (value: Object) -> Bool {
@@ -101,7 +90,7 @@ RangeConstraint: class extends Constraint {
 	}
 }
 
-CompareConstraint: class extends Constraint {
+CompareConstraint: class extends ExpectModifier {
 	comparer: Func (Object, Object) -> Bool
 	correct: Object
 	type: ComparisonType

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -145,7 +145,6 @@ Fixture: abstract class {
 	_expectCount: static Int = 0
 	totalTime: static Double
 	failureNames: static VectorList<String>
-	is ::= static IsConstraints new()
 	testsFailed: static Bool { get { This _testsFailed } }
 
 	printFailures: static func {
@@ -161,7 +160,7 @@ Fixture: abstract class {
 		text print()
 		fflush(stdout)
 	}
-	verify: static func (value: Object, constraint: Constraint) {
+	verify: static func (value: Object, constraint: ExpectModifier) {
 		This _expectCount += 1
 		if (!constraint verify(value))
 			TestFailedException new(value, constraint, This _expectCount) throw()
@@ -175,7 +174,7 @@ Fixture: abstract class {
 
 TestFailedException: class extends Exception {
 	value: Object
-	constraint: Constraint
+	constraint: ExpectModifier
 	expect: Int
 	init: func (=value, =constraint, =expect, message := "") { super(message) }
 }
@@ -192,39 +191,39 @@ Test: class {
 	run: func { this action() }
 }
 
-expect: func ~isTrue (value: Bool) { Fixture verify(Cell new(value), Fixture is true) }
-expect: func ~object (value: Object, constraint: Constraint) { Fixture verify(value, constraint) }
-expect: func ~char (value: Char, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~text (value: Text, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~boolean (value: Bool, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~int (value: Int, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~uint (value: UInt, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~uint8 (value: Byte, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~long (value: Long, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~ulong (value: ULong, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~float (value: Float, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~double (value: Double, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~ldouble (value: LDouble, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~llong (value: LLong, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~ullong (value: ULLong, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
+expect: func ~isTrue (value: Bool) { Fixture verify(Cell new(value), is true) }
+expect: func ~object (value: Object, constraint: ExpectModifier) { Fixture verify(value, constraint) }
+expect: func ~char (value: Char, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~text (value: Text, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~boolean (value: Bool, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~int (value: Int, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~uint (value: UInt, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~uint8 (value: Byte, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~long (value: Long, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~ulong (value: ULong, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~float (value: Float, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~double (value: Double, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~ldouble (value: LDouble, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~llong (value: LLong, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~ullong (value: ULLong, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
 
-expect: func ~floatvector2d (value: FloatVector2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatvector3d (value: FloatVector3D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatpoint2d (value: FloatPoint2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatpoint3d (value: FloatPoint3D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~quaternion (value: Quaternion, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floateuclidtransform (value: FloatEuclidTransform, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatrotation3d (value: FloatRotation3D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floattransform2d (value: FloatTransform2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floattransform3d (value: FloatTransform3D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~intvector2d (value: IntVector2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~intvector3d (value: IntVector3D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~intpoint2d (value: IntPoint2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~intpoint3d (value: IntPoint3D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatcomplex (value: FloatComplex, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatmatrix (value: FloatMatrix, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~inttransform2d (value: IntTransform2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatbox2d (value: FloatBox2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~intbox2d (value: IntBox2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~floatshell2d (value: FloatShell2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
-expect: func ~intshell2d (value: IntShell2D, constraint: Constraint) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatvector2d (value: FloatVector2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatvector3d (value: FloatVector3D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatpoint2d (value: FloatPoint2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatpoint3d (value: FloatPoint3D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~quaternion (value: Quaternion, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floateuclidtransform (value: FloatEuclidTransform, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatrotation3d (value: FloatRotation3D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floattransform2d (value: FloatTransform2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floattransform3d (value: FloatTransform3D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~intvector2d (value: IntVector2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~intvector3d (value: IntVector3D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~intpoint2d (value: IntPoint2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~intpoint3d (value: IntPoint3D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatcomplex (value: FloatComplex, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatmatrix (value: FloatMatrix, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~inttransform2d (value: IntTransform2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatbox2d (value: FloatBox2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~intbox2d (value: IntBox2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~floatshell2d (value: FloatShell2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }
+expect: func ~intshell2d (value: IntShell2D, constraint: ExpectModifier) { Fixture verify(Cell new(value), constraint) }

--- a/source/unit/Modifiers.ooc
+++ b/source/unit/Modifiers.ooc
@@ -13,7 +13,7 @@ import Constraints
 ExpectModifier: abstract class {
 	parent: This = null
 	child: This = null
-	init: func ~parent (=parent)
+	init: func (=parent)
 	free: override func {
 		if (this child) {
 			if (this child parent == this)
@@ -27,7 +27,7 @@ ExpectModifier: abstract class {
 		}
 		super()
 	}
-	verify: func ~parent (value: Object, _child: This = null) -> Bool {
+	verify: func (value: Object, _child: This = null) -> Bool {
 		this child = _child
 		this parent != null ? this parent verify(value, this): this test(value)
 	}
@@ -38,8 +38,7 @@ ExpectModifier: abstract class {
 EqualModifier: class extends ExpectModifier {
 	comparisonType: ComparisonType
 	withinType: ComparisonType
-	init: func ~parent (parent: ExpectModifier, type := ComparisonType Equal) {
-		super(parent)
+	init: func (type := ComparisonType Equal) {
 		this comparisonType = type
 		this withinType = type == ComparisonType Equal ? ComparisonType Within : ComparisonType NotWithin
 	}
@@ -189,10 +188,9 @@ EqualModifier: class extends ExpectModifier {
 LessModifier: class extends ExpectModifier {
 	allowEquality: Bool
 	typeToPass: ComparisonType
-	init: func ~parent (parent: ExpectModifier, allowEquals := false) {
-		super(parent)
-		this allowEquality = allowEquals
-		this typeToPass = allowEquals ? ComparisonType LessOrEqual : ComparisonType LessThan
+	init: func (comparisonType := ComparisonType LessThan) {
+		this typeToPass = comparisonType
+		this allowEquality = comparisonType == ComparisonType LessOrEqual
 	}
 	than: func ~object (right: Object) -> CompareConstraint {
 		f := func (value, c: Object) -> Bool { this allowEquality ? value <= c : value < c }
@@ -239,10 +237,9 @@ LessModifier: class extends ExpectModifier {
 GreaterModifier: class extends ExpectModifier {
 	allowEquality: Bool
 	typeToPass: ComparisonType
-	init: func ~parent (parent: ExpectModifier, allowEquals := false) {
-		super(parent)
-		this allowEquality = allowEquals
-		this typeToPass = allowEquals ? ComparisonType GreaterOrEqual : ComparisonType GreaterThan
+	init: func (comparisonType := ComparisonType GreaterThan) {
+		this typeToPass = comparisonType
+		this allowEquality = comparisonType == ComparisonType GreaterOrEqual
 	}
 	than: func ~object (right: Object) -> CompareConstraint {
 		f := func (value, c: Object) -> Bool { this allowEquality ? value >= c : value > c }


### PR DESCRIPTION
Done here:
- Removed the useless `Constraint` class.
- Removed the `Range` constructor from `RangeConstraint`.
- Removed all `~parent` suffixes.
- Made sure noone has `Is` as parent, so that it isn't freed after every expect call.
- Properly using `ComparisonType` when creating `lessOrEqual` and `greaterOrEqual` constraints.
- Renamed `IsConstraints` to `is` and made it abstract
- Removed the `is` property from `Fixture`
- Through the above, removed the need for implicit `This` when using `is`
- Moderate speedup of unit tests since we're not creating and freeing an `IsConstraints` and an extra `ExpectModifier` instance on every `expect` call.
- Verify that no new memory leaks have been introduced
- Fixes #1584 

Remaining work:
- Check if all this resolves any/all problems in #1409 or #1523 