### PR TITLE
Removing coordinate system from Image

### DIFF
--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -28,6 +28,8 @@ DrawState: cover {
 	opacity := 1.0f
 	blendMode := BlendMode Fill
 	interpolate := true
+	flipSourceX := false
+	flipSourceY := false
 	_transformNormalized := FloatTransform3D identity
 	viewport := IntBox2D new(0, 0, 0, 0)
 	_destinationNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
@@ -57,6 +59,14 @@ DrawState: cover {
 	}
 	setInterpolate: func (interpolate: Bool) -> This {
 		this interpolate = interpolate
+		this
+	}
+	setFlipSourceX: func (flipSourceX: Bool) -> This {
+		this flipSourceX = flipSourceX
+		this
+	}
+	setFlipSourceY: func (flipSourceY: Bool) -> This {
+		this flipSourceY = flipSourceY
 		this
 	}
 	setFocalLength: func ~Int (focalLength: Float, imageSize: IntVector2D) -> This {

--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -11,42 +11,26 @@ use base
 use draw
 import Canvas
 
-CoordinateSystem: enum {
-	Default = 0x00
-	XRightward = 0x00
-	XLeftward = 0x01
-	YDownward = 0x00
-	YUpward = 0x02
-}
-
 Image: abstract class {
 	_size: IntVector2D
 	_referenceCount: ReferenceCounter
-	_coordinateSystem: CoordinateSystem
 	_canvas: Canvas
 	size ::= this _size
 	width ::= this size x
 	height ::= this size y
-	coordinateSystem ::= this _coordinateSystem
 	crop: IntShell2D { get set }
 	wrap: Bool { get set }
 	referenceCount ::= this _referenceCount
-	transform ::= IntTransform2D createScaling(
-			(this coordinateSystem & CoordinateSystem XLeftward) == CoordinateSystem XLeftward ? -1 : 1,
-			(this coordinateSystem & CoordinateSystem YUpward) == CoordinateSystem YUpward ? -1 : 1)
-
 	canvas: Canvas { get {
 		if (this _canvas == null)
 			this _canvas = this _createCanvas()
 		this _canvas
 	}}
-	init: func (=_size, coordinateSystem := CoordinateSystem Default) {
+	init: func (=_size) {
 		this _referenceCount = ReferenceCounter new(this)
-		this _coordinateSystem = coordinateSystem
 	}
 	init: func ~fromImage (original: This) {
 		this init(original size)
-		this _coordinateSystem = original coordinateSystem
 		this crop = original crop
 		this wrap = original wrap
 	}

--- a/source/draw/README.md
+++ b/source/draw/README.md
@@ -53,6 +53,8 @@ Using destination or transform on the CPU would require a rewrite of legacy draw
 | inputImage | X | X | X |
 | viewport | X | X |  |
 | source | X | X |  |
+| flipSourceX | X | X |  |
+| flipSourceY | X | X |  |
 | destination | X |  |  |
 | transform | X |  |  |
 | focalLength | X |  |  |

--- a/source/draw/RasterCanvas.ooc
+++ b/source/draw/RasterCanvas.ooc
@@ -20,8 +20,8 @@ RasterCanvas: abstract class extends Canvas {
 	_target: RasterImage
 	init: func (=_target) { super(this _target size) }
 	fill: override func (color: ColorRgba) { raise("RasterCanvas fill unimplemented!") }
-	draw: override func ~DrawState (drawState: DrawState) { this _draw(drawState inputImage, drawState getSourceLocal() toIntBox2D(), drawState getViewport(), drawState interpolate) }
-	_draw: virtual func (image: Image, source, destination: IntBox2D, interpolate: Bool) { Debug error("_draw unimplemented for class " + this class name + "!") }
+	draw: override func ~DrawState (drawState: DrawState) { this _draw(drawState inputImage, drawState getSourceLocal() toIntBox2D(), drawState getViewport(), drawState interpolate, drawState flipSourceX, drawState flipSourceY) }
+	_draw: virtual func (image: Image, source, destination: IntBox2D, interpolate, flipX, flipY: Bool) { Debug error("_draw unimplemented for class " + this class name + "!") }
 	drawPoint: override func ~explicit (point: FloatPoint2D, pen: Pen) { this _drawPoint(point x as Int, point y as Int, pen) }
 	_drawPoint: abstract func (x, y: Int, pen: Pen)
 	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {

--- a/source/draw/RasterImage.ooc
+++ b/source/draw/RasterImage.ooc
@@ -17,7 +17,7 @@ RasterImage: abstract class extends Image {
 	distanceRadius ::= 1
 	stride: UInt { get }
 	init: func ~fromRasterImage (original: This) { super(original) }
-	init: func (size: IntVector2D, coordinateSystem := CoordinateSystem Default) { super(size, coordinateSystem) }
+	init: func (size: IntVector2D) { super(size) }
 	apply: abstract func ~rgb (action: Func (ColorRgb))
 	apply: abstract func ~yuv (action: Func (ColorYuv))
 	apply: abstract func ~monochrome (action: Func (ColorMonochrome))

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -49,8 +49,8 @@ RasterMonochrome: class extends RasterPacked {
 	bytesPerPixel ::= 1
 	init: func ~allocate (size: IntVector2D) { super~allocate(size) }
 	init: func ~allocateStride (size: IntVector2D, stride: UInt) { super(size, stride) }
-	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt, coordinateSystem := CoordinateSystem Default) { super(buffer, size, stride, coordinateSystem) }
-	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D, coordinateSystem := CoordinateSystem Default) { this init(buffer, size, this bytesPerPixel * size x, coordinateSystem) }
+	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
+	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
 	init: func ~fromRasterMonochrome (original: This) { super(original) }
 	init: func ~fromRasterImage (original: RasterImage) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
@@ -198,10 +198,10 @@ RasterMonochrome: class extends RasterPacked {
 		((this buffer pointer + y * this stride) as ColorMonochrome* + x)@ = value
 	}
 
-	open: static func (filename: String, coordinateSystem := CoordinateSystem Default) -> This {
+	open: static func (filename: String) -> This {
 		requiredComponents := 1
 		(buffer, size, _) := StbImage load(filename, requiredComponents)
-		This new(buffer, size, coordinateSystem)
+		This new(buffer, size)
 	}
 	convertFrom: static func (original: RasterImage) -> This {
 		result: This

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -26,7 +26,7 @@ RasterMonochromeCanvas: class extends RasterPackedCanvas {
 		if (this target isValidIn(position x, position y))
 			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toMonochrome())
 	}
-	_draw: override func (image: Image, source, destination: IntBox2D, interpolate: Bool) {
+	_draw: override func (image: Image, source, destination: IntBox2D, interpolate, flipX, flipY: Bool) {
 		monochrome: RasterMonochrome = null
 		if (image == null)
 			Debug error("Null image in RasterMonochromeCanvas draw")
@@ -36,7 +36,7 @@ RasterMonochromeCanvas: class extends RasterPackedCanvas {
 			monochrome = RasterMonochrome convertFrom(image as RasterImage)
 		else
 			Debug error("Unsupported image type in RasterMonochromeCanvas draw")
-		this _resizePacked(monochrome buffer pointer as ColorMonochrome*, monochrome, source, destination, interpolate)
+		this _resizePacked(monochrome buffer pointer as ColorMonochrome*, monochrome, source, destination, interpolate, flipX, flipY)
 		if (monochrome != image)
 			monochrome referenceCount decrease()
 	}

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -27,7 +27,7 @@ RasterRgbCanvas: class extends RasterPackedCanvas {
 		if (this target isValidIn(position x, position y))
 			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toRgb())
 	}
-	_draw: override func (image: Image, source, destination: IntBox2D, interpolate: Bool) {
+	_draw: override func (image: Image, source, destination: IntBox2D, interpolate, flipX, flipY: Bool) {
 		rgb: RasterRgb = null
 		if (image == null)
 			Debug error("Null image in RgbRasterCanvas draw")
@@ -37,7 +37,7 @@ RasterRgbCanvas: class extends RasterPackedCanvas {
 			rgb = RasterRgb convertFrom(image as RasterImage)
 		else
 			Debug error("Unsupported image type in RgbRasterCanvas draw")
-		this _resizePacked(rgb buffer pointer as ColorRgb*, rgb, source, destination, interpolate)
+		this _resizePacked(rgb buffer pointer as ColorRgb*, rgb, source, destination, interpolate, flipX, flipY)
 		if (rgb != image)
 			rgb referenceCount decrease()
 	}

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -150,8 +150,8 @@ RasterRgb: class extends RasterPacked {
 	operator [] (x, y: Int) -> ColorRgb { this isValidIn(x, y) ? ((this buffer pointer + y * this stride) as ColorRgb* + x)@ : ColorRgb new(0, 0, 0) }
 	operator []= (x, y: Int, value: ColorRgb) { ((this buffer pointer + y * this stride) as ColorRgb* + x)@ = value }
 
-	open: static func (filename: String, coordinateSystem := CoordinateSystem Default) -> This {
-		rgba := RasterRgba open(filename, coordinateSystem)
+	open: static func (filename: String) -> This {
+		rgba := RasterRgba open(filename)
 		result := This convertFrom(rgba)
 		rgba referenceCount decrease()
 		result

--- a/source/draw/RasterRgba.ooc
+++ b/source/draw/RasterRgba.ooc
@@ -36,8 +36,8 @@ RasterRgba: class extends RasterPacked {
 	bytesPerPixel ::= 4
 	init: func ~allocate (size: IntVector2D) { super~allocate(size) }
 	init: func ~allocateStride (size: IntVector2D, stride: UInt) { super(size, stride) }
-	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt, coordinateSystem := CoordinateSystem Default) { super(buffer, size, stride, coordinateSystem) }
-	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D, coordinateSystem := CoordinateSystem Default) { this init(buffer, size, this bytesPerPixel * size x, coordinateSystem) }
+	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
+	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
 	init: func ~fromRasterRgba (original: This) { super(original) }
 	init: func ~fromRasterImage (original: RasterImage) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
@@ -155,10 +155,10 @@ RasterRgba: class extends RasterPacked {
 		)
 	}
 
-	open: static func (filename: String, coordinateSystem := CoordinateSystem Default) -> This {
+	open: static func (filename: String) -> This {
 		requiredComponents := 4
 		(buffer, size, _) := StbImage load(filename, requiredComponents)
-		result := This new(buffer, size, coordinateSystem)
+		result := This new(buffer, size)
 		result swapRedBlue()
 		result
 	}

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -150,8 +150,8 @@ RasterUv: class extends RasterPacked {
 		rgb referenceCount decrease()
 		result
 	}
-	open: static func (filename: String, coordinateSystem := CoordinateSystem Default) -> This {
-		rasterRgb := RasterRgb open(filename, coordinateSystem)
+	open: static func (filename: String) -> This {
+		rasterRgb := RasterRgb open(filename)
 		result := This convertFrom(rasterRgb)
 		rasterRgb referenceCount decrease()
 		result

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -26,7 +26,7 @@ RasterUvCanvas: class extends RasterPackedCanvas {
 		if (this target isValidIn(position x, position y))
 			this target[position x, position y] = this target[position x, position y] blend(pen alphaAsFloat, pen color toUv())
 	}
-	_draw: override func (image: Image, source, destination: IntBox2D, interpolate: Bool) {
+	_draw: override func (image: Image, source, destination: IntBox2D, interpolate, flipX, flipY: Bool) {
 		uv: RasterUv = null
 		if (image == null)
 			Debug error("Null image in RasterUvCanvas draw")
@@ -36,7 +36,7 @@ RasterUvCanvas: class extends RasterPackedCanvas {
 			uv = RasterUv convertFrom(image as RasterImage)
 		else
 			Debug error("Unsupported image type in RasterUvCanvas draw")
-		this _resizePacked(uv buffer pointer as ColorUv*, uv, source, destination, interpolate)
+		this _resizePacked(uv buffer pointer as ColorUv*, uv, source, destination, interpolate, flipX, flipY)
 		if (uv != image)
 			uv referenceCount decrease()
 	}

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -16,6 +16,7 @@ import RasterUv
 import Image
 import Color
 import Pen
+import DrawState
 import RasterRgb
 import StbImage
 import io/File
@@ -36,6 +37,17 @@ RasterYuv420SemiplanarCanvas: class extends RasterCanvas {
 		yuv := color toYuv()
 		this target y fill(ColorRgba new(yuv y, 0, 0, 255))
 		this target uv fill(ColorRgba new(yuv u, yuv v, 0, 255))
+	}
+	draw: override func ~DrawState (drawState: DrawState) {
+		drawStateY := drawState setTarget((drawState target as RasterYuv420Semiplanar) y)
+		drawStateUV := drawState setTarget((drawState target as RasterYuv420Semiplanar) uv)
+		drawStateUV viewport = drawState viewport / 2
+		if (drawState inputImage != null && drawState inputImage class == RasterYuv420Semiplanar) {
+			drawStateY inputImage = (drawState inputImage as RasterYuv420Semiplanar) y
+			drawStateUV inputImage = (drawState inputImage as RasterYuv420Semiplanar) uv
+		}
+		drawStateY draw()
+		drawStateUV draw()
 	}
 }
 

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -242,8 +242,8 @@ RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {
 		}
 		result
 	}
-	open: static func (filename: String, coordinateSystem := CoordinateSystem Default) -> This {
-		rgb := RasterRgb open(filename, coordinateSystem)
+	open: static func (filename: String) -> This {
+		rgb := RasterRgb open(filename)
 		result := This convertFrom(rgb)
 		rgb free()
 		result

--- a/source/draw/gpu/GpuCanvas.ooc
+++ b/source/draw/gpu/GpuCanvas.ooc
@@ -17,8 +17,7 @@ version(!gpuOff) {
 GpuCanvas: abstract class extends Canvas {
 	_context: GpuContext
 	_defaultMap: Map
-	_coordinateTransform := IntTransform2D identity
-	init: func (size: IntVector2D, =_context, =_defaultMap, =_coordinateTransform) { super(size) }
+	init: func (size: IntVector2D, =_context, =_defaultMap) { super(size) }
 	_getDefaultMap: virtual func (image: Image) -> Map { this _defaultMap }
 	_createTextureTransform: static func ~LocalInt (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
 		This _createTextureTransform(imageSize toFloatVector2D(), box toFloatBox2D())

--- a/source/draw/gpu/GpuCanvas.ooc
+++ b/source/draw/gpu/GpuCanvas.ooc
@@ -19,16 +19,5 @@ GpuCanvas: abstract class extends Canvas {
 	_defaultMap: Map
 	init: func (size: IntVector2D, =_context, =_defaultMap) { super(size) }
 	_getDefaultMap: virtual func (image: Image) -> Map { this _defaultMap }
-	_createTextureTransform: static func ~LocalInt (imageSize: IntVector2D, box: IntBox2D) -> FloatTransform3D {
-		This _createTextureTransform(imageSize toFloatVector2D(), box toFloatBox2D())
-	}
-	_createTextureTransform: static func ~LocalFloat (imageSize: FloatVector2D, box: FloatBox2D) -> FloatTransform3D {
-		This _createTextureTransform(box / imageSize)
-	}
-	_createTextureTransform: static func ~Normalized (normalizedBox: FloatBox2D) -> FloatTransform3D {
-		scaling := FloatTransform3D createScaling(normalizedBox size x, normalizedBox size y, 1.0f)
-		translation := FloatTransform3D createTranslation(normalizedBox leftTop x, normalizedBox leftTop y, 0.0f)
-		translation * scaling
-	}
 }
 }

--- a/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
@@ -16,7 +16,7 @@ version(!gpuOff) {
 GpuCanvasYuv420Semiplanar: class extends GpuCanvas {
 	_target: GpuYuv420Semiplanar
 	init: func (=_target, context: GpuContext) {
-		super(this _target size, context, context defaultMap, IntTransform2D identity)
+		super(this _target size, context, context defaultMap)
 	}
 	draw: override func ~DrawState (drawState: DrawState) {
 		drawStateY := drawState setTarget((drawState target as GpuYuv420Semiplanar) y)

--- a/source/draw/gpu/GpuImage.ooc
+++ b/source/draw/gpu/GpuImage.ooc
@@ -21,7 +21,7 @@ GpuImage: abstract class extends Image {
 			this _canvas = this _createCanvas() as GpuCanvas
 		this _canvas as GpuCanvas
 	}}
-	init: func (size: IntVector2D, =_context, coordinateSystem := CoordinateSystem Default) { super(size, coordinateSystem) }
+	init: func (size: IntVector2D, =_context) { super(size) }
 	resizeTo: override func (size: IntVector2D) -> This {
 		result := this create(size) as This
 		DrawState new(result) setInputImage(this) draw()

--- a/source/draw/gpu/GpuYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuYuv420Semiplanar.ooc
@@ -23,20 +23,19 @@ GpuYuv420Semiplanar: class extends GpuImage {
 			this _uv filter = value
 		}
 	}
-	init: func (=_y, =_uv, context: GpuContext, coordinateSystem := CoordinateSystem Default) {
-		super(this _y size, context, coordinateSystem)
-		this _coordinateSystem = this _y coordinateSystem
+	init: func (=_y, =_uv, context: GpuContext) {
+		super(this _y size, context)
 		(this _y, this _uv) referenceCount increase()
 	}
 	init: func ~fromRaster (rasterImage: RasterYuv420Semiplanar, context: GpuContext) {
 		y := context createImage(rasterImage y)
 		uv := context createImage(rasterImage uv)
-		this init(y, uv, context, rasterImage coordinateSystem)
+		this init(y, uv, context)
 	}
-	init: func ~empty (size: IntVector2D, context: GpuContext, coordinateSystem := CoordinateSystem Default) {
+	init: func ~empty (size: IntVector2D, context: GpuContext) {
 		y := context createMonochrome(size)
 		uv := context createUv(size / 2)
-		this init(y, uv, context, coordinateSystem)
+		this init(y, uv, context)
 	}
 	free: override func {
 		(this y, this uv) referenceCount decrease()

--- a/source/draw/gpu/opengl/AndroidContext.ooc
+++ b/source/draw/gpu/opengl/AndroidContext.ooc
@@ -123,7 +123,7 @@ AndroidContext: class extends OpenGLContext {
 	unpackRgbaToYuv420Semiplanar: func (source: GpuImage, targetSize: IntVector2D, padding := 0) -> GpuYuv420Semiplanar {
 		target := this createYuv420Semiplanar(targetSize) as GpuYuv420Semiplanar
 		sourceSize := source size
-		transform := FloatTransform3D createScaling(source transform a, -source transform e, 1.0f)
+		transform := FloatTransform3D identity
 		yMap: Map = this _unpackRgbaToMonochrome
 		uvMap: Map = this _unpackRgbaToUv
 		if (padding > 0) {

--- a/source/draw/gpu/opengl/EGLRgba.ooc
+++ b/source/draw/gpu/opengl/EGLRgba.ooc
@@ -14,8 +14,8 @@ version(!gpuOff) {
 EGLRgba: class extends OpenGLRgba {
 	_buffer: GraphicBuffer
 	buffer ::= this _buffer
-	init: func ~fromGraphicBuffer (=_buffer, context: OpenGLContext, coordinateSystem := CoordinateSystem Default) {
-		super(EGLImage create(TextureType Rgba, this _buffer size, this _buffer nativeBuffer, context backend), context, coordinateSystem)
+	init: func ~fromGraphicBuffer (=_buffer, context: OpenGLContext) {
+		super(EGLImage create(TextureType Rgba, this _buffer size, this _buffer nativeBuffer, context backend), context)
 	}
 	init: func ~fromSize (size: IntVector2D, context: OpenGLContext) {
 		this init(GraphicBuffer new(size, GraphicBufferFormat Rgba8888, GraphicBufferUsage Texture | GraphicBufferUsage RenderTarget), context)

--- a/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
+++ b/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
@@ -47,7 +47,6 @@ GraphicBufferYuv420Semiplanar: class extends RasterYuv420Semiplanar {
 			this _rgba = EGLRgba new(rgbaBuffer, context)
 			this _rgba referenceCount increase()
 		}
-		this _rgba _coordinateSystem = this coordinateSystem
 		this _rgba referenceCount increase()
 		this _rgba
 	}

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -29,7 +29,7 @@ OpenGLCanvas: class extends GpuCanvas {
 		model := (drawState mesh) ? FloatTransform3D identity : this _createModelTransformNormalized(this size, drawState getDestinationNormalized(), focalLengthPerWidth * this size x)
 		view := (drawState mesh) ? FloatTransform3D identity : this _createView(targetSize, drawState getTransformNormalized())
 		projection := this _createProjection(targetSize, focalLengthPerWidth)
-		textureTransform := This _createTextureTransform(drawState getSourceNormalized())
+		textureTransform := This _createTextureTransform(drawState getSourceNormalized(), drawState flipSourceX, drawState flipSourceY)
 		if (drawState opacity < 1.0f)
 			this context backend blend(drawState opacity)
 		else if (drawState blendMode == BlendMode Add)
@@ -74,6 +74,13 @@ OpenGLCanvas: class extends GpuCanvas {
 	free: override func {
 		this _renderTarget free()
 		super()
+	}
+	_createTextureTransform: static func (normalizedBox: FloatBox2D, flipX, flipY: Bool) -> FloatTransform3D {
+		flipScaleX := flipX ? -1.0f : 1.0f
+		flipScaleY := flipY ? -1.0f : 1.0f
+		scaling := FloatTransform3D createScaling(normalizedBox size x * flipScaleX, normalizedBox size y * flipScaleY, 1.0f)
+		translation := FloatTransform3D createTranslation((normalizedBox leftTop x * flipScaleX) + (flipX ? 1.0f : 0.0f), (normalizedBox leftTop y * flipScaleY) + (flipY ? 1.0f : 0.0f), 0.0f)
+		translation * scaling
 	}
 	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
 		this _renderTarget bind()

--- a/source/draw/gpu/opengl/OpenGLCanvas.ooc
+++ b/source/draw/gpu/opengl/OpenGLCanvas.ooc
@@ -68,7 +68,7 @@ OpenGLCanvas: class extends GpuCanvas {
 			tempImageB free()
 	}
 	init: func (=_target, context: OpenGLContext) {
-		super(this _target size, context, context defaultMap, IntTransform2D identity)
+		super(this _target size, context, context defaultMap)
 		this _renderTarget = context _backend createFramebufferObject(this _target _backend as GLTexture, this _target size)
 	}
 	free: override func {
@@ -103,8 +103,8 @@ OpenGLCanvas: class extends GpuCanvas {
 	_createProjection: func (targetSize: FloatVector2D, focalLengthPerWidth: Float) -> FloatTransform3D {
 		result: FloatTransform3D
 		focalLengthPerHeight := focalLengthPerWidth * targetSize x / targetSize y
-		flipX := this _coordinateTransform a as Float
-		flipY := -(this _coordinateTransform e as Float)
+		flipX := 1.0f
+		flipY := -1.0f
 		if (focalLengthPerWidth > 0.0f) {
 			nearPlane := 0.01f
 			farPlane := 12500.0f

--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -15,13 +15,13 @@ import backend/GLTexture
 
 version(!gpuOff) {
 OpenGLMonochrome: class extends OpenGLPacked {
-	init: func ~fromPixels (size: IntVector2D, stride: UInt, data: Pointer, coordinateSystem: CoordinateSystem, context: OpenGLContext) {
-		super(context _backend createTexture(TextureType Monochrome, size, stride, data), This channelCount, context, coordinateSystem)
+	init: func ~fromPixels (size: IntVector2D, stride: UInt, data: Pointer, context: OpenGLContext) {
+		super(context _backend createTexture(TextureType Monochrome, size, stride, data), This channelCount, context)
 	}
-	init: func (size: IntVector2D, context: OpenGLContext) { this init(size, size x, null, CoordinateSystem YUpward, context) }
+	init: func (size: IntVector2D, context: OpenGLContext) { this init(size, size x, null, context) }
 	init: func ~fromTexture (texture: GLTexture, context: OpenGLContext) { super(texture, This channelCount, context) }
 	init: func ~fromRaster (rasterImage: RasterMonochrome, context: OpenGLContext) {
-		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, rasterImage coordinateSystem, context)
+		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage {
 		result := RasterMonochrome new(this size)

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -28,8 +28,8 @@ OpenGLPacked: abstract class extends GpuImage {
 			this _backend setMinFilter(InterpolationType Linear)
 		}
 	}
-	init: func (=_backend, =_channels, context: OpenGLContext, coordinateSystem := CoordinateSystem Default) {
-		super(this _backend size, context, coordinateSystem)
+	init: func (=_backend, =_channels, context: OpenGLContext) {
+		super(this _backend size, context)
 	}
 	free: override func {
 		if (this recyclable)

--- a/source/draw/gpu/opengl/OpenGLRgb.ooc
+++ b/source/draw/gpu/opengl/OpenGLRgb.ooc
@@ -15,14 +15,14 @@ import OpenGLCanvas, OpenGLPacked, OpenGLContext
 
 version(!gpuOff) {
 OpenGLRgb: class extends OpenGLPacked {
-	init: func (size: IntVector2D, stride: UInt, data: Pointer, coordinateSystem: CoordinateSystem, context: OpenGLContext) {
-		super(context _backend createTexture(TextureType Rgb, size, stride, data, true), This channelCount, context, coordinateSystem)
+	init: func (size: IntVector2D, stride: UInt, data: Pointer, context: OpenGLContext) {
+		super(context _backend createTexture(TextureType Rgb, size, stride, data, true), This channelCount, context)
 	}
 	init: func ~empty (size: IntVector2D, context: OpenGLContext) {
-		this init(size, size x * This channelCount, null, CoordinateSystem YUpward, context)
+		this init(size, size x * This channelCount, null, context)
 	}
 	init: func ~fromRaster (rasterImage: RasterRgb, context: OpenGLContext) {
-		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, rasterImage coordinateSystem, context)
+		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage { Debug error("toRasterDefault not implemented for RGB"); null }
 	toRasterDefault: override func ~target (target: RasterImage) { Debug error("toRasterDefault~target not implemented for RGB") }

--- a/source/draw/gpu/opengl/OpenGLRgba.ooc
+++ b/source/draw/gpu/opengl/OpenGLRgba.ooc
@@ -15,17 +15,17 @@ import OpenGLCanvas, OpenGLPacked, OpenGLContext
 
 version(!gpuOff) {
 OpenGLRgba: class extends OpenGLPacked {
-	init: func ~fromPixels (size: IntVector2D, stride: UInt, data: Pointer, coordinateSystem: CoordinateSystem, context: OpenGLContext) {
-		super(context _backend createTexture(TextureType Rgba, size, stride, data), This channelCount, context, coordinateSystem)
+	init: func ~fromPixels (size: IntVector2D, stride: UInt, data: Pointer, context: OpenGLContext) {
+		super(context _backend createTexture(TextureType Rgba, size, stride, data), This channelCount, context)
 	}
 	init: func (size: IntVector2D, context: OpenGLContext) {
-		this init(size, size x * This channelCount, null, CoordinateSystem YUpward, context)
+		this init(size, size x * This channelCount, null, context)
 	}
-	init: func ~fromTexture (texture: GLTexture, context: OpenGLContext, coordinateSystem := CoordinateSystem Default) {
-		super(texture, This channelCount, context, coordinateSystem)
+	init: func ~fromTexture (texture: GLTexture, context: OpenGLContext) {
+		super(texture, This channelCount, context)
 	}
 	init: func ~fromRaster (rasterImage: RasterRgba, context: OpenGLContext) {
-		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, rasterImage coordinateSystem, context)
+		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage {
 		result := RasterRgba new(this size)

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -15,15 +15,15 @@ import OpenGLCanvas, OpenGLPacked, OpenGLContext, OpenGLMap
 
 version(!gpuOff) {
 OpenGLUv: class extends OpenGLPacked {
-	init: func ~fromPixels (size: IntVector2D, stride: UInt, data: Pointer, coordinateSystem: CoordinateSystem, context: OpenGLContext) {
-		super(context _backend createTexture(TextureType Uv, size, stride, data), This channelCount, context, coordinateSystem)
+	init: func ~fromPixels (size: IntVector2D, stride: UInt, data: Pointer, context: OpenGLContext) {
+		super(context _backend createTexture(TextureType Uv, size, stride, data), This channelCount, context)
 	}
 	init: func (size: IntVector2D, context: OpenGLContext) {
-		this init(size, size x * This channelCount, null, CoordinateSystem YUpward, context)
+		this init(size, size x * This channelCount, null, context)
 	}
 	init: func ~fromTexture (texture: GLTexture, context: OpenGLContext) { super(texture, This channelCount, context) }
 	init: func ~fromRaster (rasterImage: RasterUv, context: OpenGLContext) {
-		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, rasterImage coordinateSystem, context)
+		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage {
 		result := RasterUv new(this size)

--- a/source/draw/gpu/opengl/OpenGLWindow.ooc
+++ b/source/draw/gpu/opengl/OpenGLWindow.ooc
@@ -18,14 +18,11 @@ OpenGLWindow: class extends GpuCanvas {
 	context ::= this _context as OpenGLContext
 	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { raise("Cannot draw lines directly to a window.") }
 	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { raise("Cannot draw lines directly to a window.") }
-	flipMatrix: func -> FloatTransform3D {
-		FloatTransform3D createScaling(this _coordinateTransform a as Float, -(this _coordinateTransform e as Float), 0.0f)
-	}
 	_monochromeToRgba: OpenGLMap
 	_yuvSemiplanarToRgba: OpenGLMapTransform
 	init: func (windowSize: IntVector2D, display: Pointer, nativeBackend: Long) {
 		context := OpenGLContext new(display, nativeBackend)
-		super(windowSize, context, OpenGLMap new(slurp("shaders/texture.frag"), context), IntTransform2D createScaling(1, -1))
+		super(windowSize, context, OpenGLMap new(slurp("shaders/texture.frag"), context))
 		this _monochromeToRgba = OpenGLMap new(slurp("shaders/monochromeToRgba.frag"), context)
 		this _yuvSemiplanarToRgba = OpenGLMapTransform new(slurp("shaders/yuvSemiplanarToRgba.frag"), context)
 	}

--- a/source/ui/x11/UnixWindow.ooc
+++ b/source/ui/x11/UnixWindow.ooc
@@ -73,7 +73,7 @@ UnixWindow: class extends UnixWindowBase {
 			case (matchedImage: GpuImage) =>
 				map add("texture0", matchedImage)
 		}
-		map use(null, this _openGLWindow flipMatrix(), FloatTransform3D identity)
+		map use(null, FloatTransform3D identity, FloatTransform3D identity)
 		this _openGLWindow context backend setViewport(IntBox2D new(image size))
 		this _openGLWindow context backend disableBlend()
 		this _openGLWindow context drawQuad()

--- a/test/draw/RasterCanvasTest.ooc
+++ b/test/draw/RasterCanvasTest.ooc
@@ -99,6 +99,22 @@ RasterCanvasTest: class extends Fixture {
 			(original, image) referenceCount decrease()
 			output free()
 		})
+		this add("draw rgb image", func {
+			inputSpace := "test/draw/input/Space.png"
+			output := "test/draw/output/RasterCanvas_drawYUVonRGB.png"
+			imageFlower := RasterYuv420Semiplanar open(this inputFlower)
+			outputImage := RasterRgb open(inputSpace)
+			DrawState new(outputImage) setInputImage(imageFlower) setViewport(IntBox2D new(20, 30, 100, 250)) setInterpolate(true) draw()
+			imageFlowerYUpward := RasterYuv420Semiplanar open(this inputFlower)
+			DrawState new(outputImage) setInputImage(imageFlowerYUpward) setFlipSourceY(true) setViewport(IntBox2D new(130, 30, 100, 250)) setInterpolate(true) draw()
+			imageFlowerXLeftward := RasterYuv420Semiplanar open(this inputFlower)
+			DrawState new(outputImage) setInputImage(imageFlowerXLeftward) setFlipSourceX(true) setViewport(IntBox2D new(240, 30, 100, 250)) setInterpolate(false) draw()
+			imageFlowerXLeftwardYUpward := RasterYuv420Semiplanar open(this inputFlower)
+			DrawState new(outputImage) setInputImage(imageFlowerXLeftwardYUpward) setFlipSourceX(true) setFlipSourceY(true) setViewport(IntBox2D new(350, 30, 100, 250)) setInterpolate(false) draw()
+			outputImage save(output)
+			(imageFlower, imageFlowerYUpward, imageFlowerXLeftward, imageFlowerXLeftwardYUpward, outputImage) referenceCount decrease()
+			(inputSpace, output) free()
+		})
 		this add("draw uv image", func {
 			output := "test/draw/output/RasterCanvas_drawRGBonUV.png"
 			inputSpace := "test/draw/input/Space.png"

--- a/test/draw/RasterCanvasTest.ooc
+++ b/test/draw/RasterCanvasTest.ooc
@@ -99,22 +99,6 @@ RasterCanvasTest: class extends Fixture {
 			(original, image) referenceCount decrease()
 			output free()
 		})
-		this add("draw rgb image", func {
-			inputSpace := "test/draw/input/Space.png"
-			output := "test/draw/output/RasterCanvas_drawYUVonRGB.png"
-			imageFlower := RasterYuv420Semiplanar open(this inputFlower)
-			outputImage := RasterRgb open(inputSpace)
-			DrawState new(outputImage) setInputImage(imageFlower) setViewport(IntBox2D new(20, 30, 100, 250)) setInterpolate(true) draw()
-			imageFlowerYUpward := RasterYuv420Semiplanar open(this inputFlower, CoordinateSystem YUpward)
-			DrawState new(outputImage) setInputImage(imageFlowerYUpward) setViewport(IntBox2D new(130, 30, 100, 250)) setInterpolate(true) draw()
-			imageFlowerXLeftward := RasterYuv420Semiplanar open(this inputFlower, CoordinateSystem XLeftward)
-			DrawState new(outputImage) setInputImage(imageFlowerXLeftward) setViewport(IntBox2D new(240, 30, 100, 250)) setInterpolate(false) draw()
-			imageFlowerXLeftwardYUpward := RasterYuv420Semiplanar open(this inputFlower, CoordinateSystem XLeftward | CoordinateSystem YUpward)
-			DrawState new(outputImage) setInputImage(imageFlowerXLeftwardYUpward) setViewport(IntBox2D new(350, 30, 100, 250)) setInterpolate(false) draw()
-			outputImage save(output)
-			(imageFlower, imageFlowerYUpward, imageFlowerXLeftward, imageFlowerXLeftwardYUpward, outputImage) referenceCount decrease()
-			(inputSpace, output) free()
-		})
 		this add("draw uv image", func {
 			output := "test/draw/output/RasterCanvas_drawRGBonUV.png"
 			inputSpace := "test/draw/input/Space.png"

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -107,8 +107,6 @@ RasterMonochromeTest: class extends Fixture {
 			image2 := image copy()
 			expect(image size == image2 size)
 			expect(image stride, is equal to(image2 stride))
-			expect(image transform == image2 transform)
-			expect(image coordinateSystem == image2 coordinateSystem)
 			expect(image crop == image2 crop)
 			expect(image wrap, is equal to(image2 wrap))
 			expect(image referenceCount != image2 referenceCount)

--- a/test/draw/RasterRgbTest.ooc
+++ b/test/draw/RasterRgbTest.ooc
@@ -78,6 +78,39 @@ RasterRgbTest: class extends Fixture {
 			(image, image2) referenceCount decrease()
 			outputFast free()
 		})
+		this add("flipping", func {
+			output := "test/draw/output/coordinateswap.png"
+			image := RasterRgb open(this sourceSpace)
+			image2 := image copy()
+
+			image referenceCount decrease()
+			image = RasterRgb open(this sourceSpace)
+			DrawState new(image2) setInputImage(image) setFlipSourceY(true) setInterpolate(false) draw()
+			for (row in 0 .. image2 height)
+				for (column in 0 .. image2 width)
+					expect(image2[column, row] == image[column, image height - row - 1])
+
+			image referenceCount decrease()
+			image = RasterRgb open(this sourceSpace)
+			image2 save(output) . free()
+			image2 = RasterRgb open(output)
+			DrawState new(image2) setInputImage(image) setFlipSourceX(true) setFlipSourceY(true) setInterpolate(false) draw()
+			for (row in 0 .. image2 height)
+				for (column in 0 .. image2 width)
+					expect(image2[column, row] == image[image width - column - 1, image height - row - 1])
+
+			image referenceCount decrease()
+			image = RasterRgb open(this sourceSpace)
+			image2 save(output) . free()
+			image2 = RasterRgb open(output)
+			DrawState new(image2) setInputImage(image) setFlipSourceX(true) setInterpolate(false) draw()
+			for (row in 0 .. image2 height)
+				for (column in 0 .. image2 width)
+					expect(image2[column, row] == image[image width - column - 1, row])
+
+			(image, image2) referenceCount decrease()
+			output free()
+		})
 	}
 }
 

--- a/test/draw/RasterRgbTest.ooc
+++ b/test/draw/RasterRgbTest.ooc
@@ -78,48 +78,6 @@ RasterRgbTest: class extends Fixture {
 			(image, image2) referenceCount decrease()
 			outputFast free()
 		})
-		this add("coordinate systems", func {
-			output := "test/draw/output/coordinateswap.png"
-			image := RasterRgb open(this sourceSpace)
-			image2 := image copy()
-
-			image referenceCount decrease()
-			image = RasterRgb open(this sourceSpace, CoordinateSystem YUpward)
-			DrawState new(image2) setInputImage(image) setInterpolate(false) draw()
-			for (row in 0 .. image2 height)
-				for (column in 0 .. image2 width)
-					expect(image2[column, row] == image[column, image height - row - 1])
-
-			image referenceCount decrease()
-			image = RasterRgb open(this sourceSpace)
-			image2 save(output) . free()
-			image2 = RasterRgb open(output, CoordinateSystem XLeftward | CoordinateSystem YUpward)
-			DrawState new(image2) setInputImage(image) setInterpolate(false) draw()
-			for (row in 0 .. image2 height)
-				for (column in 0 .. image2 width)
-					expect(image2[column, row] == image[image width - column - 1, image height - row - 1])
-
-			image referenceCount decrease()
-			image = RasterRgb open(this sourceSpace, CoordinateSystem XLeftward)
-			image2 save(output) . free()
-			image2 = RasterRgb open(output)
-			DrawState new(image2) setInputImage(image) setInterpolate(false) draw()
-			for (row in 0 .. image2 height)
-				for (column in 0 .. image2 width)
-					expect(image2[column, row] == image[image width - column - 1, row])
-
-			image referenceCount decrease()
-			image = RasterRgb open(this sourceSpace)
-			image2 save(output) . free()
-			image2 = RasterRgb open(output, CoordinateSystem XRightward | CoordinateSystem YDownward)
-			DrawState new(image2) setInputImage(image) setInterpolate(false) draw()
-			for (row in 0 .. image2 height)
-				for (column in 0 .. image2 width)
-					expect(image2[column, row] == image[column, row])
-
-			(image, image2) referenceCount decrease()
-			output free()
-		})
 	}
 }
 

--- a/test/draw/gpu/GpuImageReflectionTest.ooc
+++ b/test/draw/gpu/GpuImageReflectionTest.ooc
@@ -44,6 +44,24 @@ GpuImageReflectionTest: class extends Fixture {
 			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
 			(correctImage, gpuImage, rasterFromGpu) free()
 		})
+		this add("GPU flip X (RGBA)", func {
+			correctImage := RasterRgba open("test/draw/gpu/correct/reflection_rgba_X.png")
+			gpuImage := gpuContext createRgba(this sourceImage size)
+			gpuImage fill(ColorRgba black)
+			DrawState new(gpuImage) setFlipSourceX(true) setInputImage(this sourceImage) draw()
+			rasterFromGpu := gpuImage toRaster()
+			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
+			(correctImage, gpuImage, rasterFromGpu) free()
+		})
+		this add("GPU flip Y (RGBA)", func {
+			correctImage := RasterRgba open("test/draw/gpu/correct/reflection_rgba_Y.png")
+			gpuImage := gpuContext createRgba(this sourceImage size)
+			gpuImage fill(ColorRgba black)
+			DrawState new(gpuImage) setFlipSourceY(true) setInputImage(this sourceImage) draw()
+			rasterFromGpu := gpuImage toRaster()
+			expect(rasterFromGpu distance(correctImage), is equal to(0.0f))
+			(correctImage, gpuImage, rasterFromGpu) free()
+		})
 	}
 	free: override func {
 		this sourceImage free()


### PR DESCRIPTION
I moved the coordinate system from Kean.
Replaced coordinate system with flipSourceX and flipSourceY in DrawState so that the CPU can still flip images without using a transform.