### PR TITLE
Fixed memory leaks in concurrent tests

### DIFF
--- a/test/concurrent/PromiseCollectorTest.ooc
+++ b/test/concurrent/PromiseCollectorTest.ooc
@@ -54,7 +54,7 @@ PromiseCollectorTest: class extends Fixture {
 			promises += Promise start(func { for (i in 0 .. 10_000_000) { } })
 			promises += Promise start(func { for (i in 0 .. 10_000_000) { } })
 			expect(promises wait())
-			promises clear()
+			promises clear() . free()
 		})
 		this add("wait with timeout", func {
 			promises := PromiseCollector new()

--- a/test/concurrent/PromiseTest.ooc
+++ b/test/concurrent/PromiseTest.ooc
@@ -78,7 +78,7 @@ PromiseTest: class extends Fixture {
 			expect(promise2 wait(), is true)
 			result := future wait(t"cancel")
 			expect(result == t"cancel")
-			(result, promise, future) free()
+			(result, promise, promise2, future) free()
 		})
 		this add("nonblocking free", func {
 			promise2 := Promise start(this counter)

--- a/test/concurrent/SynchronizedQueueTest.ooc
+++ b/test/concurrent/SynchronizedQueueTest.ooc
@@ -53,14 +53,15 @@ SynchronizedQueueTest: class extends Fixture {
 		this add("multiple threads", This _testMultipleThreads)
 		this add("multiple threads (class)", This _testMultipleThreadsWithClass)
 		this add("clear and empty", func {
-			queue := SynchronizedQueue<Cell<ULong>> new()
+			queue := SynchronizedQueue<Int> new()
 			for (i in 0 .. 10) {
-				queue enqueue(Cell<ULong> new(i))
+				queue enqueue(i)
 				expect(queue count, is equal to(i + 1))
 			}
 			expect(queue empty, is false)
 			queue clear()
 			expect(queue empty, is true)
+			queue free()
 		})
 	}
 	_testMultipleThreads: static func {

--- a/test/concurrent/ThreadPoolTest.ooc
+++ b/test/concurrent/ThreadPoolTest.ooc
@@ -65,6 +65,7 @@ ThreadPoolTest: class extends Fixture {
 			comparison := t"fail"
 			result := future wait(comparison)
 			expect(result == comparison)
+			pool free()
 		})
 		this add("wait with timeout", func {
 			pool := ThreadPool new(2)

--- a/test/concurrent/ThreadTest.ooc
+++ b/test/concurrent/ThreadTest.ooc
@@ -84,6 +84,7 @@ ThreadTest: class extends Fixture {
 		otherId free()
 		(job as Closure) free()
 		expect(myId equals(Thread currentThreadId()), is true)
+		(thisThreadInstance, otherThreadInstance) free()
 	}
 	_timedJoin: static func {
 		job := func {

--- a/test/concurrent/WaitLockTest.ooc
+++ b/test/concurrent/WaitLockTest.ooc
@@ -69,6 +69,8 @@ WaitLockTest: class extends Fixture {
 		expect(waitResult, is true)
 		waitingThread cancel()
 		expect(waitingThread wait(1.0), is true)
+		(testThread _code as Closure) free()
+		(waitingThread _code as Closure) free()
 		(testThread, waitingThread, waitLock, globalMutex) free()
 	}
 	_testWakeWithPassingCondition: static func {
@@ -108,6 +110,8 @@ WaitLockTest: class extends Fixture {
 		waitingThread start()
 		expect(testThread wait(1.0), is true)
 		expect(waitingThread alive(), is false)
+		(testThread _code as Closure) free()
+		(waitingThread _code as Closure) free()
 		(testThread, waitingThread, waitLock) free()
 	}
 }


### PR DESCRIPTION
Part of the work on #1699 

Eliminating these wasteful leaks have shown some leaks in `Promise`, `PromiseCollector`, and `ThreadPool` that would occur if they're used in ways not currently used today. They will be fixed in a later PR.