### PR TITLE
Fixed ProcessTest on Windows

### DIFF
--- a/test/io/PipeTest.ooc
+++ b/test/io/PipeTest.ooc
@@ -22,7 +22,7 @@ PipeTest: class extends Fixture {
 			else
 				scriptName = "test/io/input/pipeprocesstester.sh"
 
-			scriptArgs := [scriptName, "10000"]
+			scriptArgs := [scriptName, "50005000"]
 			process := Process new(scriptArgs)
 			scriptArgs free()
 
@@ -31,7 +31,7 @@ PipeTest: class extends Fixture {
 			process executeNoWait()
 			reader := PipeReader new(pipe)
 
-			Time sleepMilli(50)
+			Time sleepMilli(250)
 			data: String
 			for (i in 1 .. 10) {
 				data = reader readUntil('\n')

--- a/test/io/ProcessTest.ooc
+++ b/test/io/ProcessTest.ooc
@@ -23,7 +23,7 @@ ProcessTest: class extends Fixture {
 			else
 				scriptName = "test/io/input/pipeprocesstester.sh"
 
-			scriptArgs := [scriptName, "10000", "abcABC"]
+			scriptArgs := [scriptName, "50005000", "abcABC"]
 			process := Process new(scriptArgs)
 			process setStdout(Pipe new())
 			process execute()
@@ -31,6 +31,7 @@ ProcessTest: class extends Fixture {
 			process free()
 			scriptArgs free()
 
+			Time sleepMilli(250)
 			reader := FileReader new(t"test/io/output/sum.txt")
 			expect(reader hasNext())
 			data := CString new(16)

--- a/test/io/input/pipeprocesstester.sh
+++ b/test/io/input/pipeprocesstester.sh
@@ -1,15 +1,9 @@
 #!/bin/bash
-sum_to () (
-    set -- $(seq $1)
-    IFS=+
-    echo "$*" | bc
-)
+rm "test/io/output/sum.txt"
+echo "$1 $2" > "test/io/output/sum.txt"
 
 for i in `seq 1 16`
 do
-	echo $i
-	sum=$(sum_to $1)
-	echo $sum
+	echo "$i"
+	echo "$1"
 done
-
-echo "$sum $2" > "test/io/output/sum.txt"


### PR DESCRIPTION
The script was too complex for the bash clone on windows, and to be honest it didn't need any complexity at all. `ProcessTest` now passes.

The `PipeTest` no longer crashes, which is nice, but only gets the first data from the pipe for some reason.