### PR TITLE
Fixed unnecessary canvas allocation when recycling image.

### DIFF
--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -116,7 +116,7 @@ OpenGLContext: class extends GpuContext {
 		this _renderer drawPoints(positions, pointList count, 2)
 	}
 	recycle: virtual func (image: OpenGLPacked) {
-		(image canvas as OpenGLCanvas) onRecycle()
+		image onRecycle()
 		match (image) {
 			case (i: OpenGLMonochrome) => this _recycleBinMonochrome add(i)
 			case (i: OpenGLRgb) => this _recycleBinRgb add(i)

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -46,5 +46,9 @@ OpenGLPacked: abstract class extends GpuImage {
 		}
 	}
 	_createCanvas: override func -> GpuCanvas { OpenGLCanvas new(this, this context) }
+	onRecycle: func {
+		if (this _canvas != null)
+			(this _canvas as OpenGLCanvas) onRecycle()
+	}
 }
 }


### PR DESCRIPTION
Cherry picked from primaryFeature1.1 branch.
@marcusnaslund 