### PR TITLE
General cleanup in old SDK files

### DIFF
--- a/source/concurrent/Thread.ooc
+++ b/source/concurrent/Thread.ooc
@@ -25,8 +25,7 @@ Thread: abstract class {
 			result = ThreadUnix new(_code) as This
 		version (windows)
 			result = ThreadWin32 new(_code) as This
-		if (result == null)
-			Exception new(This, "Unsupported platform!\n") throw()
+		raise(result == null, "Unsupported platform!\n", This)
 		result
 	}
 	currentThread: static func -> This {

--- a/source/concurrent/WaitCondition.ooc
+++ b/source/concurrent/WaitCondition.ooc
@@ -18,8 +18,7 @@ WaitCondition: abstract class {
 			result = ConditionUnix new() as This
 		version (windows)
 			result = ConditionWin32 new() as This
-		if (result == null)
-			Exception new(This, "Unsupported platform!\n") throw()
+		raise(result == null, "Unsupported platform!\n", This)
 		result
 	}
 }

--- a/source/io/Pipe.ooc
+++ b/source/io/Pipe.ooc
@@ -58,8 +58,7 @@ Pipe: abstract class {
 			result = PipeUnix new() as This
 		version(windows)
 			result = PipeWin32 new() as This
-		if (result == null)
-			Exception new(This, "Unsupported platform!\n") throw()
+		raise(result == null, "Unsupported platform!\n", This)
 		result
 	}
 }

