### PR TITLE
CPU shaders

### DIFF
--- a/draw.use
+++ b/draw.use
@@ -24,6 +24,7 @@ Imports: FloatImage
 Imports: Canvas
 Imports: Pen
 Imports: Map
+Imports: CpuMap
 Imports: Mesh
 Imports: DrawState
 Additionals: source/draw/stb_image/stb_image.h

--- a/source/draw/CpuMap.ooc
+++ b/source/draw/CpuMap.ooc
@@ -1,0 +1,42 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+use base
+use geometry
+use draw
+use collections
+
+CpuMap: class extends Map {
+	init: func
+	// Pre-conditions: target and inputImage in drawState inherits RasterPacked
+	// Side-effects: Renders a quad to drawState target using the settings in drawState
+	// Bottlenecks: All texture access will be faster for known texture types
+	render: virtual static func (drawState: DrawState) {
+		if (drawState inputImage == null)
+			raise("Needs input image!")
+		else if (!drawState inputImage inheritsFrom(RasterPacked))
+			raise("Needs packed CPU image!")
+		else {
+			finalViewport := drawState viewport intersection(IntBox2D new(drawState target size))
+			dx := 1.0f / (finalViewport width as Float)
+			dy := 1.0f / (finalViewport height as Float)
+			readY := 0.0f
+			for (writeY in finalViewport top .. finalViewport bottom) {
+				readY += dy
+				readX := 0.0f
+				for (writeX in finalViewport left .. finalViewport right) {
+					readX += dx
+					// Pixel shader
+					outputColor := (drawState inputImage as RasterPacked) samplePixelGpuClamped(readX, readY)
+					// Blend stage (skip to clip pixels)
+					(drawState target as RasterPacked) writePixelGpu(writeX, writeY, outputColor)
+				}
+			}
+		}
+	}
+}

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -224,4 +224,10 @@ RasterMonochrome: class extends RasterPacked {
 		}
 		result
 	}
+	writePixelGpu: override func (x, y: Int, color: ColorRgba) {
+		this[x, y] = ColorMonochrome new(color r)
+	}
+	readPixelGpu: override func (x, y: Int) -> ColorRgba {
+		ColorRgba new(this[x, y] y, 0, 0, 255)
+	}
 }

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -181,4 +181,11 @@ RasterRgb: class extends RasterPacked {
 		}
 		result
 	}
+	writePixelGpu: override func (x, y: Int, color: ColorRgba) {
+		this[x, y] = ColorRgb new(color r, color g, color b)
+	}
+	readPixelGpu: override func (x, y: Int) -> ColorRgba {
+		color := this[x, y]
+		ColorRgba new(color r, color g, color b, 255)
+	}
 }

--- a/source/draw/RasterRgba.ooc
+++ b/source/draw/RasterRgba.ooc
@@ -193,4 +193,11 @@ RasterRgba: class extends RasterPacked {
 		}
 		result
 	}
+	writePixelGpu: override func (x, y: Int, color: ColorRgba) {
+		this[x, y] = ColorRgba new(color r, color g, color b, color a)
+	}
+	readPixelGpu: override func (x, y: Int) -> ColorRgba {
+		color := this[x, y]
+		ColorRgba new(color r, color g, color b, color a)
+	}
 }

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -161,4 +161,11 @@ RasterUv: class extends RasterPacked {
 		}
 		result
 	}
+	writePixelGpu: override func (x, y: Int, color: ColorRgba) {
+		this[x, y] = ColorUv new(color r, color g)
+	}
+	readPixelGpu: override func (x, y: Int) -> ColorRgba {
+		color := this[x, y]
+		ColorRgba new(color u, color v, 0, 255)
+	}
 }

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -144,4 +144,11 @@ RasterYuv422Semipacked: class extends RasterPacked {
 		fileReader free()
 		result
 	}
+	writePixelGpu: override func (x, y: Int, color: ColorRgba) {
+		raise("writePixelGpu unimplemented for RasterYuv422Semipacked")
+	}
+	readPixelGpu: override func (x, y: Int) -> ColorRgba {
+		raise("writePixelGpu unimplemented for RasterYuv422Semipacked")
+		ColorRgba new(0, 0, 0, 255)
+	}
 }


### PR DESCRIPTION
Made an untested prototype of CPU shaders to discuss the concept before making a fully working version.

Concept:
Instead of trying to fully emulate shaders all the time, one can define everything from rasterization to blending in the same `render` function to get more performance from the CPU. Shaders that almost fully emulate the CPU will only be used as a reference implementation for asserting correctness of GPU shaders.