### PR TITLE
Removed almost all remaining memory leaks in Net

### DIFF
--- a/source/collections/LinkedList.ooc
+++ b/source/collections/LinkedList.ooc
@@ -18,6 +18,7 @@ LinkedList: class <T> {
 	}
 	free: override func {
 		this clear()
+		this _head free()
 		super()
 	}
 	add: func (data: T) {

--- a/source/net/DNS.ooc
+++ b/source/net/DNS.ooc
@@ -17,10 +17,7 @@ DNS: class {
 		Perform DNS lookup using the hostname.
 		Returns information about the host that was found.
 	*/
-	resolve: static func (hostname: String) -> HostInfo {
-		resolve(hostname, 0, 0)
-	}
-	resolve: static func ~filter (hostname: String, socketType: Int, socketFamily: Int) -> HostInfo {
+	resolve: static func ~filter (hostname: String, socketType := 0, socketFamily := 0) -> HostInfo {
 		hints: AddrInfo
 		info: AddrInfo*
 		memset(hints&, 0, hints class size)
@@ -36,13 +33,11 @@ DNS: class {
 		Perform DNS lookup using the hostname.
 		Returns the first IPAddress found for the host.
 	*/
-	resolveOne: static func (host: String) -> IPAddress {
-		info := resolve(host)
-		info addresses()[0]
-	}
-	resolveOne: static func ~filter (host: String, socketType: Int, socketFamily: Int) -> IPAddress {
+	resolveOne: static func (host: String, socketType := 0, socketFamily := 0) -> IPAddress {
 		info := resolve(host, socketType, socketFamily)
-		info addresses()[0]
+		result := info addresses()[0]
+		info free()
+		result
 	}
 
 	/**
@@ -102,6 +97,7 @@ HostInfo: class {
 
 	free: override func {
 		this addresses free()
+		this name free()
 		super()
 	}
 }

--- a/source/net/ServerSocket.ooc
+++ b/source/net/ServerSocket.ooc
@@ -75,6 +75,7 @@ ServerSocket: class extends Socket {
 	bind: func ~withAddr (addr: SocketAddress) {
 		if (bind(descriptor, addr addr(), addr length()) == -1)
 			raise("SocketError bind")
+		addr free()
 	}
 
 	/**
@@ -140,5 +141,5 @@ ServerSocket: class extends Socket {
 
 // Workaround to let TCPReaderWriterPair be in this file
 TCPServerReaderWriterPair: class extends TCPReaderWriterPair {
-	init: func (=sock) { super(sock) }
+	init: func (.sock) { super(sock) }
 }

--- a/source/net/TCPSocket.ooc
+++ b/source/net/TCPSocket.ooc
@@ -72,6 +72,12 @@ TCPSocket: class extends Socket {
 		init(SocketAddress new(ip, port))
 	}
 
+	free: override func {
+		this remote free()
+		this readerWriter free()
+		super()
+	}
+
 	/**
 	   Attempt to connect this socket to the remote host.
 
@@ -222,6 +228,10 @@ TCPSocketReader: class extends Reader {
 
 	init: func (=source) { marker = 0 }
 	close: override func { source close() }
+	free: override func {
+		this source free()
+		super()
+	}
 
 	read: override func (chars: Char*, offset: Int, count: Int) -> SizeT {
 		skip(offset - marker)
@@ -250,6 +260,10 @@ TCPSocketReader: class extends Reader {
 TCPSocketWriter: class extends Writer {
 	dest: TCPSocket
 	init: func (=dest)
+	free: override func {
+		this dest close()
+		super()
+	}
 	close: override func { dest close() }
 	write: override func ~chr (chr: Char) { dest sendByte(chr) }
 	write: override func (chars: Char*, length: SizeT) -> SizeT { dest send(chars, length, 0, true) }

--- a/source/net/UDPSocket.ooc
+++ b/source/net/UDPSocket.ooc
@@ -39,6 +39,11 @@ UDPSocket: class extends Socket {
 		type = AddressFamily IP4
 	}
 
+	free: override func {
+		this remote free()
+		super()
+	}
+
 	/**
 		Bind the socket
 	*/

--- a/source/net/utilities.ooc
+++ b/source/net/utilities.ooc
@@ -16,9 +16,7 @@ import berkeley, translation, Socket, Address
 	Is the IP provided valid as either IPv6 or IPv4? (Returns type, from AddressFamily)
 */
 ipType: func (ip: String) -> Int {
-	(atColons, atPeriods) := (ip split(":"), ip split("."))
-	(colonCount, periodCount) := (atColons count, atPeriods count)
-	(atColons, atPeriods) free()
+	(colonCount, periodCount) := (1 + ip count(':'), 1 + ip count('.'))
 
 	if (colonCount >= 2)
 		AddressFamily IP6 // 2 or more colons, assume IPv6

--- a/test/net/NetTest.ooc
+++ b/test/net/NetTest.ooc
@@ -31,6 +31,7 @@ NetTest: class extends Fixture {
 						clientSocket out write(clientMessageNumber as Char)
 					}
 				}
+				ipaddress free()
 				clientSocket close() . free()
 			})
 			serverSocket := ServerSocket new(this ip, 8000) . listen()
@@ -47,7 +48,9 @@ NetTest: class extends Fixture {
 			expect(serverReceivedData, is equal to(9))
 			(connection, serverSocket) close()
 			(connection, serverSocket) free()
-			tcpClientThread wait() . free()
+			tcpClientThread wait()
+			(tcpClientThread _code as Closure) free()
+			tcpClientThread free()
 		})
 		this add("UDP Socket Client Readlines", func {
 			udpClientThread := Thread new(func {
@@ -56,7 +59,7 @@ NetTest: class extends Fixture {
 				correct := "udp is fun"
 				for (_ in 0 .. 5)
 					clientSocket send(correct)
-				(ipaddress, correct) free()
+				(ipaddress, correct, clientSocket) free()
 			})
 			ip := IP4Address new(this ip)
 			serverSocket := UDPSocket new(SocketAddress new(ip, 5000)) . bind()
@@ -69,8 +72,9 @@ NetTest: class extends Fixture {
 				bufferString free()
 			}
 
-			udpClientThread wait() . free()
-			expected free()
+			udpClientThread wait()
+			(udpClientThread _code as Closure) free()
+			(udpClientThread, expected, ip) free()
 			serverSocket close() . free()
 		})
 	}


### PR DESCRIPTION
Only 190 bytes in 8 blocks left, but they're a bit more complicated (related to the use of `LinkedList` or `TCPReaderWriterPair`.