### PR TITLE
Implicit canvas

### DIFF
--- a/source/draw/Canvas.ooc
+++ b/source/draw/Canvas.ooc
@@ -35,7 +35,7 @@ Canvas: abstract class {
 	drawPoints: func ~white (pointList: VectorList<FloatPoint2D>) { this drawPoints(pointList, Pen new(ColorRgba white)) }
 	drawPoints: abstract func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen)
 	drawLines: func ~white (pointList: VectorList<FloatPoint2D>) { this drawLines(pointList, Pen new(ColorRgba white)) }
-	drawLines: abstract func ~explicit (lines: VectorList<FloatPoint2D>, pen: Pen)
+	drawLines: abstract func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen)
 	drawBox: virtual func ~white (box: FloatBox2D) { this drawBox(box, Pen new(ColorRgba white)) }
 	drawBox: virtual func ~explicit (box: FloatBox2D, pen: Pen) {
 		positions := VectorList<FloatPoint2D> new()

--- a/source/draw/DrawContext.ooc
+++ b/source/draw/DrawContext.ooc
@@ -40,7 +40,7 @@ DrawContext: abstract class {
 	createYuv420Semiplanar: abstract func ~fromRaster (raster: RasterYuv420Semiplanar) -> Image
 	createImageFromTextAndFont: virtual func (message: Text, fontAtlas: Image) -> Image {
 		target := this createMonochrome(This getTextPixelBounds(message take(), fontAtlas))
-		target canvas fill(ColorRgba black)
+		target fill(ColorRgba black)
 		target write(message take(), fontAtlas, IntPoint2D new(0, 0))
 		message free(Owner Receiver)
 		target

--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -59,6 +59,17 @@ Image: abstract class {
 		this _canvas = null
 		super()
 	}
+	drawPoint: func ~white (position: FloatPoint2D) { this canvas drawPoint~white(position) }
+	drawPoint: func ~explicit (position: FloatPoint2D, pen: Pen) { this canvas drawPoint~explicit(position, pen) }
+	drawLine: func ~white (start, end: FloatPoint2D) { this canvas drawLine~white(start, end) }
+	drawLine: func ~explicit (start, end: FloatPoint2D, pen: Pen) { this canvas drawLine~explicit(start, end, pen) }
+	drawPoints: func ~white (pointList: VectorList<FloatPoint2D>) { this canvas drawPoints~white(pointList) }
+	drawPoints: func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { this canvas drawPoints~explicit(pointList, Pen new(ColorRgba white)) }
+	drawLines: func ~white (pointList: VectorList<FloatPoint2D>) { this canvas drawLines~white(pointList) }
+	drawLines: func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { this canvas drawLines~explicit(pointList, Pen new(ColorRgba white)) }
+	drawBox: func ~white (box: FloatBox2D) { this canvas drawBox~white(box) }
+	drawBox: func ~explicit (box: FloatBox2D, pen: Pen) { this canvas drawBox~explicit(box, Pen new(ColorRgba white)) }
+	fill: func ~implicitCanvas (color: ColorRgba) { this canvas fill(color) }
 	resizeWithin: func (restriction: IntVector2D) -> This {
 		restrictionFraction := (restriction x as Float / this size x as Float) minimum(restriction y as Float / this size y as Float)
 		this resizeTo((this size toFloatVector2D() * restrictionFraction) toIntVector2D())

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -56,11 +56,11 @@ RasterCanvas: abstract class extends Canvas {
 			}
 		}
 	}
-	drawLines: override func ~explicit (lines: VectorList<FloatPoint2D>, pen: Pen) {
-		if (lines count > 1)
-			for (i in 0 .. lines count - 1) {
-				start := IntPoint2D new(lines[i] x, lines[i] y)
-				end := IntPoint2D new(lines[i + 1] x, lines[i + 1] y)
+	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
+		if (pointList count > 1)
+			for (i in 0 .. pointList count - 1) {
+				start := IntPoint2D new(pointList[i] x, pointList[i] y)
+				end := IntPoint2D new(pointList[i + 1] x, pointList[i + 1] y)
 				this _drawLine(start, end, pen)
 			}
 	}

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -57,12 +57,11 @@ RasterCanvas: abstract class extends Canvas {
 		}
 	}
 	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
-		if (pointList count > 1)
-			for (i in 0 .. pointList count - 1) {
-				start := IntPoint2D new(pointList[i] x, pointList[i] y)
-				end := IntPoint2D new(pointList[i + 1] x, pointList[i + 1] y)
-				this _drawLine(start, end, pen)
-			}
+		for (i in 0 .. pointList count - 1) {
+			start := IntPoint2D new(pointList[i] x, pointList[i] y)
+			end := IntPoint2D new(pointList[i + 1] x, pointList[i + 1] y)
+			this _drawLine(start, end, pen)
+		}
 	}
 	_map: func (point: IntPoint2D) -> IntPoint2D {
 		point + this _size / 2

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -34,8 +34,8 @@ RasterYuv420SemiplanarCanvas: class extends RasterCanvas {
 	}
 	fill: override func (color: ColorRgba) {
 		yuv := color toYuv()
-		this target y canvas fill(ColorRgba new(yuv y, 0, 0, 255))
-		this target uv canvas fill(ColorRgba new(yuv u, yuv v, 0, 255))
+		this target y fill(ColorRgba new(yuv y, 0, 0, 255))
+		this target uv fill(ColorRgba new(yuv u, yuv v, 0, 255))
 	}
 }
 

--- a/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
@@ -41,8 +41,8 @@ GpuCanvasYuv420Semiplanar: class extends GpuCanvas {
 	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { this _target y canvas drawPoints(pointList, pen) }
 	fill: override func (color: ColorRgba) {
 		yuv := color toYuv()
-		this _target y canvas fill(ColorRgba new(yuv y, 0, 0, 255))
-		this _target uv canvas fill(ColorRgba new(yuv u, yuv v, 0, 255))
+		this _target y fill(ColorRgba new(yuv y, 0, 0, 255))
+		this _target uv fill(ColorRgba new(yuv u, yuv v, 0, 255))
 	}
 }
 }

