### PR TITLE
Implemented fill for raster images.

### DIFF
--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -32,8 +32,10 @@ ByteBuffer: class {
 		this _pointer = null
 		super()
 	}
-	zero: func ~whole { memset(this _pointer, 0, this _size) }
-	zero: func ~range (offset, length: Int) { memset(this _pointer + offset, 0, length) }
+	zero: func ~whole { this memset(0) }
+	zero: func ~range (offset, length: Int) { this memset(offset, length, 0) }
+	memset: func ~whole (value: Byte) { memset(this _pointer, value, this _size) }
+	memset: func ~range (offset, length: Int, value: Byte) { memset(this _pointer + offset, value, length) }
 	slice: func (offset, size: Int) -> This { _SlicedByteBuffer new(this, offset, size) }
 	copy: func -> This {
 		result := This new(this size)

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -41,9 +41,7 @@ RasterMonochromeCanvas: class extends RasterPackedCanvas {
 			monochrome referenceCount decrease()
 	}
 	fill: override func (color: ColorRgba) {
-		for (y in 0 .. this size y)
-			for (x in 0 .. this size x)
-				this target[x, y] = ColorMonochrome new(color r)
+		this target buffer memset(color r)
 	}
 }
 

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -40,6 +40,11 @@ RasterMonochromeCanvas: class extends RasterPackedCanvas {
 		if (monochrome != image)
 			monochrome referenceCount decrease()
 	}
+	fill: override func (color: ColorRgba) {
+		for (y in 0 .. this size y)
+			for (x in 0 .. this size x)
+				this target[x, y] = ColorMonochrome new(color r)
+	}
 }
 
 RasterMonochrome: class extends RasterPacked {

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -41,6 +41,11 @@ RasterRgbCanvas: class extends RasterPackedCanvas {
 		if (rgb != image)
 			rgb referenceCount decrease()
 	}
+	fill: override func (color: ColorRgba) {
+		for (y in 0 .. this size y)
+			for (x in 0 .. this size x)
+				this target[x, y] = color toRgb()
+	}
 }
 
 RasterRgb: class extends RasterPacked {

--- a/source/draw/RasterRgba.ooc
+++ b/source/draw/RasterRgba.ooc
@@ -25,6 +25,11 @@ RasterRgbaCanvas: class extends RasterPackedCanvas {
 		if (this target isValidIn(position x, position y))
 			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color)
 	}
+	fill: override func (color: ColorRgba) {
+		for (y in 0 .. this size y)
+			for (x in 0 .. this size x)
+				this target[x, y] = color
+	}
 }
 
 RasterRgba: class extends RasterPacked {

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -40,6 +40,11 @@ RasterUvCanvas: class extends RasterPackedCanvas {
 		if (uv != image)
 			uv referenceCount decrease()
 	}
+	fill: override func (color: ColorRgba) {
+		for (y in 0 .. this size y)
+			for (x in 0 .. this size x)
+				this target[x, y] = ColorUv new(color r, color g)
+	}
 }
 
 RasterUv: class extends RasterPacked {

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -32,6 +32,11 @@ RasterYuv420SemiplanarCanvas: class extends RasterCanvas {
 		if (this target isValidIn(position x, position y))
 			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toYuv())
 	}
+	fill: override func (color: ColorRgba) {
+		yuv := color toYuv()
+		this target y canvas fill(ColorRgba new(yuv y, 0, 0, 255))
+		this target uv canvas fill(ColorRgba new(yuv u, yuv v, 0, 255))
+	}
 }
 
 RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {

--- a/test/base/ByteBufferTest.ooc
+++ b/test/base/ByteBufferTest.ooc
@@ -58,6 +58,26 @@ ByteBufferTest: class extends Fixture {
 			expect(yuv referenceCount _count, is equal to(1))
 			uv referenceCount decrease()
 		})
+		this add("memset", func {
+			buffer := ByteBuffer new(64)
+			for (i in 0 .. 64)
+				buffer pointer[i] = i
+			buffer memset(35)
+			for (i in 0 .. 64)
+				expect(buffer pointer[i] as Int, is equal to(35))
+			buffer referenceCount decrease()
+		})
+		this add("memset range", func {
+			buffer := ByteBuffer new(64)
+			for (i in 0 .. 64)
+				buffer pointer[i] = i
+			buffer memset(1, 62, 35)
+			expect(buffer pointer[0] as Int, is equal to(0))
+			for (i in 1 .. 63)
+				expect(buffer pointer[i] as Int, is equal to(35))
+			expect(buffer pointer[63] as Int, is equal to(63))
+			buffer referenceCount decrease()
+		})
 	}
 }
 

--- a/test/draw/gpu/FillTest.ooc
+++ b/test/draw/gpu/FillTest.ooc
@@ -1,0 +1,57 @@
+/* This file is part of magic-sdk, an sdk for the open source programming language magic.
+ *
+ * Copyright (C) 2016 magic-lang
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+use base
+use collections
+use geometry
+use draw-gpu
+use draw
+use opengl
+use unit
+
+FillTest: class extends Fixture {
+	init: func {
+		super("Fill")
+		imageSize := IntVector2D new(16, 16)
+		color := ColorRgba new(134, 176, 31, 0)
+		this add("Fill RGB", func {
+			cpuImage := RasterRgb new(imageSize)
+			cpuImage canvas fill(color)
+			for (y in 0 .. cpuImage size y)
+				for (x in 0 .. cpuImage size x)
+					expect(cpuImage[x, y] == ColorRgb new(134, 176, 31))
+			cpuImage free()
+		})
+		this add("Fill RGBA", func {
+			gpuImage := gpuContext createRgba(imageSize)
+			cpuImage := RasterRgba new(imageSize)
+			gpuImage canvas fill(color)
+			cpuImage canvas fill(color)
+			gpuToCpuImage := gpuImage toRaster()
+			expect(gpuToCpuImage distance(cpuImage), is equal to(0.0f))
+			expect(cpuImage[7, 7] == color)
+			expect(cpuImage[0, 0] == color)
+			expect(cpuImage[0, 15] == color)
+			expect(cpuImage[15, 0] == color)
+			expect(cpuImage[15, 15] == color)
+			(gpuToCpuImage, cpuImage, gpuImage) free()
+		})
+		this add("Fill YUV420Semiplanar", func {
+			gpuImage := gpuContext createYuv420Semiplanar(imageSize)
+			cpuImage := RasterYuv420Semiplanar new(imageSize)
+			gpuImage canvas fill(color)
+			cpuImage canvas fill(color)
+			gpuToCpuImage := gpuImage toRaster()
+			expect(gpuToCpuImage distance(cpuImage), is equal to(0.0f))
+			(gpuToCpuImage, cpuImage, gpuImage) free()
+		})
+	}
+}
+gpuContext := OpenGLContext new()
+FillTest new() run() . free()
+gpuContext free()


### PR DESCRIPTION
It should now be possible to fill raster images with colors.

Since filling a YUV image is usually to the whole image and not individual components, filling monochrome or UV images only takes the first channels from the RGBA color just like the GPU does.

Since RGB cannot be loaded back to the CPU, I could not test the already implemented RGB fill on the GPU.

Solves https://github.com/magic-lang/ooc-kean/issues/1411