### PR TITLE
Fixed memory leaks in geometry

### DIFF
--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -122,7 +122,7 @@ FloatBox2D: cover {
 		newSize := FloatVector2D linearInterpolation(this size, other size, weight)
 		This createAround(newCenter, newSize)
 	}
-	toString: func -> String { "#{this leftTop toString()}, #{this size toString()}" }
+	toString: func -> String { (this leftTop toString() >> ", ") & this size toString() }
 	toText: func -> Text { this leftTop toText() + t", " + this size toText() }
 	toIntBox2D: func -> IntBox2D { IntBox2D new(this left, this top, this width, this height) }
 

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -41,7 +41,7 @@ FloatPoint2D: cover {
 	polar: static func (radius, azimuth: Float) -> This { This new(radius * cos(azimuth), radius * sin(azimuth)) }
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x as Int, this y as Int) }
 	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x, this y) }
-	toString: func -> String { this x toString() & ", " clone() & this y toString() }
+	toString: func -> String { (this x toString() >> ", ") & this y toString() }
 	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -45,7 +45,7 @@ FloatVector2D: cover {
 	limitLength: func (maximum: Float) -> This { this norm > maximum ? this normalized * maximum : this }
 	toIntVector2D: func -> IntVector2D { IntVector2D new(this x as Int, this y as Int) }
 	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x, this y) }
-	toString: func -> String { "#{this x toString()}, #{this y toString()}" }
+	toString: func -> String { (this x toString() >> ", ") & this y toString() }
 	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -49,7 +49,7 @@ FloatVector3D: cover {
 	limitLength: func (maximum: Float) -> This { this norm > maximum ? this normalized * maximum : this }
 	toIntVector3D: func -> IntVector3D { IntVector3D new(this x as Int, this y as Int, this z as Int) }
 	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x, this y, this z) }
-	toString: func -> String { "#{this x toString()}, #{this y toString()}, #{this z toString()}" }
+	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
 	toText: func -> Text { this x toText() + t", " + this y toText() + t", " + this z toText() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -97,7 +97,7 @@ IntBox2D: cover {
 	}
 	contains: func ~box (box: This) -> Bool { this intersection(box) == box }
 	toFloatBox2D: func -> FloatBox2D { FloatBox2D new(this left, this top, this width, this height) }
-	toString: func -> String { "#{this leftTop toString()}, #{this size toString()}" }
+	toString: func -> String { (this leftTop toString() >> ", ") & this size toString() }
 	toText: func -> Text { this leftTop toText() + t", " + this size toText() }
 
 	operator + (other: This) -> This {

--- a/source/geometry/IntPoint2D.ooc
+++ b/source/geometry/IntPoint2D.ooc
@@ -23,7 +23,7 @@ IntPoint2D: cover {
 	maximum: func (floor: This) -> This { This new(this x maximum(floor x), this y maximum(floor y)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y)) }
 	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x as Float, this y as Float) }
-	toString: func -> String { "#{this x toString()}, #{this y toString()}" }
+	toString: func -> String { (this x toString() >> ", ") & this y toString() }
 	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }

--- a/source/geometry/IntPoint3D.ooc
+++ b/source/geometry/IntPoint3D.ooc
@@ -22,7 +22,7 @@ IntPoint3D: cover {
 	maximum: func (floor: This) -> This { This new(this x maximum(floor x), this y maximum(floor y), this z maximum(floor z)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
 	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x as Float, this y as Float, this z as Float) }
-	toString: func -> String { "#{this x toString()}, #{this y toString()}, #{this z toString()}" }
+	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
 	toText: func -> Text { this x toText() + t", " + this y toText() + t", " + this z toText() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }

--- a/source/geometry/IntVector2D.ooc
+++ b/source/geometry/IntVector2D.ooc
@@ -32,7 +32,7 @@ IntVector2D: cover {
 	polar: static func (radius, azimuth: Float) -> This { This new((radius * cos(azimuth)) as Int, (radius * sin(azimuth)) as Int) }
 	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x as Float, this y as Float) }
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x, this y) }
-	toString: func -> String { "#{this x toString()}, #{this y toString()}" }
+	toString: func -> String { (this x toString() >> ", ") & this y toString() }
 	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }

