### PR TITLE
Removing more image constructors

### DIFF
--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -23,7 +23,6 @@ RasterMonochrome: class extends RasterPacked {
 	init: func ~allocateStride (size: IntVector2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
-	init: func ~fromRasterMonochrome (original: This) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -47,7 +46,7 @@ RasterMonochrome: class extends RasterPacked {
 	fill: override func (color: ColorRgba) {
 		this buffer memset(color r)
 	}
-	copy: override func -> This { This new(this) }
+	copy: override func -> This { This new(this buffer copy(), this size, this stride) }
 	apply: override func ~rgb (action: Func(ColorRgb)) {
 		convert := ColorConvert fromMonochrome(action)
 		this apply(convert)

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -24,7 +24,6 @@ RasterMonochrome: class extends RasterPacked {
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
 	init: func ~fromRasterMonochrome (original: This) { super(original) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -200,7 +199,7 @@ RasterMonochrome: class extends RasterPacked {
 		if (original instanceOf(This))
 			result = (original as This) copy()
 		else {
-			result = This new(original)
+			result = This new(original size)
 			row := result buffer pointer as PtrDiff
 			rowLength := result stride
 			rowEnd := row + rowLength

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -32,11 +32,6 @@ RasterPacked: abstract class extends RasterImage {
 		stride := this bytesPerPixel * size x
 		this init(ByteBuffer new(stride * size y), size, stride)
 	}
-	init: func ~fromOriginal (original: This) {
-		super(original size)
-		this _buffer = original buffer copy()
-		this _stride = original stride
-	}
 	free: override func {
 		if (this _buffer != null)
 			this _buffer referenceCount decrease()

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -37,11 +37,6 @@ RasterPacked: abstract class extends RasterImage {
 		this _buffer = original buffer copy()
 		this _stride = original stride
 	}
-	init: func ~fromRasterImage (original: RasterImage) {
-		super(original size)
-		this _stride = this bytesPerPixel * original width
-		this _buffer = ByteBuffer new(this stride * original height)
-	}
 	free: override func {
 		if (this _buffer != null)
 			this _buffer referenceCount decrease()

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -25,7 +25,6 @@ RasterRgb: class extends RasterPacked {
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
 	init: func ~fromRasterRgb (original: This) { super(original) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -162,7 +161,7 @@ RasterRgb: class extends RasterPacked {
 		if (original instanceOf(This))
 			result = (original as This) copy()
 		else {
-			result = This new(original)
+			result = This new(original size)
 			row := result buffer pointer as PtrDiff
 			rowLength := result size x
 			rowEnd := row as ColorRgb* + rowLength

--- a/source/draw/RasterRgb.ooc
+++ b/source/draw/RasterRgb.ooc
@@ -24,7 +24,6 @@ RasterRgb: class extends RasterPacked {
 	init: func ~allocateStride (size: IntVector2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
-	init: func ~fromRasterRgb (original: This) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -50,7 +49,7 @@ RasterRgb: class extends RasterPacked {
 			for (x in 0 .. this size x)
 				this[x, y] = color toRgb()
 	}
-	copy: override func -> This { This new(this) }
+	copy: override func -> This { This new(this buffer copy(), this size, this stride) }
 	apply: override func ~rgb (action: Func(ColorRgb)) {
 		for (row in 0 .. this size y)
 			for (pixel in 0 .. this size x) {

--- a/source/draw/RasterRgba.ooc
+++ b/source/draw/RasterRgba.ooc
@@ -23,7 +23,6 @@ RasterRgba: class extends RasterPacked {
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
 	init: func ~fromRasterRgba (original: This) { super(original) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -169,7 +168,7 @@ RasterRgba: class extends RasterPacked {
 		if (original instanceOf(This))
 			result = (original as This) copy()
 		else {
-			result = This new(original)
+			result = This new(original size)
 			row := result buffer pointer as PtrDiff
 			rowLength := result stride
 			rowEnd := row + rowLength

--- a/source/draw/RasterRgba.ooc
+++ b/source/draw/RasterRgba.ooc
@@ -22,7 +22,6 @@ RasterRgba: class extends RasterPacked {
 	init: func ~allocateStride (size: IntVector2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
-	init: func ~fromRasterRgba (original: This) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -34,7 +33,7 @@ RasterRgba: class extends RasterPacked {
 			for (x in 0 .. this size x)
 				this[x, y] = color
 	}
-	copy: override func -> This { This new(this) }
+	copy: override func -> This { This new(this buffer copy(), this size, this stride) }
 	apply: override func ~rgb (action: Func(ColorRgb)) {
 		for (row in 0 .. this size y) {
 			source := this buffer pointer + row * this stride

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -23,7 +23,6 @@ RasterUv: class extends RasterPacked {
 	init: func ~allocateStride (size: IntVector2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
-	init: func ~fromRasterUv (original: This) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -49,7 +48,7 @@ RasterUv: class extends RasterPacked {
 			for (x in 0 .. this size x)
 				this[x, y] = ColorUv new(color r, color g)
 	}
-	copy: override func -> This { This new(this) }
+	copy: override func -> This { This new(this buffer copy(), this size, this stride) }
 	apply: override func ~rgb (action: Func(ColorRgb)) {
 		convert := ColorConvert fromYuv(action)
 		this apply(convert)

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -24,7 +24,6 @@ RasterUv: class extends RasterPacked {
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntVector2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntVector2D) { this init(buffer, size, this bytesPerPixel * size x) }
 	init: func ~fromRasterUv (original: This) { super(original) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
 	create: override func (size: IntVector2D) -> Image { This new(size) }
 	_drawPoint: override func (x, y: Int, pen: Pen) {
 		position := this _map(IntPoint2D new(x, y))
@@ -152,7 +151,7 @@ RasterUv: class extends RasterPacked {
 		if (original instanceOf(This))
 			result = (original as This) copy()
 		else {
-			result = This new(original)
+			result = This new(original size)
 			row := result buffer pointer
 			rowLength := result size x
 			rowEnd := row as ColorUv* + rowLength


### PR DESCRIPTION
Removing two image constructors that were almost impossible to remove. I had to remove the constructor taking RasterImage before I could remove the constructor taking RasterPacked. When done in the wrong order, calls with RasterPacked were automatically accepted as the unpadded non-copying method accepting RasterPacked as RasterImage leading to segmentation fault and missing data.