### PR TITLE
Only drawing to packed images

### DIFF
--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -43,6 +43,8 @@ Image: abstract class {
 		this _canvas = null
 		super()
 	}
+	getFirstPacked: abstract func -> This
+	getSecondPacked: abstract func -> This
 	drawPoint: func ~white (position: FloatPoint2D) { this canvas drawPoint~white(position) }
 	drawPoint: func ~explicit (position: FloatPoint2D, pen: Pen) { this canvas drawPoint~explicit(position, pen) }
 	drawLine: func ~white (start, end: FloatPoint2D) { this canvas drawLine~white(start, end) }

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -127,6 +127,8 @@ RasterPacked: abstract class extends RasterImage {
 		this _buffer = null
 		super()
 	}
+	getFirstPacked: override func -> This { this }
+	getSecondPacked: override func -> This { null }
 	equals: func (other: Image) -> Bool {
 		other instanceOf(This) && this bytesPerPixel == (other as This) bytesPerPixel && this as Image equals(other)
 	}

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -38,17 +38,6 @@ RasterYuv420SemiplanarCanvas: class extends RasterCanvas {
 		this target y fill(ColorRgba new(yuv y, 0, 0, 255))
 		this target uv fill(ColorRgba new(yuv u, yuv v, 0, 255))
 	}
-	draw: override func ~DrawState (drawState: DrawState) {
-		drawStateY := drawState setTarget((drawState target as RasterYuv420Semiplanar) y)
-		drawStateUV := drawState setTarget((drawState target as RasterYuv420Semiplanar) uv)
-		drawStateUV viewport = drawState viewport / 2
-		if (drawState inputImage != null && drawState inputImage class == RasterYuv420Semiplanar) {
-			drawStateY inputImage = (drawState inputImage as RasterYuv420Semiplanar) y
-			drawStateUV inputImage = (drawState inputImage as RasterYuv420Semiplanar) uv
-		}
-		drawStateY draw()
-		drawStateUV draw()
-	}
 }
 
 RasterYuv420Semiplanar: class extends RasterYuvSemiplanar {

--- a/source/draw/RasterYuvSemiplanar.ooc
+++ b/source/draw/RasterYuvSemiplanar.ooc
@@ -21,6 +21,8 @@ RasterYuvSemiplanar: abstract class extends RasterPlanar {
 	_uv: RasterUv
 	y ::= this _y
 	uv ::= this _uv
+	getFirstPacked: override func -> Image { this _y }
+	getSecondPacked: override func -> Image { this _uv }
 	crop: IntShell2D {
 		get
 		set (value) {

--- a/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuCanvasYuv420Semiplanar.ooc
@@ -18,17 +18,6 @@ GpuCanvasYuv420Semiplanar: class extends GpuCanvas {
 	init: func (=_target, context: GpuContext) {
 		super(this _target size, context, context defaultMap)
 	}
-	draw: override func ~DrawState (drawState: DrawState) {
-		drawStateY := drawState setTarget((drawState target as GpuYuv420Semiplanar) y)
-		drawStateUV := drawState setTarget((drawState target as GpuYuv420Semiplanar) uv)
-		drawStateUV viewport = drawState viewport / 2
-		if (drawState inputImage != null && drawState inputImage class == GpuYuv420Semiplanar) {
-			drawStateY inputImage = (drawState inputImage as GpuYuv420Semiplanar) y
-			drawStateUV inputImage = (drawState inputImage as GpuYuv420Semiplanar) uv
-		}
-		drawStateY draw()
-		drawStateUV draw()
-	}
 	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) {
 		yuv := pen color toYuv()
 		this _target y canvas drawLines(pointList, Pen new(ColorRgba new(yuv y, 0, 0, 255), pen width))

--- a/source/draw/gpu/GpuYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuYuv420Semiplanar.ooc
@@ -16,6 +16,8 @@ GpuYuv420Semiplanar: class extends GpuImage {
 	_uv: GpuImage
 	y ::= this _y
 	uv ::= this _uv
+	getFirstPacked: override func -> Image { this _y }
+	getSecondPacked: override func -> Image { this _uv }
 	filter: Bool {
 		get { this _y filter }
 		set(value) {

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -39,6 +39,8 @@ OpenGLPacked: abstract class extends GpuImage {
 			super()
 		}
 	}
+	getFirstPacked: override func -> This { this }
+	getSecondPacked: override func -> This { null }
 	upload: override func (image: RasterImage) {
 		if (image instanceOf(RasterPacked)) {
 			raster := image as RasterPacked


### PR DESCRIPTION
Drawing to YUV images has been removed so that DrawState can take multiple input images with explicit indices to reduce confusion in the most common cases.
`getFirstPacked` and `getSecondPacked` were created to handle this transition because some calls were CPU/GPU agnostic and there is no type for YUV semiplanar on both CPU and GPU. The Y and UV channels cannot be mentioned in `Image`.

Later I will remove the drawing from YUV image and start to take all input textures by indices in DrawState so that the interface is consistent with one instead of three ways of doing the same thing. Then I can easily add more safety features against uninitialized memory and crashes that depend on drivers and hardware.