### PR TITLE
Replacing enableBlend

### DIFF
--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -34,7 +34,7 @@ OpenGLCanvas: class extends OpenGLSurface {
 		else if (drawState blendMode == BlendMode Add)
 			this context backend blend()
 		else
-			this context backend enableBlend(false)
+			this context backend disableBlend()
 		tempImageA: GpuImage = null
 		tempImageB: GpuImage = null
 		if (drawState inputImage) {

--- a/source/draw/gpu/opengl/OpenGLSurface.ooc
+++ b/source/draw/gpu/opengl/OpenGLSurface.ooc
@@ -25,14 +25,14 @@ OpenGLSurface: abstract class extends GpuCanvas {
 	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
 		this _bind()
 		this context backend setViewport(IntBox2D new(this size))
-		this context backend enableBlend(false)
+		this context backend disableBlend()
 		this context drawLines(pointList, this _createProjection(this size toFloatVector2D(), 0.0f) * this _toLocal, pen)
 		this _unbind()
 	}
 	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
 		this _bind()
 		this context backend setViewport(IntBox2D new(this size))
-		this context backend enableBlend(false)
+		this context backend disableBlend()
 		this context drawPoints(pointList, this _createProjection(this size toFloatVector2D(), 0.0f) * this _toLocal, pen)
 		this _unbind()
 	}

--- a/source/draw/gpu/opengl/backend/GLContext.ooc
+++ b/source/draw/gpu/opengl/backend/GLContext.ooc
@@ -18,7 +18,7 @@ GLContext: abstract class {
 	makeCurrent: abstract func -> Bool
 	swapBuffers: abstract func
 	setViewport: abstract func (viewport: IntBox2D)
-	enableBlend: abstract func (on: Bool)
+	disableBlend: abstract func
 	blend: abstract func ~constant (factor: Float)
 	blend: abstract func ~alphaMonochrome
 	createFence: abstract func -> GLFence

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
@@ -154,13 +154,10 @@ Gles3Context: class extends GLContext {
 		glViewport(viewport left, viewport top, viewport width, viewport height)
 		version(debugGL) { validateEnd("Context setViewport") }
 	}
-	enableBlend: override func (on: Bool) {
-		version(debugGL) { validateStart("Context enableBlend") }
-		if (on)
-			glEnable(GL_BLEND)
-		else
-			glDisable(GL_BLEND)
-		version(debugGL) { validateEnd("Context enableBlend") }
+	disableBlend: override func {
+		version(debugGL) { validateStart("Context disableBlend") }
+		glDisable(GL_BLEND)
+		version(debugGL) { validateEnd("Context disableBlend") }
 	}
 	blend: override func ~constant (factor: Float) {
 		version(debugGL) { validateStart("Context blend~constant") }

--- a/source/ui/x11/UnixWindow.ooc
+++ b/source/ui/x11/UnixWindow.ooc
@@ -81,7 +81,7 @@ UnixWindow: class extends UnixWindowBase {
 		map use(null)
 		this _openGLWindow _bind()
 		this _openGLWindow context backend setViewport(IntBox2D new(image size))
-		this _openGLWindow context backend enableBlend(false)
+		this _openGLWindow context backend disableBlend()
 		this _openGLWindow context drawQuad()
 		this _openGLWindow _unbind()
 		if (tempImageA)


### PR DESCRIPTION
Minimal change to make the inner blend interface less confusing. The function was named `enableBlend` but was only used to disable blend.