### PR TITLE
simple benchmark() function for Profiler

### DIFF
--- a/source/base/Profiler.ooc
+++ b/source/base/Profiler.ooc
@@ -50,6 +50,19 @@ Profiler: class {
 		This _profilers free()
 		This _profilers = null
 	}
+	benchmark: static func (task: Func, timeoutMilliseconds := 1000.0) -> Double {
+		numberOfIterations := 0
+		timer := WallTimer new()
+		totalTime := 0.0
+		while (totalTime < timeoutMilliseconds * 1000.0) {
+			numberOfIterations += 1
+			timer start()
+			task()
+			totalTime += timer stop()
+		}
+		timer free()
+		totalTime / (numberOfIterations * 1000)
+	}
 	_logResults: static func (logMethod: Func (String)) {
 		for (i in 0 .. This _profilers count) {
 			profiler := This _profilers[i]

--- a/test/base/ProfilerTest.ooc
+++ b/test/base/ProfilerTest.ooc
@@ -27,12 +27,19 @@ ProfilerTest: class extends Fixture {
 			expect(content empty(), is false)
 			(profiler, content, file) free()
 		})
+		this add("benchmark", This _testBenchmark)
 		this add("cleanup", func {
 			profiler := Profiler new("for cleanup")
 			profiler start() . stop()
 			profilerToFree := Profiler new("to free")
 			profilerToFree free()
 		})
+	}
+	_testBenchmark: static func {
+		slowTask := func { Time sleepMilli(1) }
+		fastTask := func
+		expect(Profiler benchmark(slowTask, 5), is greater than(Profiler benchmark(fastTask, 5)))
+		(slowTask as Closure, fastTask as Closure) free()
 	}
 }
 


### PR DESCRIPTION
Just a simple idea for basic performance measurements. Use like:
```ooc
use base
include sched

"average : %f ms" printfln(Profiler benchmark(func {
	Time sleepMilli(300)
}))
```

> average : 300.116500 ms

@marcusnaslund what do you think about this ?