### PR TITLE
Moved default font atlas to OpenGLContext

### DIFF
--- a/source/draw/gpu/GpuContext.ooc
+++ b/source/draw/gpu/GpuContext.ooc
@@ -35,18 +35,7 @@ ToRasterFuture: class extends Future<RasterImage> {
 
 GpuContext: abstract class extends DrawContext {
 	defaultMap ::= null as Map
-	_defaultFontGpu: GpuImage = null
-	defaultFontGpu: GpuImage { get {
-		if (this _defaultFontGpu == null)
-			this _defaultFontGpu = this createImage(this defaultFontRaster)
-		this _defaultFontGpu
-	}}
 	init: func
-	free: override func {
-		if (this _defaultFontGpu != null)
-			this _defaultFontGpu free()
-		super()
-	}
 	createMonochrome: abstract func (size: IntVector2D) -> GpuImage
 	createRgb: abstract func (size: IntVector2D) -> GpuImage
 	createRgba: abstract func (size: IntVector2D) -> GpuImage
@@ -63,6 +52,5 @@ GpuContext: abstract class extends DrawContext {
 		Promise empty
 	}
 	toRasterAsync: virtual func (source: GpuImage) -> ToRasterFuture { raise("toRasterAsync unimplemented"); null }
-	getDefaultFont: override func -> Image { this defaultFontGpu }
 }
 }

--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -42,7 +42,12 @@ OpenGLContext: class extends GpuContext {
 	backend ::= this _backend
 	meshShader ::= this _meshShader
 	defaultMap ::= this _transformTextureMap as Map
-
+	_defaultFontGpu: GpuImage = null
+	defaultFontGpu: GpuImage { get {
+		if (this _defaultFontGpu == null)
+			this _defaultFontGpu = this createImage(this defaultFontRaster)
+		this _defaultFontGpu
+	}}
 	init: func ~backend (=_backend) {
 		super()
 		this _recycleBin = RecycleBin<OpenGLPacked> new(60, func (image: OpenGLPacked) {
@@ -66,6 +71,8 @@ OpenGLContext: class extends GpuContext {
 	}
 	init: func ~window (display: Pointer, nativeBackend: Long) { this init(GLContext createContext(display, nativeBackend)) }
 	free: override func {
+		if (this _defaultFontGpu != null)
+			this _defaultFontGpu free()
 		this _backend makeCurrent()
 		this _transformTextureMap free()
 		this _packMonochrome free()
@@ -191,5 +198,6 @@ OpenGLContext: class extends GpuContext {
 			vertices[i] = toGL * vertices[i]
 		OpenGLMesh new(vertices, textureCoordinates, this)
 	}
+	getDefaultFont: override func -> Image { this defaultFontGpu }
 }
 }


### PR DESCRIPTION
Any textures in GpuContext cannot be freed because it is called from super in OpenGLContext's destructor after the recycle bin and GLContext used to free textures has been freed.