### PR TITLE
Inlined GpuCanvas into OpenGLWindow 

### DIFF
--- a/source/draw/gpu/opengl/OpenGLWindow.ooc
+++ b/source/draw/gpu/opengl/OpenGLWindow.ooc
@@ -13,24 +13,22 @@ use opengl
 use base
 
 version(!gpuOff) {
-OpenGLWindow: class extends GpuCanvas {
-	_toLocal := FloatTransform3D createScaling(1.0f, -1.0f, -1.0f)
+OpenGLWindow: class {
+	_context: GpuContext
 	context ::= this _context as OpenGLContext
-	drawLines: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { raise("Cannot draw lines directly to a window.") }
-	drawPoints: override func ~explicit (pointList: VectorList<FloatPoint2D>, pen: Pen) { raise("Cannot draw lines directly to a window.") }
 	_monochromeToRgba: OpenGLMap
 	_yuvSemiplanarToRgba: OpenGLMapTransform
-	init: func (windowSize: IntVector2D, display: Pointer, nativeBackend: Long) {
+	init: func (display: Pointer, nativeBackend: Long) {
 		context := OpenGLContext new(display, nativeBackend)
-		super(windowSize, context, OpenGLMap new(slurp("shaders/texture.frag"), context))
+		this _context = context
 		this _monochromeToRgba = OpenGLMap new(slurp("shaders/monochromeToRgba.frag"), context)
 		this _yuvSemiplanarToRgba = OpenGLMapTransform new(slurp("shaders/yuvSemiplanarToRgba.frag"), context)
 	}
 	free: override func {
-		(this _yuvSemiplanarToRgba, this _monochromeToRgba, this _defaultMap, this _context) free()
+		(this _yuvSemiplanarToRgba, this _monochromeToRgba, this _context) free()
 		super()
 	}
-	_getDefaultMap: override func (image: Image) -> Map {
+	_getDefaultMap: func (image: Image) -> Map {
 		match (image class) {
 			case GpuYuv420Semiplanar => this _yuvSemiplanarToRgba
 			case RasterYuv420Semiplanar => this _yuvSemiplanarToRgba
@@ -40,6 +38,5 @@ OpenGLWindow: class extends GpuCanvas {
 		}
 	}
 	refresh: func { this context update() }
-	fill: override func (color: ColorRgba)
 }
 }

--- a/source/ui/x11/UnixWindow.ooc
+++ b/source/ui/x11/UnixWindow.ooc
@@ -48,7 +48,7 @@ UnixWindow: class extends UnixWindowBase {
 	context ::= this _openGLWindow context
 	init: func (size: IntVector2D, title: String) {
 		super(size, title)
-		this _openGLWindow = OpenGLWindow new(this _xWindow size, this _xWindow display, this _xWindow backend)
+		this _openGLWindow = OpenGLWindow new(this _xWindow display, this _xWindow backend)
 	}
 	free: override func {
 		this _openGLWindow free()


### PR DESCRIPTION
Inlined GpuCanvas into OpenGLWindow since all it did was holding a pointer to the context.
By seeing what was unused and not having to override unused methods anymore, this code duplication actually reduced the amount of code.
After this, `Canvas` should be possible to merge into `Image`.