### PR TITLE
The free() method in classes should always be override

### DIFF
--- a/source/base/Profiler.ooc
+++ b/source/base/Profiler.ooc
@@ -41,8 +41,7 @@ Profiler: class {
 	logResults: static func (fileName := "profiling.txt") {
 		fileWriter := FileWriter new(fileName)
 		This _logResults(func (s: String) { fileWriter write(s) })
-		fileWriter close()
-		fileWriter free()
+		fileWriter close() . free()
 	}
 	resetAll: static func { This _profilers apply(func (profiler: This) { profiler reset() }) }
 	free: static func ~all {

--- a/source/base/TextBuilder.ooc
+++ b/source/base/TextBuilder.ooc
@@ -31,7 +31,7 @@ TextBuilder: class {
 		this init()
 		this append(original)
 	}
-	free: func {
+	free: override func {
 		for (i in 0 .. this _data count)
 			this _data[i] free(Owner Receiver)
 		this _data free()

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -246,8 +246,7 @@ RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {
 		result := This new(size)
 		fileReader read((result y buffer pointer as Char*), 0, result y buffer size)
 		fileReader read((result uv buffer pointer as Char*), 0, result uv buffer size)
-		fileReader close()
-		fileReader free()
+		fileReader close() . free()
 		result
 	}
 }

--- a/source/io/CsvReader.ooc
+++ b/source/io/CsvReader.ooc
@@ -22,7 +22,7 @@ CsvReader: class extends Iterator<VectorList<Text>> {
 			while (this _fileReader hasNext() && ((readCharacter = this _fileReader read()) != '\n' && readCharacter != '\0')) { }
 		}
 	}
-	free: func {
+	free: override func {
 		if (this _fileReader != null)
 			this _fileReader close() . free()
 		super()

--- a/source/io/CsvWriter.ooc
+++ b/source/io/CsvWriter.ooc
@@ -18,11 +18,9 @@ CsvWriter: class {
 	init: func (=_fileWriter, delimiter := ',') {
 		this _delimiter = delimiter
 	}
-	free: func {
-		if (this _fileWriter != null) {
-			this _fileWriter close()
-			this _fileWriter free()
-		}
+	free: override func {
+		if (this _fileWriter != null)
+			this _fileWriter close() . free()
 		super()
 	}
 	write: func (row: VectorList<Text>) {

--- a/source/net/TCPSocket.ooc
+++ b/source/net/TCPSocket.ooc
@@ -271,7 +271,7 @@ TCPReaderWriterPair: class {
 	close: func {
 		sock close()
 	}
-	free: func {
+	free: override func {
 		(this sock, this in, this out) free()
 		super()
 	}

--- a/source/system/Iterators.ooc
+++ b/source/system/Iterators.ooc
@@ -82,7 +82,7 @@ _MappingIterator: class <T, S> extends Iterator<S> {
 	_backend: Iterator<T>
 	_mapFunction: Func(T) -> S
 	init: func (=_backend, =_mapFunction)
-	free: func {
+	free: override func {
 		this _backend free()
 		super()
 	}


### PR DESCRIPTION
Also merged some `close() . free()` calls.

Peer review @sebastianbaginski ?