### PR TITLE
Fixed incorrect test directory

### DIFF
--- a/test/system/FileTest.ooc
+++ b/test/system/FileTest.ooc
@@ -12,7 +12,7 @@ import io/FileWriter
 import io/FileReader
 
 FileTest: class extends Fixture {
-	_testOutput := "test/sdk/output/"
+	_testOutput := "test/system/output/"
 	init: func {
 		super("File")
 		this add("creating directory", func {


### PR DESCRIPTION
I've always wondered why I kept getting an empty `test/sdk` folder even after I had deleted it.... now I know.
@sebastianbaginski ?