### PR TITLE
Added file methods for HashMap

### DIFF
--- a/test/system/FileTest.ooc
+++ b/test/system/FileTest.ooc
@@ -12,7 +12,7 @@ import io/FileWriter
 import io/FileReader
 
 FileTest: class extends Fixture {
-	_testOutput := "test/system/output/"
+	_testOutput := "test/system/output/file/"
 	init: func {
 		super("File")
 		this add("creating directory", func {

--- a/test/system/HashMapTest.ooc
+++ b/test/system/HashMapTest.ooc
@@ -177,6 +177,30 @@ HashMapTest: class extends Fixture {
 
 			hashmap free()
 		})
+		this add("to and from file", func {
+			hashmap := HashMap<String, String> new()
+			hashmap put("pi", "3.14159")
+			hashmap put("e", "2.71828")
+			hashmap put("sqrt(2)", "1.41459")
+			hashmap put("primes", "2,3,5,7,11,13,17")
+			hashmap writeToFile("test/system/output/mathmap.txt")
+			hashmap free()
+
+			tolerance := 0.00001f
+			input := HashMap readFromFile(t"test/system/output/mathmap.txt")
+			expect(input, is notNull)
+			expect(input count, is equal to(4))
+			(piString, eString, sqrtTwoString, primeString) := (input get("pi"), input get("e"), input get("sqrt(2)"), input get("primes"))
+			(pi, e, sqrtTwo) := (piString, eString, sqrtTwoString) toFloat()
+			expect(pi, is equal to(3.14159f) within(tolerance))
+			expect(e, is equal to(2.71828f) within(tolerance))
+			expect(sqrtTwo, is equal to(1.41459f) within(tolerance))
+			primes := primeString split(',')
+			expect(primes count, is equal to(7))
+			primes free()
+
+			input freeContent() . free()
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #1720 

It is now possible to write the contents of a `<String, String>`-hashmap to file. They will be saved in the very simple format
```
key1:value1
key2:value2
key3:value3
...
```
These files can also be read in to create a new `HashMap<String, String>`. Lines with zero (or more than one) colon will be ignored.

---

This is pretty neat:
```ooc
numbers := HashMap readFromFile("mynumbers.txt")
evenNumberString := numbers get("even") split(',')
evenNumbers := IntVectorList new()
for (i in 0 .. evenNumberString count)
    evenNumbers add(evenNumbers[i] toInt())
```

---

Yes, `readFromFile` takes a `Text` argument and `writeToFile` takes a `String` argument... since this is what's expected from `FileReader` and `FileWriter`, respectively. This is a mess we need to figure out.
