### PR TITLE
Implemented runtime serialization for monochrome images.

### DIFF
--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -290,8 +290,10 @@ RasterMonochrome: class extends RasterPacked {
 			alphabetMap[i] = 0
 		for (i in 0 .. alphabetSize) {
 			code := alphabet[i] as Int
-			raise(code < 32 || code > 126, "Character '" + alphabet[i] + "' (" + code toString() + ") is not printable standard ascii!")
-			raise(alphabetMap[code] > 0, "Character '" + alphabet[i] + "' (" + code toString() + ") is used more than once!")
+			if (code < 32 || code > 126)
+				raise("Character '" + alphabet[i] + "' (" + code toString() + ") is not printable standard ascii!")
+			if (alphabetMap[code] > 0)
+				raise("Character '" + alphabet[i] + "' (" + code toString() + ") is used more than once!")
 			value := ((i as Float) * (255.0f / ((alphabetSize - 1) as Float))) as Int clamp(0, 255)
 			alphabetMap[code] = value
 		}

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -49,7 +49,7 @@ RasterMonochromeTest: class extends Fixture {
 			image1 := RasterMonochrome open(this sourceSpace)
 			asciiImage := image1 toAscii(" .,-_':;!+~=^?*abcdefghijklmnopqrstuvwxyz()[]{}|&%@#0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 			image2 := RasterMonochrome fromAscii(asciiImage)
-			expect(image1 distance(image2) < 0.01)
+			expect(image1 distance(image2) < 0.01f)
 			image1 referenceCount decrease(); image2 referenceCount decrease()
 		})
 		this add("getRow and getColumn", func {

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -45,6 +45,13 @@ RasterMonochromeTest: class extends Fixture {
 			expect(image1 equals(image2))
 			image1 referenceCount decrease(); image2 referenceCount decrease()
 		})
+		this add("lossy ascii serialization", func {
+			image1 := RasterMonochrome open(this sourceSpace)
+			asciiImage := image1 toAscii(" .,-_':;!+~=^?*abcdefghijklmnopqrstuvwxyz()[]{}|&%@#0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+			image2 := RasterMonochrome fromAscii(asciiImage)
+			expect(image1 distance(image2) < 0.01)
+			image1 referenceCount decrease(); image2 referenceCount decrease()
+		})
 		this add("getRow and getColumn", func {
 			size := IntVector2D new(500, 256)
 			image := RasterMonochrome new(size)

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -47,10 +47,11 @@ RasterMonochromeTest: class extends Fixture {
 		})
 		this add("lossy ascii serialization", func {
 			image1 := RasterMonochrome open(this sourceSpace)
-			asciiImage := image1 toAscii(" .,-_':;!+~=^?*abcdefghijklmnopqrstuvwxyz()[]{}|&%@#0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+			alphabet := " .,-_':;!+~=^?*abcdefghijklmnopqrstuvwxyz()[]{}|&%@#0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+			asciiImage := image1 toAscii(alphabet)
 			image2 := RasterMonochrome fromAscii(asciiImage)
 			expect(image1 distance(image2) < 0.01f)
-			image1 referenceCount decrease(); image2 referenceCount decrease()
+			(image1, image2) referenceCount decrease(); (asciiImage, alphabet) free()
 		})
 		this add("getRow and getColumn", func {
 			size := IntVector2D new(500, 256)


### PR DESCRIPTION
The ascii serialization is a lossy but compact way to store images in the source code.
It begins with the alphabet (a gradient from black to white) and continues with each line of pixels in the image. A pixel is represented by the character in the initial alphabet that is closest to the original luma value. Each line begins with `<` and ends with `>` so that text editors will not mess up the data that is stored using white space.