--- a/test/draw/gpu/FillTest.ooc
+++ b/test/draw/gpu/FillTest.ooc
@@ -21,7 +21,7 @@ FillTest: class extends Fixture {
 		color := ColorRgba new(134, 176, 31, 0)
 		this add("Fill RGB", func {
 			cpuImage := RasterRgb new(imageSize)
-			cpuImage canvas fill(color)
+			cpuImage fill(color)
 			for (y in 0 .. cpuImage size y)
 				for (x in 0 .. cpuImage size x)
 					expect(cpuImage[x, y] == ColorRgb new(134, 176, 31))
@@ -30,8 +30,8 @@ FillTest: class extends Fixture {
 		this add("Fill RGBA", func {
 			gpuImage := gpuContext createRgba(imageSize)
 			cpuImage := RasterRgba new(imageSize)
-			gpuImage canvas fill(color)
-			cpuImage canvas fill(color)
+			gpuImage fill(color)
+			cpuImage fill(color)
 			gpuToCpuImage := gpuImage toRaster()
 			expect(gpuToCpuImage distance(cpuImage), is equal to(0.0f))
 			expect(cpuImage[7, 7] == color)
@@ -44,8 +44,8 @@ FillTest: class extends Fixture {
 		this add("Fill YUV420Semiplanar", func {
 			gpuImage := gpuContext createYuv420Semiplanar(imageSize)
 			cpuImage := RasterYuv420Semiplanar new(imageSize)
-			gpuImage canvas fill(color)
-			cpuImage canvas fill(color)
+			gpuImage fill(color)
+			cpuImage fill(color)
 			gpuToCpuImage := gpuImage toRaster()
 			expect(gpuToCpuImage distance(cpuImage), is equal to(0.0f))
 			(gpuToCpuImage, cpuImage, gpuImage) free()

--- a/test/draw/gpu/GpuImageReflectionTest.ooc
+++ b/test/draw/gpu/GpuImageReflectionTest.ooc
@@ -20,7 +20,7 @@ GpuImageReflectionTest: class extends Fixture {
 		this add("GPU reflection X (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/reflection_rgba_X.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba black)
+			gpuImage fill(ColorRgba black)
 			DrawState new(gpuImage) setTransformNormalized(FloatTransform3D createReflectionX()) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -29,7 +29,7 @@ GpuImageReflectionTest: class extends Fixture {
 		this add("GPU reflection Y (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/reflection_rgba_Y.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba black)
+			gpuImage fill(ColorRgba black)
 			DrawState new(gpuImage) setTransformNormalized(FloatTransform3D createReflectionY()) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -38,7 +38,7 @@ GpuImageReflectionTest: class extends Fixture {
 		this add("GPU reflection Z (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/reflection_rgba_Z.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba black)
+			gpuImage fill(ColorRgba black)
 			DrawState new(gpuImage) setTransformNormalized(FloatTransform3D createReflectionZ()) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))

--- a/test/draw/gpu/GpuImageRotationTest.ooc
+++ b/test/draw/gpu/GpuImageRotationTest.ooc
@@ -23,7 +23,7 @@ GpuImageRotationTest: class extends Fixture {
 		this add("GPU rotation flip X (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/rotation_flip_rgba_X.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setTransformReference(FloatTransform3D createRotationX(flipRotation)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -32,7 +32,7 @@ GpuImageRotationTest: class extends Fixture {
 		this add("GPU rotation flip Y (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/rotation_flip_rgba_Y.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setTransformReference(FloatTransform3D createRotationY(flipRotation)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -41,7 +41,7 @@ GpuImageRotationTest: class extends Fixture {
 		this add("GPU rotation flip Z (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/rotation_flip_rgba_Z.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setTransformReference(FloatTransform3D createRotationZ(flipRotation)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -50,7 +50,7 @@ GpuImageRotationTest: class extends Fixture {
 		this add("GPU rotation small X (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/rotation_small_rgba_X.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLength(focalLength, gpuImage size) setTransformReference(FloatTransform3D createRotationX(smallRotation)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f) within(0.005f))
@@ -59,7 +59,7 @@ GpuImageRotationTest: class extends Fixture {
 		this add("GPU rotation small Y (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/rotation_small_rgba_Y.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLength(focalLength, gpuImage size) setTransformReference(FloatTransform3D createRotationY(smallRotation)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f) within(0.05f))
@@ -68,7 +68,7 @@ GpuImageRotationTest: class extends Fixture {
 		this add("GPU rotation small Z (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/rotation_small_rgba_Z.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLength(focalLength, gpuImage size) setTransformReference(FloatTransform3D createRotationZ(smallRotation)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))

--- a/test/draw/gpu/GpuImageScalingTest.ooc
+++ b/test/draw/gpu/GpuImageScalingTest.ooc
@@ -21,7 +21,7 @@ GpuImageScalingTest: class extends Fixture {
 		this add("Scaling X rotation", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/scaling_X_rotation.png")
 			gpuImage := gpuContext createRgba(IntVector2D new(200, 150))
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLengthNormalized(0.1f) setTransformReference(FloatTransform3D createRotationX(5.0f toRadians())) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -30,7 +30,7 @@ GpuImageScalingTest: class extends Fixture {
 		this add("Scaling Y rotation", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/scaling_Y_rotation.png")
 			gpuImage := gpuContext createRgba(IntVector2D new(100, 200))
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLengthNormalized(0.1f) setTransformReference(FloatTransform3D createRotationY(5.0f toRadians())) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))

--- a/test/draw/gpu/GpuImageTranslationTest.ooc
+++ b/test/draw/gpu/GpuImageTranslationTest.ooc
@@ -28,7 +28,7 @@ GpuImageTranslationTest: class extends Fixture {
 			gpuImage := gpuContext createRgba(this sourceImage size)
 			expect(gpuImage size x, is equal to(636))
 			expect(gpuImage size y, is equal to(424))
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLength(focalLength, gpuImage size) setTransformReference(FloatTransform3D createTranslation(xTranslation, 0.0f, 0.0f)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -37,7 +37,7 @@ GpuImageTranslationTest: class extends Fixture {
 		this add("GPU translate Y (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/translation_rgba_Y.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLength(focalLength, gpuImage size) setTransformReference(FloatTransform3D createTranslation(0.0f, yTranslation, 0.0f)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
@@ -46,7 +46,7 @@ GpuImageTranslationTest: class extends Fixture {
 		this add("GPU translate Z (RGBA)", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/translation_rgba_Z.png")
 			gpuImage := gpuContext createRgba(this sourceImage size)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			DrawState new(gpuImage) setFocalLength(focalLength, gpuImage size) setTransformReference(FloatTransform3D createTranslation(0.0f, 0.0f, zTranslation)) setInputImage(this sourceImage) draw()
 			rasterFromGpu := gpuImage toRaster()
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f) within(3.0f))

--- a/test/draw/gpu/GpuSurfaceTest.ooc
+++ b/test/draw/gpu/GpuSurfaceTest.ooc
@@ -22,7 +22,7 @@ GpuSurfaceTest: class extends Fixture {
 		this add("draw red quadrant scale 1:1", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/quadrant_red.png")
 			gpuImage := gpuContext createRgba(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			quadrantRed := FloatBox2D new(0.0f, 0.0f, 0.5f, 0.5f)
 			DrawState new(gpuImage) setInputImage(this sourceImage) setSourceNormalized(quadrantRed) setDestinationNormalized(quadrantRed) draw()
 			rasterFromGpu := gpuImage toRaster()
@@ -32,7 +32,7 @@ GpuSurfaceTest: class extends Fixture {
 		this add("draw yellow quadrant scale 1:1", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/quadrant_yellow.png")
 			gpuImage := gpuContext createRgba(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			quadrantYellow := FloatBox2D new(0.5f, 0.0f, 0.5f, 0.5f)
 			DrawState new(gpuImage) setInputImage(this sourceImage) setSourceNormalized(quadrantYellow) setDestinationNormalized(quadrantYellow) draw()
 			rasterFromGpu := gpuImage toRaster()
@@ -42,7 +42,7 @@ GpuSurfaceTest: class extends Fixture {
 		this add("draw blue quadrant scale 1:1", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/quadrant_blue.png")
 			gpuImage := gpuContext createRgba(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			quadrantBlue := FloatBox2D new(0.0f, 0.5f, 0.5f, 0.5f)
 			DrawState new(gpuImage) setInputImage(this sourceImage) setSourceNormalized(quadrantBlue) setDestinationNormalized(quadrantBlue) draw()
 			rasterFromGpu := gpuImage toRaster()
@@ -52,7 +52,7 @@ GpuSurfaceTest: class extends Fixture {
 		this add("draw green quadrant scale 1:1", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/quadrant_green.png")
 			gpuImage := gpuContext createRgba(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			quadrantGreen := FloatBox2D new(0.5f, 0.5f, 0.5f, 0.5f)
 			DrawState new(gpuImage) setInputImage(this sourceImage) setSourceNormalized(quadrantGreen) setDestinationNormalized(quadrantGreen) draw()
 			rasterFromGpu := gpuImage toRaster()
@@ -66,7 +66,7 @@ GpuSurfaceTest: class extends Fixture {
 			quadrantGreen := RasterRgba open("test/draw/gpu/correct/quadrant_green.png")
 			correctImage := RasterRgba open("test/draw/gpu/correct/quad.png")
 			gpuImage := gpuContext createRgba(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			redBox := FloatBox2D new(0.0f, 0.0f, 0.5f, 0.5f)
 			yellowBox := FloatBox2D new(0.5f, 0.0f, 0.5f, 0.5f)
 			blueBox := FloatBox2D new(0.0f, 0.5f, 0.5f, 0.5f)
@@ -82,7 +82,7 @@ GpuSurfaceTest: class extends Fixture {
 		this add("draw red quadrant zoomed", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/quadrant_red_zoom.png")
 			gpuImage := gpuContext createRgba(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			redBox := FloatBox2D new(0.0f, 0.0f, 0.5f, 0.5f)
 			DrawState new(gpuImage) setInputImage(this sourceImage) setSourceNormalized(redBox) draw()
 			rasterFromGpu := gpuImage toRaster()
@@ -92,7 +92,7 @@ GpuSurfaceTest: class extends Fixture {
 		this add("draw quad 1:4 scale top left bottom right and 180deg x rotation", func {
 			correctImage := RasterRgba open("test/draw/gpu/correct/quad_scaled_top_left_bottom_right_180deg_x_rotation.png")
 			gpuImage := gpuContext createRgba(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			quadrantTopLeft := FloatBox2D new(0.0f, 0.0f, 0.5f, 0.5f)
 			quadrantBottomRight := FloatBox2D new(0.5f, 0.5f, 0.5f, 0.5f)
 			DrawState new(gpuImage) setInputImage(this sourceImage) setDestinationNormalized(quadrantTopLeft) setTransformNormalized(FloatTransform3D createRotationX(180.0f toRadians())) draw()
@@ -104,7 +104,7 @@ GpuSurfaceTest: class extends Fixture {
 		this add("draw shapes", func {
 			correctImage := RasterMonochrome open("test/draw/gpu/correct/shapes.png")
 			gpuImage := gpuContext createMonochrome(sourceSize)
-			gpuImage canvas fill(ColorRgba transparent)
+			gpuImage fill(ColorRgba transparent)
 			trianglePoints := VectorList<FloatPoint2D> new()
 			lineLength := 200.0f
 			trianglePoints add(FloatPoint2D new(-lineLength, lineLength / 2.0f))


### PR DESCRIPTION
Filling, line drawing and point drawing can now be accessed directly from images. There shall be no occurrences of the deprecated identifier "canvas" outside of Kean.

After a while when no one uses the canvas in new pull requests, the methods can be moved from canvas to image. Draw will still exist in canvas for the display window until we can find a way to completely remove canvas.