### PR TITLE
Fixed memory leaks from Raster* apply()

### DIFF
--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -58,7 +58,9 @@ RasterUv: class extends RasterPacked {
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	copy: override func -> This { This new(this) }
 	apply: override func ~rgb (action: Func(ColorRgb)) {
-		this apply(ColorConvert fromYuv(action))
+		convert := ColorConvert fromYuv(action)
+		this apply(convert)
+		(convert as Closure) free()
 	}
 	apply: override func ~yuv (action: Func(ColorYuv)) {
 		uvRow := this buffer pointer
@@ -80,7 +82,9 @@ RasterUv: class extends RasterPacked {
 		}
 	}
 	apply: override func ~monochrome (action: Func(ColorMonochrome)) {
-		this apply(ColorConvert fromYuv(action))
+		convert := ColorConvert fromYuv(action)
+		this apply(convert)
+		(convert as Closure) free()
 	}
 	resizeTo: override func (size: IntVector2D) -> This {
 		this resizeTo(size, true) as This

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -177,7 +177,7 @@ RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {
 		fileWriter := FileWriter new(filename)
 		fileWriter write(this y buffer pointer as Char*, this y buffer size)
 		fileWriter write(this uv buffer pointer as Char*, this uv buffer size)
-		fileWriter close()
+		fileWriter close() . free()
 	}
 	_createCanvas: override func -> Canvas { RasterYuv420SemiplanarCanvas new(this) }
 

--- a/source/draw/RasterYuvSemiplanar.ooc
+++ b/source/draw/RasterYuvSemiplanar.ooc
@@ -50,10 +50,14 @@ RasterYuvSemiplanar: abstract class extends RasterPlanar {
 		super()
 	}
 	apply: override func ~rgb (action: Func (ColorRgb)) {
-		this apply(ColorConvert fromYuv(action))
+		convert := ColorConvert fromYuv(action)
+		this apply(convert)
+		(convert as Closure) free()
 	}
 	apply: override func ~monochrome (action: Func (ColorMonochrome)) {
-		this apply(ColorConvert fromYuv(action))
+		convert := ColorConvert fromYuv(action)
+		this apply(convert)
+		(convert as Closure) free()
 	}
 	distance: override func (other: Image) -> Float {
 		result := 0.0f


### PR DESCRIPTION
The behaviour in `RasterUv` and `RasterYuvSemiplanar` were different from the `apply` methods in other `Raster` classes.

Also fixed a leak in `saveRaw`.

Fixes the `draw` item of #1699 