### PR TITLE
Added option in Fixture to hide debug output

### DIFF
--- a/source/base/Debug.ooc
+++ b/source/base/Debug.ooc
@@ -27,7 +27,7 @@ Debug: class {
 		This _printFunction = f
 	}
 	print: static func (string: String, level := DebugLevel Everything) {
-		if (This _level == level || (This _level == DebugLevel Everything))
+		if (This _level == level || This _level == DebugLevel Everything)
 			This _printFunction(string)
 	}
 	print: static func ~text (text: Text, level := DebugLevel Everything) {

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -16,10 +16,14 @@ import Modifiers
 Fixture: abstract class {
 	name: String
 	tests := VectorList<Test> new(32, false)
+	_previousDebugFunc: Func (String)
+	_hasPreviousDebugFunc := false
 
 	init: func (=name)
 	free: override func {
 		(this tests, this name) free()
+		if (this _hasPreviousDebugFunc)
+			Debug initialize(this _previousDebugFunc)
 		super()
 	}
 	add: func ~action (name: String, action: Func) {
@@ -137,6 +141,11 @@ Fixture: abstract class {
 		result append(t"was")
 		result append(testedValue toText())
 		result join(' ')
+	}
+	hideDebugOutput: func {
+		this _hasPreviousDebugFunc = true
+		this _previousDebugFunc = Debug _printFunction
+		Debug initialize(func (s: String) { })
 	}
 
 	_testsFailed: static Bool


### PR DESCRIPTION
This allows us to add `this hideDebugOutput()` to a test to remove debug output in a test, which is useful to get clean test output in other projects (like `No sensor set, defaulting to...` and `File not found...`)