### PR TITLE
wrapper for basic openssl functionality

### DIFF
--- a/source/ssl/include/ssl.ooc
+++ b/source/ssl/include/ssl.ooc
@@ -1,0 +1,30 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+include openssl/rand, openssl/aes, openssl/crypto, openssl/evp
+
+AesKey: cover from AES_KEY
+
+AES_BLOCK_SIZE,
+AES_ENCRYPT,
+AES_DECRYPT: extern const Int
+
+OPENSSL_VERSION_NUMBER: extern const Long
+
+SSLEAY_VERSION,
+SSLEAY_CFLAGS,
+SSLEAY_BUILT_ON,
+SSLEAY_PLATFORM,
+SSLEAY_DIR: extern const Int
+
+AES_set_encrypt_key: extern func (keyData: Byte*, keyLength: Int, aesKey: AesKey*)
+AES_set_decrypt_key: extern func (keyData: Byte*, keyLength: Int, aesKey: AesKey*)
+AES_cbc_encrypt: extern func (input: const Byte*, output: Byte*, inputLength: SizeT, key: AesKey*, initVector: Byte*, mode: Int)
+RAND_bytes: extern func (output: Byte*, length: Int) -> Int
+SSLeay: extern func -> Long
+SSLeay_version: extern func (type: Int) -> CString

--- a/source/ssl/include/ssl.ooc
+++ b/source/ssl/include/ssl.ooc
@@ -6,9 +6,12 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-include openssl/rand, openssl/aes, openssl/crypto, openssl/evp
+include openssl/aes, openssl/crypto, openssl/evp, openssl/rand
 
 AesKey: cover from AES_KEY
+
+EvpMessageDigestContext: cover from EVP_MD_CTX
+EvpMessageDigest: cover from EVP_MD
 
 AES_BLOCK_SIZE,
 AES_ENCRYPT,
@@ -25,6 +28,18 @@ SSLEAY_DIR: extern const Int
 AES_set_encrypt_key: extern func (keyData: Byte*, keyLength: Int, aesKey: AesKey*)
 AES_set_decrypt_key: extern func (keyData: Byte*, keyLength: Int, aesKey: AesKey*)
 AES_cbc_encrypt: extern func (input: const Byte*, output: Byte*, inputLength: SizeT, key: AesKey*, initVector: Byte*, mode: Int)
+
+EVP_MD_CTX_create: extern func -> EvpMessageDigestContext*
+EVP_MD_CTX_destroy: extern func (context: EvpMessageDigestContext*)
+EVP_DigestInit: extern func (context: EvpMessageDigestContext*, type: EvpMessageDigest*) -> Int
+EVP_DigestUpdate: extern func (context: EvpMessageDigestContext*, data: Void*, size: SizeT) -> Int
+EVP_DigestFinal: extern func (context: EvpMessageDigestContext*, output: Byte*, bytesWritten: UInt*) -> Int
+
+EVP_md5: extern func -> EvpMessageDigest*
+EVP_sha1: extern func -> EvpMessageDigest*
+EVP_sha256: extern func -> EvpMessageDigest*
+EVP_sha512: extern func -> EvpMessageDigest*
+
 RAND_bytes: extern func (output: Byte*, length: Int) -> Int
 SSLeay: extern func -> Long
 SSLeay_version: extern func (type: Int) -> CString

