### PR TITLE
Fixed memory leaks in LinkedList

### DIFF
--- a/source/collections/LinkedList.ooc
+++ b/source/collections/LinkedList.ooc
@@ -165,8 +165,7 @@ Node: class <T> {
 	init: func
 	init: func ~withParams (=prev, =next, =data)
 	free: override func {
-		if (T inheritsFrom(Object))
-			memfree(this data)
+		memfree(this data)
 		super()
 	}
 }


### PR DESCRIPTION
Well, that was easy. A remnant line from when we weren't using `__onheap__`.
Peer review @thomasfanell ?