### PR TITLE
Keyword

### DIFF
--- a/source/draw/Map.ooc
+++ b/source/draw/Map.ooc
@@ -59,7 +59,7 @@ Map: abstract class {
 		this _bindings free()
 		super()
 	}
-	use: abstract func (forbiddenInput: Pointer, positionTransform, textureTransform: FloatTransform3D)
+	useProgram: abstract func (forbiddenInput: Pointer, positionTransform, textureTransform: FloatTransform3D)
 	add: func <T> (key: String, value: T) {
 		if (T inheritsFrom(Object))
 			this _bindings add(key, value as Object, false)

--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -90,14 +90,14 @@ OpenGLContext: class extends GpuContext {
 	drawLines: func (pointList: VectorList<FloatPoint2D>, projection: FloatTransform3D, pen: Pen) {
 		positions := pointList pointer as Float*
 		this _linesShader add("color", pen color normalized)
-		this _linesShader use(null, projection, FloatTransform3D identity)
+		this _linesShader useProgram(null, projection, FloatTransform3D identity)
 		this _renderer drawLines(positions, pointList count, 2, pen width)
 	}
 	drawPoints: func (pointList: VectorList<FloatPoint2D>, projection: FloatTransform3D, pen: Pen) {
 		positions := pointList pointer
 		this _pointsShader add("color", pen color normalized)
 		this _pointsShader add("pointSize", pen width)
-		this _pointsShader use(null, projection, FloatTransform3D identity)
+		this _pointsShader useProgram(null, projection, FloatTransform3D identity)
 		this _renderer drawPoints(positions, pointList count, 2)
 	}
 	recycle: virtual func (image: OpenGLPacked) {

--- a/source/draw/gpu/opengl/OpenGLMap.ooc
+++ b/source/draw/gpu/opengl/OpenGLMap.ooc
@@ -47,8 +47,8 @@ OpenGLMap: class extends Map {
 		this _program free()
 		super()
 	}
-	use: override func (forbiddenInput: Pointer, positionTransform, textureTransform: FloatTransform3D) {
-		this _currentProgram use()
+	useProgram: override func (forbiddenInput: Pointer, positionTransform, textureTransform: FloatTransform3D) {
+		this _currentProgram useProgram()
 		textureCount := 0
 		action := func (key: String, value: Object) {
 			program := this _currentProgram
@@ -94,7 +94,7 @@ OpenGLMap: class extends Map {
 							case Float => program setUniform(key, vector _backend as Float*, vector capacity)
 							case => Debug error("Invalid Vector type in OpenGLMap use")
 						}
-					case => Debug error("Invalid object type in OpenGLMap use: %s" format(value class name))
+					case => Debug error("Invalid object type in OpenGLMap useProgram: %s" format(value class name))
 				}
 		}
 		this apply(action)
@@ -104,7 +104,7 @@ OpenGLMap: class extends Map {
 
 OpenGLMapTransform: class extends OpenGLMap {
 	init: func (fragmentSource: String, context: OpenGLContext) { super(This vertexSource, fragmentSource, context) }
-	use: override func (forbiddenInput: Pointer, positionTransform: FloatTransform3D, textureTransform: FloatTransform3D) {
+	useProgram: override func (forbiddenInput: Pointer, positionTransform: FloatTransform3D, textureTransform: FloatTransform3D) {
 		this add("transform", positionTransform)
 		this add("textureTransform", textureTransform)
 		super(forbiddenInput, positionTransform, textureTransform)

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -84,7 +84,7 @@ OpenGLPacked: abstract class extends GpuImage {
 					gpuMap add("texture0", image)
 			}
 		}
-		gpuMap use(this, projection * view * model, textureTransform)
+		gpuMap useProgram(this, projection * view * model, textureTransform)
 		this _renderTarget bind()
 		if (drawState mesh)
 			drawState mesh draw()

--- a/source/draw/gpu/opengl/backend/GLShaderProgram.ooc
+++ b/source/draw/gpu/opengl/backend/GLShaderProgram.ooc
@@ -11,7 +11,7 @@ use draw
 
 version(!gpuOff) {
 GLShaderProgram: abstract class {
-	use: abstract func
+	useProgram: abstract func
 	setUniform: abstract func ~Int (name: String, x: Int)
 	setUniform: abstract func ~Int2 (name: String, x, y: Int)
 	setUniform: abstract func ~Int3 (name: String, x, y, z: Int)

--- a/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
@@ -23,10 +23,10 @@ Gles3ShaderProgram: class extends GLShaderProgram {
 		version(debugGL) { validateEnd("ShaderProgram dispose") }
 		super()
 	}
-	use: override func {
-		version(debugGL) { validateStart("ShaderProgram use") }
+	useProgram: override func {
+		version(debugGL) { validateStart("ShaderProgram useProgram") }
 		glUseProgram(this _backend)
-		version(debugGL) { validateEnd("ShaderProgram use") }
+		version(debugGL) { validateEnd("ShaderProgram useProgram") }
 	}
 	setUniform: override func ~Int (name: String, x: Int) {
 		version(debugGL) { validateStart("ShaderProgram setUniform~Int") }

--- a/source/ui/x11/UnixWindow.ooc
+++ b/source/ui/x11/UnixWindow.ooc
@@ -80,7 +80,7 @@ UnixWindow: class extends UnixWindowBase {
 			case (matchedImage: GpuImage) =>
 				map add("texture0", matchedImage)
 		}
-		map use(null, FloatTransform3D identity, FloatTransform3D identity)
+		map useProgram(null, FloatTransform3D identity, FloatTransform3D identity)
 		this context backend setViewport(IntBox2D new(image size))
 		this context backend disableBlend()
 		this context drawQuad()


### PR DESCRIPTION
Changed two keyword identifiers. One of them caused text colors to malfunction in Atom.

Cells are also using the get keyword as an identifier but that is hard to change without version conflicts.