### PR TITLE
Cleaning up image constructors

### DIFF
--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -20,9 +20,6 @@ Image: abstract class {
 	init: func (=_size) {
 		this _referenceCount = ReferenceCounter new(this)
 	}
-	init: func ~fromImage (original: This) {
-		this init(original size)
-	}
 	free: override func {
 		if (this referenceCount != null)
 			this referenceCount free()

--- a/source/draw/RasterImage.ooc
+++ b/source/draw/RasterImage.ooc
@@ -17,7 +17,6 @@ import StbImage
 RasterImage: abstract class extends Image {
 	distanceRadius ::= 1
 	stride: UInt { get }
-	init: func ~fromRasterImage (original: This) { super(original) }
 	init: func (size: IntVector2D) { super(size) }
 	apply: abstract func ~rgb (action: Func (ColorRgb))
 	apply: abstract func ~yuv (action: Func (ColorYuv))

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -33,12 +33,12 @@ RasterPacked: abstract class extends RasterImage {
 		this init(ByteBuffer new(stride * size y), size, stride)
 	}
 	init: func ~fromOriginal (original: This) {
-		super(original)
+		super(original size)
 		this _buffer = original buffer copy()
 		this _stride = original stride
 	}
 	init: func ~fromRasterImage (original: RasterImage) {
-		super(original)
+		super(original size)
 		this _stride = this bytesPerPixel * original width
 		this _buffer = ByteBuffer new(this stride * original height)
 	}

--- a/source/draw/RasterYuv420Semiplanar.ooc
+++ b/source/draw/RasterYuv420Semiplanar.ooc
@@ -29,19 +29,9 @@ RasterYuv420Semiplanar: class extends RasterImage {
 	y ::= this _y
 	uv ::= this _uv
 	stride ::= this _y stride
-	init: func ~fromRasterImages (yImage: RasterMonochrome, uvImage: RasterUv) {
-		super(yImage size)
-		this _y = yImage
-		this _y referenceCount increase()
-		this _uv = uvImage
-		this _uv referenceCount increase()
-	}
-	init: func ~fromYuvSemiplanar (original: This, y: RasterMonochrome, uv: RasterUv) {
-		super(original)
-		this _y = y
-		this _y referenceCount increase()
-		this _uv = uv
-		this _uv referenceCount increase()
+	init: func ~fromRasterImages (=_y, =_uv) {
+		super(this _y size)
+		(this _y, this _uv) referenceCount increase()
 	}
 	init: func ~allocateOffset (size: IntVector2D, stride: UInt, uvOffset: UInt) {
 		(yImage, uvImage) := This _allocate(size, stride, uvOffset)
@@ -51,7 +41,7 @@ RasterYuv420Semiplanar: class extends RasterImage {
 	init: func ~allocate (size: IntVector2D) { this init(size, size x) }
 	init: func ~fromThis (original: This) {
 		(yImage, uvImage) := This _allocate(original size, original stride, original stride * original size y)
-		this init(original, yImage, uvImage)
+		this init(yImage, uvImage)
 	}
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D, stride: UInt, uvOffset: UInt) {
 		(yImage, uvImage) := This _createSubimages(buffer, size, stride, uvOffset)


### PR DESCRIPTION
Removed some of the image constructors that took an image just to get the same size.
I am trying to override the copy function instead of using the constructors for everything but since there are 13 constructors to choose from, any remaining call to the removed constructor will always match another constructor with a completely different meaning.