### PR TITLE
Raster* distance() only checks 50% of pixels

### DIFF
--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -87,8 +87,9 @@ RasterMonochrome: class extends RasterPacked {
 			result = this distance(converted)
 			converted referenceCount decrease()
 		} else {
-			for (y in 0 .. this size y)
-				for (x in 0 .. this size x) {
+			for (y in 0 .. this size y) {
+				x := y % 2
+				while (x < this size x) {
 					c := this[x, y]
 					o := (other as This)[x, y]
 					if (c distance(o) > 0) {
@@ -110,8 +111,10 @@ RasterMonochrome: class extends RasterPacked {
 							distance += (c y - maximum y) as Float squared
 						result += distance sqrt()
 					}
+					x += 2
 				}
-			result /= (this size x squared + this size y squared as Float sqrt())
+			}
+			result /= ((this size x squared + this size y squared) as Float sqrt())
 		}
 		result
 	}

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -82,8 +82,9 @@ RasterRgb: class extends RasterPacked {
 			result = this distance(converted)
 			converted referenceCount decrease()
 		} else {
-			for (y in 0 .. this size y)
-				for (x in 0 .. this size x) {
+			for (y in 0 .. this size y) {
+				x := y % 2
+				while (x < this size x) {
 					c := this[x, y]
 					o := (other as This)[x, y]
 					if (c distance(o) > 0) {
@@ -121,7 +122,9 @@ RasterRgb: class extends RasterPacked {
 							distance += (c r - maximum r) as Float squared
 						result += (distance) sqrt() / 3
 					}
+					x += 2
 				}
+			}
 			result /= this size length
 		}
 		result

--- a/source/draw/RasterRgba.ooc
+++ b/source/draw/RasterRgba.ooc
@@ -66,8 +66,9 @@ RasterRgba: class extends RasterPacked {
 			result = this distance(converted)
 			converted referenceCount decrease()
 		} else {
-			for (y in 0 .. this size y)
-				for (x in 0 .. this size x) {
+			for (y in 0 .. this size y) {
+				x := y % 2
+				while (x < this size x) {
 					c := this[x, y]
 					o := (other as This)[x, y]
 					if (c distance(o) > 0) {
@@ -113,7 +114,9 @@ RasterRgba: class extends RasterPacked {
 							distance += (c a - maximum a) as Float squared
 						result += (distance) sqrt() / 4
 					}
+					x += 2
 				}
+			}
 			result /= this size length
 		}
 		result

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -84,8 +84,9 @@ RasterUv: class extends RasterPacked {
 			result = this distance(converted)
 			converted referenceCount decrease()
 		} else {
-			for (y in 0 .. this size y)
-				for (x in 0 .. this size x) {
+			for (y in 0 .. this size y) {
+				x := y % 2
+				while (x < this size x) {
 					c := this[x, y]
 					o := (other as This)[x, y]
 					if (c distance(o) > 0) {
@@ -115,7 +116,9 @@ RasterUv: class extends RasterPacked {
 							distance += (c v - maximum v) as Float squared
 						result += (distance) sqrt() / 3
 					}
+					x += 2
 				}
+			}
 			result /= ((this size x squared + this size y squared) as Float sqrt())
 		}
 		result

--- a/source/draw/RasterYuvPlanar.ooc
+++ b/source/draw/RasterYuvPlanar.ooc
@@ -66,8 +66,9 @@ RasterYuvPlanar: abstract class extends RasterPlanar {
 		if (!other || (this size != other size) || !other instanceOf(This))
 			result = Float maximumValue
 		else {
-			for (y in 0 .. this size y)
-				for (x in 0 .. this size x) {
+			for (y in 0 .. this size y) {
+				x := y % 2
+				while (x < this size x) {
 					c := this[x, y]
 					o := (other as This)[x, y]
 					if (c distance(o) > 0) {
@@ -105,7 +106,9 @@ RasterYuvPlanar: abstract class extends RasterPlanar {
 							distance += (c v - maximum v) as Float squared
 						result += (distance) sqrt() / 3
 					}
+					x += 2
 				}
+			}
 			result /= this size length
 		}
 	}

--- a/source/draw/RasterYuvSemiplanar.ooc
+++ b/source/draw/RasterYuvSemiplanar.ooc
@@ -61,8 +61,9 @@ RasterYuvSemiplanar: abstract class extends RasterPlanar {
 		if (!other || (this size != other size) || !other instanceOf(This))
 			result = Float maximumValue
 		else {
-			for (y in 0 .. this size y)
-				for (x in 0 .. this size x) {
+			for (y in 0 .. this size y) {
+				x := y % 2
+				while (x < this size x) {
 					c := this[x, y]
 					o := (other as This)[x, y]
 					if (c distance(o) > 0) {
@@ -100,7 +101,9 @@ RasterYuvSemiplanar: abstract class extends RasterPlanar {
 							distance += (c v - maximum v) as Float squared
 						result += (distance) sqrt() / 3
 					}
+					x += 2
 				}
+			}
 			result /= this size length
 		}
 	}


### PR DESCRIPTION
Reduces the runtime of the `draw` tests by about 15-20%.
Fixes #1551 (?)