### PR TITLE
Removed most memory leaks in net test

### DIFF
--- a/source/net/ServerSocket.ooc
+++ b/source/net/ServerSocket.ooc
@@ -31,13 +31,15 @@ ServerSocket: class extends Socket {
 	*/
 	init: func ~ipPortBacklogAndListen (ip := "0.0.0.0", port: Int, bl := 100, enabled := false) {
 		backlog = bl
-		ip = DNS resolveOne(ip) toString()
+		resolved := DNS resolveOne(ip)
+		ip = resolved toString()
+		resolved free()
 		type = ipType(ip)
 		super(type, SocketType STREAM, 0)
 		this bind(ip, port)
-		if (enabled) {
+		if (enabled)
 			this listen()
-		}
+		ip free()
 	}
 
 	/**

--- a/source/net/utilities.ooc
+++ b/source/net/utilities.ooc
@@ -16,11 +16,13 @@ import berkeley, translation, Socket, Address
 	Is the IP provided valid as either IPv6 or IPv4? (Returns type, from AddressFamily)
 */
 ipType: func (ip: String) -> Int {
-	atColons := ip split(":")
-	atPeriods := ip split(".")
-	if (atColons count >= 2)
+	(atColons, atPeriods) := (ip split(":"), ip split("."))
+	(colonCount, periodCount) := (atColons count, atPeriods count)
+	(atColons, atPeriods) free()
+
+	if (colonCount >= 2)
 		AddressFamily IP6 // 2 or more colons, assume IPv6
-	else if (atPeriods count == 4 && atColons count == 1)
+	else if (periodCount == 4 && colonCount == 1)
 		AddressFamily IP4 // No colons, 4 sections separated by 3 periods, assume IPv4
 	else
 		AddressFamily UNSPEC // Who knows what was given, return UNSPEC


### PR DESCRIPTION
Reduced from
```
definitely lost: 1,224 bytes in 49 blocks
indirectly lost: 21,672 bytes in 150 blocks
```
to
```
definitely lost: 576 bytes in 22 blocks
indirectly lost: 816 bytes in 29 blocks
```