--- a/source/system/Cell.ooc
+++ b/source/system/Cell.ooc
@@ -50,6 +50,8 @@ Cell: class <T> {
 			result = (this val as LDouble) toText()
 		else if (T inheritsFrom(Range))
 			result = (this val as Range) toText()
+		else if (T inheritsFrom(Byte))
+			result = (this val as Byte) toText()
 		else
 			raise("[Cell] toText() is not implemented on the specified type")
 		result

--- a/ssl.use
+++ b/ssl.use
@@ -1,0 +1,6 @@
+Name: OpenSSL
+Description: Wrapper for OpenSSL and libcrypto
+SourcePath: source/ssl
+Requires: base
+Libs: -lcrypto
+Libs: -lssl

--- a/test/ssl/OpenSslTest.ooc
+++ b/test/ssl/OpenSslTest.ooc
@@ -1,0 +1,100 @@
+use base
+use ssl
+use unit
+
+import include/ssl
+
+OpenSslTest: class extends Fixture {
+	init: func {
+		super("OpenSsl")
+		this add("version", func {
+			expect(OPENSSL_VERSION_NUMBER != 0)
+			expect(OPENSSL_VERSION_NUMBER, is equal to(SSLeay()))
+		})
+		this add("random", func {
+			length := 16
+			buffer1: Byte[length]
+			buffer2: Byte[length]
+			for (i in 0 .. 32) {
+				expect(RAND_bytes(buffer1[0]&, length), is equal to(1))
+				expect(RAND_bytes(buffer2[0]&, length), is equal to(1))
+				outputDifferent := false
+				for (b in 0 .. length)
+					if (buffer1[b] != buffer2[b]) {
+						outputDifferent = true
+						break
+					}
+				expect(outputDifferent)
+			}
+		})
+		this add("encrypt / decrypt (text, AES-256)", func {
+			keyLengthBits := 256
+			keyLength := keyLengthBits / 8
+			encryptedLength := AES_BLOCK_SIZE
+			password: Byte[keyLength]
+			initVector, initVectorDecrypt: Byte[AES_BLOCK_SIZE]
+			plainText := ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+			expectedCipher := [ 0x51, 0x40, 0xBC, 0x1A, 0x07, 0x3E, 0xC3, 0x6B, 0xEF, 0x1B, 0x01, 0xBC, 0x92, 0xF5, 0x4E, 0xA9 ]
+			cipherText: Byte[encryptedLength]
+			decipheredText: Byte[plainText length]
+			encryptionKey, decryptionKey: AesKey
+
+			memset(initVector[0]&, 0, AES_BLOCK_SIZE)
+			memset(initVectorDecrypt[0]&, 0, AES_BLOCK_SIZE)
+			memset(password[0]&, 0, keyLength)
+			memcpy(password[0]&, c"secretkey", 9)
+
+			AES_set_encrypt_key(password[0]&, keyLengthBits, encryptionKey&)
+			AES_cbc_encrypt(plainText data, cipherText[0]&, plainText length, encryptionKey&, initVector[0]&, AES_ENCRYPT)
+
+			for (i in 0 .. expectedCipher length)
+				expect(cipherText[i] as Byte, is equal to(expectedCipher[i] as Byte))
+
+			AES_set_decrypt_key(password[0]&, keyLengthBits, decryptionKey&)
+			AES_cbc_encrypt(cipherText[0]&, decipheredText[0]&, expectedCipher length, decryptionKey&, initVectorDecrypt[0]&, AES_DECRYPT)
+
+			expect(memcmp(plainText[0]&, decipheredText[0]&, plainText length), is equal to(0))
+			(expectedCipher, plainText) free()
+		})
+		this add("encrypt / decrypt (random data)", func {
+			keyLengthsToTest := [128, 192, 256]
+			for (k in 0 .. keyLengthsToTest length) {
+				keyLengthBits := keyLengthsToTest[k]
+				keyLength := keyLengthBits / 8
+				inputLength := 1024
+				encryptedLength := 1024
+				password: Byte[keyLength]
+				initVector, initVectorDecrypt: Byte[AES_BLOCK_SIZE]
+				plainText, decipheredText: Byte[inputLength]
+				cipherText: Byte[encryptedLength]
+				encryptionKey, decryptionKey: AesKey
+
+				expect(RAND_bytes(password[0]&, keyLength), is equal to(1))
+				expect(RAND_bytes(plainText[0]&, inputLength), is equal to(1))
+				expect(RAND_bytes(initVector[0]&, AES_BLOCK_SIZE), is equal to(1))
+				memcpy(initVectorDecrypt[0]&, initVector[0]&, AES_BLOCK_SIZE)
+
+				AES_set_encrypt_key(password[0]&, keyLengthBits, encryptionKey&)
+				AES_cbc_encrypt(plainText[0]&, cipherText[0]&, inputLength, encryptionKey&, initVector[0]&, AES_ENCRYPT)
+
+				isEncrypted := false
+				for (i in 0 .. inputLength)
+					if (plainText[i] != cipherText[i]) {
+						isEncrypted = true
+						break
+					}
+				expect(isEncrypted)
+
+				AES_set_decrypt_key(password[0]&, keyLengthBits, decryptionKey&)
+				AES_cbc_encrypt(cipherText[0]&, decipheredText[0]&, encryptedLength, decryptionKey&, initVectorDecrypt[0]&, AES_DECRYPT)
+
+				for (i in 0 .. inputLength)
+					if (plainText[i] != decipheredText[i])
+						expect(false)
+			}
+			keyLengthsToTest free()
+		})
+	}
+}
+
+OpenSslTest new() run() . free()

--- a/test/ssl/OpenSslTest.ooc
+++ b/test/ssl/OpenSslTest.ooc
@@ -94,6 +94,27 @@ OpenSslTest: class extends Fixture {
 			}
 			keyLengthsToTest free()
 		})
+		this add("sha256", func {
+			expectedOutput := [ 0x9c, 0x56, 0xcc, 0x51,
+				0xb3, 0x74, 0xc3, 0xba,
+				0x18, 0x92, 0x10, 0xd5,
+				0xb6, 0xd4, 0xbf, 0x57,
+				0x79, 0x0d, 0x35, 0x1c,
+				0x96, 0xc4, 0x7c, 0x02,
+				0x19, 0x0e, 0xcf, 0x1e,
+				0x43, 0x06, 0x35, 0xab ]
+			context := EVP_MD_CTX_create()
+			expect(EVP_DigestInit(context, EVP_sha256()), is equal to(1))
+			expect(EVP_DigestUpdate(context, c"abcdefgh", 8), is equal to(1))
+			result: Byte[32]
+			outputSize: UInt
+			expect(EVP_DigestFinal(context, result[0]&, outputSize&), is equal to(1))
+			expect(outputSize, is equal to(32))
+			for (i in 0 .. outputSize)
+				expect(result[i], is equal to(expectedOutput[i] as Byte))
+			EVP_MD_CTX_destroy(context)
+			expectedOutput free()
+		})
 	}
 }
 


### PR DESCRIPTION
- base file for openssl types and functions
- test cases for AES encryption (both hard-coded input and random data)
- test case for SHA-256 (hard-coded input)
- updated `Cell toText` to support `Byte`

@marcusnaslund What do you think, could we have this in the sdk ?