### PR TITLE
Removes error message from ProcessTest

### DIFF
--- a/test/io/input/pipeprocesstester.sh
+++ b/test/io/input/pipeprocesstester.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rm "test/io/output/sum.txt"
+rm -f "test/io/output/sum.txt"
 echo "$1 $2" > "test/io/output/sum.txt"
 
 for i in `seq 1 16`


### PR DESCRIPTION
If the test hasn't been run before, this would give an error message since `sum.txt` didn't exist.

Peer review @sebastianbaginski ?