### PR TITLE
Using onheap keyword in concurrent classes

### DIFF
--- a/source/concurrent/Promise.ooc
+++ b/source/concurrent/Promise.ooc
@@ -103,7 +103,7 @@ Future: abstract class <T> {
 }
 
 _ThreadFuture: class <T> extends Future<T> {
-	_result: Object
+	_result: __onheap__ T
 	_action: Func
 	_thread: Thread
 	_threadAlive := true
@@ -113,10 +113,7 @@ _ThreadFuture: class <T> extends Future<T> {
 		this _state = _PromiseState Unfinished
 		this _action = func {
 			temporary := task()
-			if (T inheritsFrom(Object))
-				this _result = temporary
-			else
-				this _result = Cell<T> new(temporary)
+			this _result = temporary
 			if (this _state != _PromiseState Cancelled)
 				this _state = _PromiseState Finished
 			if (this _freeOnCompletion) {
@@ -132,6 +129,7 @@ _ThreadFuture: class <T> extends Future<T> {
 			this _freeOnCompletion = true
 			this _thread detach()
 		} else {
+			memfree(this _result)
 			this _thread free()
 			(this _action as Closure) free()
 			super()
@@ -152,10 +150,7 @@ _ThreadFuture: class <T> extends Future<T> {
 	getResult: override func (defaultValue: T) -> T {
 		result := defaultValue
 		if (this _state == _PromiseState Finished && this _result != null)
-			if (T inheritsFrom(Object))
-				result = this _result
-			else
-				result = (this _result as Cell<T>) get()
+			result = this _result
 		result
 	}
 	cancel: override func -> Bool {

--- a/test/concurrent/SynchronizedListTest.ooc
+++ b/test/concurrent/SynchronizedListTest.ooc
@@ -10,6 +10,12 @@ use base
 use concurrent
 use unit
 
+applyIndex: static Int = 0
+applyTestFunc := func (value: Int*) {
+	expect(value@, is equal to(applyIndex + 1))
+	applyIndex = applyIndex + 1
+}
+
 SynchronizedListTest: class extends Fixture {
 	init: func {
 		super("SynchronizedList")
@@ -118,10 +124,7 @@ SynchronizedListTest: class extends Fixture {
 		this add("single thread - apply", func {
 			list := SynchronizedList<Int> new()
 			list add(1) . add(2) . add(3)
-			c := 1
-			list apply(|value|
-				expect(value, is equal to(c))
-				c += 1)
+			list apply(applyTestFunc)
 			list free()
 		})
 		this add("single thread - map", func {

--- a/test/concurrent/ThreadPoolTest.ooc
+++ b/test/concurrent/ThreadPoolTest.ooc
@@ -60,12 +60,13 @@ ThreadPoolTest: class extends Fixture {
 		})
 		this add("threaded_result_cancel", func {
 			pool := ThreadPool new()
-			future := pool getFuture(func { for (i in 0 .. 50_000_000) { } t"pass" })
+			future := pool getFuture(func { for (i in 0 .. 5_000_000) { } t"pass" })
 			future cancel()
 			comparison := t"fail"
 			result := future wait(comparison)
 			expect(result == comparison)
-			pool free()
+			Time sleepMilli(1000)
+			(future, pool) free()
 		})
 		this add("wait with timeout", func {
 			pool := ThreadPool new(2)


### PR DESCRIPTION
This is better than creating a new `Cell` instance every time (which also leaks in certain circumstances, as memchecking the tests show).

This PR fixes *all* (yay!) memory leaks in concurrent tests as part of #1699 together with #1712 

Will have to be tested thoroughly.