### PR TITLE
fixed wake and wakeAll in WaitLock

### DIFF
--- a/source/concurrent/ThreadPool.ooc
+++ b/source/concurrent/ThreadPool.ooc
@@ -55,8 +55,8 @@ _Task: abstract class {
 			this _mutex unlock()
 			this free()
 		} else {
-			this _mutex unlock()
 			this _waitCondition broadcast()
+			this _mutex unlock()
 		}
 	}
 }

--- a/source/concurrent/WaitLock.ooc
+++ b/source/concurrent/WaitLock.ooc
@@ -34,6 +34,16 @@ WaitLock: class {
 		(condition as Closure) free(Owner Receiver)
 	}
 	with: func (f: Func) { this _mutex with(f) }
-	wake: func -> Bool { this _waitCondition signal() }
-	wakeAll: func -> Bool { this _waitCondition broadcast() }
+	wake: func -> Bool {
+		this lock()
+		result := this _waitCondition signal()
+		this unlock()
+		result
+	}
+	wakeAll: func -> Bool {
+		this lock()
+		result := this _waitCondition broadcast()
+		this unlock()
+		result
+	}
 }


### PR DESCRIPTION
According to pthread documentation, 
```
lock()
broadcast() / signal()
unlock()
```
is a better way to signal waiting threads: 
>  if predictable scheduling behavior is required, then that mutex shall be locked by the thread calling pthread_cond_broadcast() or pthread_cond_signal()
( http://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_cond_broadcast.html ) 

Qt implementation of Wait Condition for reference:
http://code.qt.io/cgit/qt/qt.git/tree/src/corelib/thread/qwaitcondition_unix.cpp#n129

@marcusnaslund peer review