--- a/source/geometry/IntVector3D.ooc
+++ b/source/geometry/IntVector3D.ooc
@@ -23,7 +23,7 @@ IntVector3D: cover {
 	maximum: func (floor: This) -> This { This new(this x maximum(floor x), this y maximum(floor y), this z maximum(floor z)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
 	toFloatVector3D: func -> FloatVector3D { FloatVector3D new(this x as Float, this y as Float, this z as Float) }
-	toString: func -> String { "#{this x toString()}, #{this y toString()}, #{this z toString()}" }
+	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
 	toText: func -> Text { this x toText() + t", " + this y toText() + t", " + this z toText() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }

--- a/test/geometry/FloatConvexHull2DTest.ooc
+++ b/test/geometry/FloatConvexHull2DTest.ooc
@@ -39,13 +39,13 @@ FloatConvexHull2DTest: class extends Fixture {
 		})
 		this add("hull computation", func {
 			points := VectorList<FloatPoint2D> new()
-			points add(FloatPoint2D new(1.0f, 0.0f)) //hull
-			points add(FloatPoint2D new(-1.0f, 0.0f)) //hull
+			points add(FloatPoint2D new(1.0f, 0.0f)) // hull
+			points add(FloatPoint2D new(-1.0f, 0.0f)) // hull
 			points add(FloatPoint2D new(-1.0f, -1.0f)) // hull
 			points add(FloatPoint2D new(-0.9f, -0.5f)) // inside
-			points add(FloatPoint2D new(0.0f, 1.0f)) //inside
+			points add(FloatPoint2D new(0.0f, 1.0f)) // inside
 			points add(FloatPoint2D new(0.0f, 0.0f)) // inside
-			points add(FloatPoint2D new(0.0f, -1.0f)) //hull
+			points add(FloatPoint2D new(0.0f, -1.0f)) // hull
 			points add(FloatPoint2D new(0.5f, 2.0f)) // hull
 			points add(FloatPoint2D new(-0.5f, 0)) // inside
 
@@ -72,16 +72,16 @@ FloatConvexHull2DTest: class extends Fixture {
 			square := FloatBox2D new(1.0f, 1.0f, 3.0f, 4.0f)
 			hull := FloatConvexHull2D new(square)
 			expect(hull count, is equal to(4))
-			expect(hull toString() == "(1.00, 1.00) (1.00, 5.00) (4.00, 5.00) (4.00, 1.00) ")
-			hull free()
+			string := hull toString()
+			expect(string == "(1.00, 1.00) (1.00, 5.00) (4.00, 5.00) (4.00, 1.00) ")
+			(string, hull) free()
 		})
 		this add("toText", func {
 			square := FloatBox2D new(1.0f, 1.0f, 3.0f, 4.0f)
 			hull := FloatConvexHull2D new(square)
 			text := hull toText() take()
 			expect(text, is equal to(t"(1.00, 1.00) (1.00, 5.00) (4.00, 5.00) (4.00, 1.00)"))
-			hull free()
-			text free()
+			(hull, text) free()
 		})
 	}
 }

--- a/test/geometry/FloatPoint3DTest.ooc
+++ b/test/geometry/FloatPoint3DTest.ooc
@@ -60,10 +60,12 @@ FloatPoint3DTest: class extends Fixture {
 		})
 		this add("casting", func {
 			value := t"12.00000000, 13.00000000, 20.00000000"
-			expect(this point1 toString(), is equal to(value toString()))
+			(point1String, valueString) := (this point1 toString(), value toString())
+			expect(point1String, is equal to(valueString))
 			expect(FloatPoint3D parse(value) x, is equal to(this point1 x))
 			expect(FloatPoint3D parse(value) y, is equal to(this point1 y))
 			expect(FloatPoint3D parse(value) z, is equal to(this point1 z))
+			(point1String, valueString) free()
 		})
 		this add("p norm", func {
 			oneNorm := this point0 pNorm(1.0f)

--- a/test/geometry/FloatTransform2DTest.ooc
+++ b/test/geometry/FloatTransform2DTest.ooc
@@ -286,6 +286,7 @@ FloatTransform2DTest: class extends Fixture {
 		this add("toString", func {
 			string := FloatTransform2D new(3.123456789f, 1.123456789f, 0.12365f, -11.52416f, 0.0f, 1.9) toString()
 			expect(string, is equal to("3.123457, 1.123457, 0.000000\t0.123650, -11.524160, 0.000000\t0.000000, 1.900000, 1.000000\t"))
+			string free()
 		})
 		this add("createSkewingX", func {
 			skewingX := FloatTransform2D createSkewingX(4.0f * Float pi / 3.0f)

--- a/test/geometry/FloatTransform3DTest.ooc
+++ b/test/geometry/FloatTransform3DTest.ooc
@@ -266,7 +266,9 @@ FloatTransform3DTest: class extends Fixture {
 		})
 		this add("casting", func {
 			value := "10.00000000, 40.00000000, 70.00000000, 100.00000000\n20.00000000, 50.00000000, 80.00000000, 110.00000000\n30.00000000, 60.00000000, 90.00000000, 120.00000000\n0.00000000, 0.00000000, 0.00000000, 1.00000000"
-			expect(this transform4 toString(), is equal to(value))
+			string := this transform4 toString()
+			expect(string, is equal to(value))
+			string free()
 		})
 		this add("toText", func {
 			text := FloatTransform3D new(1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3) toText() take()

--- a/test/geometry/IntTransform2DTest.ooc
+++ b/test/geometry/IntTransform2DTest.ooc
@@ -158,6 +158,7 @@ IntTransform2DTest: class extends Fixture {
 		this add("toString", func {
 			string := IntTransform2D new(3, 1, 0, -11, 0, 2) toString()
 			expect(string, is equal to("3, 1, 0\t0, -11, 0\t0, 2, 1\t"))
+			string free()
 		})
 		this add("toFloatTransform2D", func {
 			transform := this transform0 toFloatTransform2D()

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -356,7 +356,9 @@ QuaternionTest: class extends Fixture {
 			expect(interpolated z, is equal to(0.99080002f) within(tolerance))
 		})
 		this add("toString", func {
-			expect(this quaternion0 toString() == "Real: 33.000000 Imaginary: 10.000000 -12.000000 54.500000")
+			string := this quaternion0 toString()
+			expect(string == "Real: 33.000000 Imaginary: 10.000000 -12.000000 54.500000")
+			string free()
 		})
 		this add("weightedQuaternionMean_X", func {
 			this quaternionList clear()


### PR DESCRIPTION
Note: `"#{this x toString()}, #{this y toString()}, #{this z toString()}"` is converted to `this x toString() + ", " + this y toString() + ", " + this z toString()`, which of course (and unfortunately) leaks.