--- a/source/io/native/ProcessWin32.ooc
+++ b/source/io/native/ProcessWin32.ooc
@@ -18,7 +18,7 @@ ProcessWin32: class extends Process {
 	init: func ~win32 (=args) {
 		sb := CharBuffer new()
 		for (arg in args)
-			sb append(arg). append(' ')
+			sb append(arg) . append(' ')
 		this cmdLine = sb toString()
 		ZeroMemory(this si&, StartupInfo size)
 		this si structSize = StartupInfo size

--- a/source/system/CharBuffer.ooc
+++ b/source/system/CharBuffer.ooc
@@ -61,7 +61,7 @@ CharBuffer: class {
 			if (!tmp)
 				OutOfMemoryException new(This) throw()
 
-			// if we were coming from a string literal, copy the original data as well (gc_realloc cant work on text segment)
+			// if we were coming from a string literal, copy the original data as well (realloc cant work on text segment)
 			if (this size > 0 && this mallocAddr == null) {
 				rs = 0
 				if (tmp != null && this data != null)

--- a/source/system/Character.ooc
+++ b/source/system/Character.ooc
@@ -105,7 +105,7 @@ CString: cover from Char* {
 	toString: func -> String { (this == null) ? null as String : String new(this, this length()) }
 	length: extern (strlen) func -> Int
 	print: func { stdout write(this, 0, this length()) }
-	println: func { stdout write(this, 0, this length()). write('\n') }
+	println: func { stdout write(this, 0, this length()) . write('\n') }
 	new: static func ~withLength (length: Int) -> This {
 		result := calloc(1, length + 1) as Char*
 		result[length] = '\0'

--- a/source/system/Exception.ooc
+++ b/source/system/Exception.ooc
@@ -222,7 +222,7 @@ version ((linux || apple) && !android) {
 			case SIGTERM => "(SIGTERM) software termination signal"
 			case => "(?) unknown signal %d" format(sig)
 		}
-		stderr write(message). write('\n')
+		stderr write(message) . write('\n')
 		stderr write(Exception getCurrentBacktrace())
 		exit(sig)
 	}
@@ -254,7 +254,7 @@ version (windows) {
 			case EXCEPTION_STACK_OVERFLOW => "(STACK_OVERFLOW) the thread used up its stack"
 			case => "(?) unknown exception code %lu" format(code as ULong)
 		}
-		stderr write(message). write('\n')
+		stderr write(message) . write('\n')
 		handler := BacktraceHandler get()
 		context := exceptionInfo@ ContextRecord as Pointer
 		backtrace := handler backtraceWithContext(context)

--- a/source/system/Mutex.ooc
+++ b/source/system/Mutex.ooc
@@ -32,8 +32,7 @@ Mutex: abstract class {
 					result = MutexUnix new()
 				version (windows)
 					result = MutexWin32 new()
-				if (result == null)
-					Exception new(This, "Unsupported platform!\n") throw()
+				raise(result == null, "Unsupported platform!\n", This)
 			}
 			case MutexType Unsafe =>
 				result = MutexUnsafe new()
@@ -69,8 +68,7 @@ RecursiveMutex: abstract class extends Mutex {
 			result = RecursiveMutexUnix new()
 		version (windows)
 			result = RecursiveMutexWin32 new()
-		if (result == null)
-			Exception new(This, "Unsupported platform!\n") throw()
+		raise(result == null, "Unsupported platform!\n", This)
 		result
 	}
 }

--- a/source/system/System.ooc
+++ b/source/system/System.ooc
@@ -30,11 +30,10 @@ System: class {
 			result = hostname toString()
 		}
 		version (linux || apple) {
-			BUF_SIZE: SizeT = 255
-			hostname := CharBuffer new(BUF_SIZE + 1)
-			value := gethostname(hostname data as Pointer, BUF_SIZE)
-			if (value != 0)
-				Exception new("System host name longer than 256 characters!!") throw()
+			bufferSize: SizeT = 255
+			hostname := CharBuffer new(bufferSize + 1)
+			value := gethostname(hostname data as Pointer, bufferSize)
+			raise(value != 0, "System host name longer than 256 characters!!")
 			hostname sizeFromData()
 			result = hostname toString()
 		}

--- a/source/system/external/stdio.ooc
+++ b/source/system/external/stdio.ooc
@@ -126,9 +126,7 @@ FStream: cover from FILE* {
 	readChar: func -> Char {
 		c := '\0'
 		count := fread(c&, 1, 1, this)
-		if (count != 1 && this error()) {
-			Exception new("Trying to read a char at the end of a file!") throw()
-		}
+		raise(count != 1 && this error(), "Trying to read a char at the end of a file!")
 		c
 	}
 

--- a/source/system/io/BufferReader.ooc
+++ b/source/system/io/BufferReader.ooc
@@ -19,9 +19,7 @@ BufferReader: class extends Reader {
 	hasNext: override func -> Bool { this marker < this buffer size }
 	close: override func
 	read: override func (dest: Char*, destOffset: Int, maxRead: Int) -> SizeT {
-		if (this marker >= this buffer size)
-			Exception new(This, "Buffer overflow! Offset is larger than buffer size.") throw()
-
+		raise(this marker >= this buffer size, "Buffer overflow! Offset is larger than buffer size.", This)
 		copySize := (this marker + maxRead > this buffer size ? this buffer size - this marker : maxRead)
 		memcpy(dest, this buffer data + this marker, copySize)
 		this marker += copySize

--- a/source/system/io/BufferWriter.ooc
+++ b/source/system/io/BufferWriter.ooc
@@ -30,7 +30,7 @@ BufferWriter: class extends Writer {
 	}
 	seek: func (p: Long) {
 		if (p < 0 || p > this buffer size)
-			Exception new("Seeking out of bounds! p = %d, size = %d" format(p, this buffer size)) throw()
+			raise("Seeking out of bounds! p = %d, size = %d" format(p, this buffer size))
 		this pos = p
 	}
 	write: override func (chars: Char*, length: SizeT) -> SizeT {

--- a/source/system/io/File.ooc
+++ b/source/system/io/File.ooc
@@ -167,10 +167,10 @@ File: abstract class {
 	getChildrenNames: abstract func -> VectorList<String>
 	getChildren: abstract func -> VectorList<This>
 	rm: func -> Bool { _remove(this) }
-	rm_rf: func -> Bool {
+	rmrf: func -> Bool {
 		if (this dir())
 			for (child in this getChildren())
-				if (!child rm_rf())
+				if (!child rmrf())
 					return false
 		this rm()
 	}

--- a/source/system/io/Writer.ooc
+++ b/source/system/io/Writer.ooc
@@ -8,10 +8,6 @@
 
 import io/Reader
 
-/**
- * The writer interface provides a medium-independent way to write
- * bytes to anything.
- */
 Writer: abstract class {
 	write: abstract func ~chr (chr: Char)
 	write: abstract func (bytes: CString, length: SizeT) -> SizeT
@@ -26,12 +22,10 @@ Writer: abstract class {
 		cursor, bytesTransfered: Int
 		cursor = 0
 		bytesTransfered = 0
-
 		while (source hasNext()) {
 			buffer setLength( source read(buffer data, cursor, bufferSize) )
 			bytesTransfered += this write(buffer data, buffer size)
 		}
-
 		buffer free()
 		bytesTransfered
 	}

--- a/source/system/native/FileWin32.ooc
+++ b/source/system/native/FileWin32.ooc
@@ -38,11 +38,12 @@ version(windows) {
 		_getFindData: func -> (FindData, Bool) {
 			ffd: FindData
 			hFind := FindFirstFile(this path toCString(), ffd&)
-			if (hFind != INVALID_HANDLE_VALUE) FindClose(hFind)
-			else {
-				return (ffd, false)
-			}
-			return (ffd, true)
+			status := true
+			if (hFind != INVALID_HANDLE_VALUE)
+				FindClose(hFind)
+			else
+				status = false
+			return (ffd, status)
 		}
 
 		/**

--- a/source/system/structs/HashMap.ooc
+++ b/source/system/structs/HashMap.ooc
@@ -81,8 +81,8 @@ murmurHash: func <K> (keyTagazok: K) -> SizeT {
  * @param s The string to hash
  * @return UInt
  */
-ac_X31_hash: func <K> (key: K) -> SizeT {
-	raise(key == null, "key in ac_X31_hash must be non-null!")
+acX31Hash: func <K> (key: K) -> SizeT {
+	raise(key == null, "key in acX31Hash must be non-null!")
 	s : Char* = (K == String) ? (key as String) toCString() as Char* : key as Char*
 	h = s@ : SizeT
 	if (h) {
@@ -97,7 +97,7 @@ ac_X31_hash: func <K> (key: K) -> SizeT {
 
 getStandardHashFunc: func <T> (T: Class) -> Func <T> (T) -> SizeT {
 	if (T == String)
-		ac_X31_hash
+		acX31Hash
 	else if (T size == Pointer size)
 		pointerHash
 	else if (T size == UInt size)


### PR DESCRIPTION
Removed underscores inside names, added missing spaces and moved two VarArgs functions from the global namespace.

Peer review @thomasfanell ?