### PR TITLE
Removed use of Text in uri namespace

### DIFF
--- a/source/base/StringBuilder.ooc
+++ b/source/base/StringBuilder.ooc
@@ -7,8 +7,10 @@
  */
 
 StringBuilder: class {
-	_items := VectorList<String> new()
-	init: func
+	_items: VectorList<String>
+	init: func (capacity := 32) {
+		this _items = VectorList<String> new(capacity, false)
+	}
 	free: override func {
 		this _items free()
 		super()

--- a/source/system/CharBuffer.ooc
+++ b/source/system/CharBuffer.ooc
@@ -444,7 +444,7 @@ CharBuffer: class {
 				break
 			sdist := findResults[item] - sstart // bytes to copy
 			if (maxTokens != 0 || sdist > 0) {
-				b := This new ((this data + sstart) as CString, sdist)
+				b := This new((this data + sstart) as CString, sdist)
 				result add(b)
 			}
 			sstart += sdist + delimiterLength

--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -100,7 +100,7 @@ String: class {
 	_bufVectorListToStrVectorList: func (x: VectorList<CharBuffer>) -> VectorList<This> {
 		result := VectorList<This> new(x count)
 		for (i in 0 .. x count)
-			result add (x[i] toString())
+			result add(x[i] toString())
 		result
 	}
 	capitalize: func -> This {
@@ -127,7 +127,10 @@ String: class {
 		this _bufVectorListToStrVectorList(this _buffer split(c, maxTokens))
 	}
 	split: func ~withStringWithoutmaxTokens (s: This) -> VectorList<This> {
-		this _bufVectorListToStrVectorList(this _buffer split(s _buffer, -1))
+		bufferSplit := this _buffer split(s _buffer)
+		result := this _bufVectorListToStrVectorList(bufferSplit)
+		bufferSplit free()
+		result
 	}
 	split: func ~withCharWithoutmaxTokens (c: Char) -> VectorList<This> {
 		bufferSplit := this _buffer split(c)

--- a/source/uri/Authority.ooc
+++ b/source/uri/Authority.ooc
@@ -6,6 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+use base
 use uri
 
 Authority: class {
@@ -14,7 +15,7 @@ Authority: class {
 	user ::= this _user
 	endpoint ::= this _endpoint
 
-	init: func(=_user, =_endpoint)
+	init: func (=_user, =_endpoint)
 	free: override func {
 		if (this _user != null)
 			this _user free()
@@ -22,25 +23,35 @@ Authority: class {
 			this _endpoint free()
 		super()
 	}
-	toText: func -> Text {
-		result := Text new()
-		if (this _user != null)
-			result += this _user toText() + t"@"
-		if (this _endpoint != null)
-			result += this _endpoint toText()
+	toString: func -> String {
+		contents := StringBuilder new()
+		userString: String = null
+		endpointString: String = null
+		if (this _user != null) {
+			userString = this _user toString()
+			contents add(userString) . add("@")
+		}
+		if (this _endpoint != null) {
+			endpointString = this _endpoint toString()
+			contents add(endpointString)
+		}
+		result := contents join("")
+		contents free()
+		if (userString != null)
+			userString free()
+		if (endpointString != null)
+			endpointString free()
 		result
 	}
-	parse: static func(data: Text) -> This {
+	parse: static func (data: String) -> This {
 		result: This
-		d := data take()
-		if (!d isEmpty) {
-			splitted := d split(t"@")
-			newUser := splitted count > 1 ? User parse(splitted remove(0)) : null
-			newEndpoint := Endpoint parse(splitted remove())
+		if (!data empty()) {
+			splitted := data split('@')
+			newUser := splitted count > 1 ? User parse(splitted[0]) : null
+			newEndpoint := splitted count > 1 ? Endpoint parse(splitted[1]) : Endpoint parse(splitted[0])
 			result = This new(newUser, newEndpoint)
 			splitted free()
 		}
-		data free(Owner Receiver)
 		result
 	}
 }

--- a/source/uri/Endpoint.ooc
+++ b/source/uri/Endpoint.ooc
@@ -6,48 +6,42 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+use base
+
 Endpoint: class {
-	_host: VectorList<Text>
+	_host: VectorList<String>
 	_port: Int
-	host: VectorList<Text> { get {
-		result := VectorList<Text> new()
-		for (i in 0 .. this _host count)
-			result add(this _host[i] take())
-		result
-	}}
+	host ::= this _host
 	port ::= this _port
 
 	init: func (=_host, =_port)
 	free: override func {
-		for (i in 0 .. this _host count)
-			this _host[i] free(Owner Receiver)
 		this _host free()
 		super()
 	}
-	toText: func -> Text {
-		result := Text new()
-		for (i in 0 .. this _host count)
-			result += i == 0 ? this _host[i] take() : t"." + this _host[i] take()
-		if (this _port != 0) {
-			portString := this _port toString()
-			result += t":" + Text new(portString)
-			portString free()
+	toString: func -> String {
+		contents := StringBuilder new()
+		for (i in 0 .. this _host count) {
+			if (i != 0)
+				contents add(".")
+			contents add(this _host[i])
 		}
+		portString := this _port toString()
+		if (this _port != 0)
+			contents add(":") . add(portString)
+		result := contents join("")
+		(contents, portString) free()
 		result
 	}
-	parse: static func(data: Text) -> This {
+	parse: static func (data: String) -> This {
 		result: This
-		d := data take()
-		if (!d isEmpty) {
-			splitted := d split(t":")
-			newPort := splitted count > 1 ? splitted remove() toInt() : 0
-			newHost := splitted remove() split(t".")
-			for (i in 0 .. newHost count)
-				newHost[i] = newHost[i] take()
+		if (!data empty()) {
+			splitted := data split(':')
+			newPort := splitted count > 1 ? splitted[1] toInt() : 0
+			newHost := splitted[0] split('.')
 			result = This new(newHost, newPort)
 			splitted free()
 		}
-		data free(Owner Receiver)
 		result
 	}
 }

--- a/source/uri/User.ooc
+++ b/source/uri/User.ooc
@@ -6,37 +6,38 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-User: class {
-	_name: Text
-	_password: Text
-	name ::= this _name take()
-	password ::= this _password take()
+use base
 
-	init: func(=_name, =_password)
+User: class {
+	_name: String
+	_password: String
+	name ::= this _name
+	password ::= this _password
+
+	init: func (=_name, =_password)
 	free: override func {
-		this _name free(Owner Receiver)
-		this _password free(Owner Receiver)
+		(this _name, this _password) free()
 		super()
 	}
-	toText: func -> Text {
-		result := Text empty
-		if (!this name isEmpty)
-			result += this name
-		if (!this password isEmpty)
-			result += t":" + this password
+	toString: func -> String {
+		contents := StringBuilder new()
+		if (!this name empty())
+			contents add(this name)
+		if (!this password empty())
+			contents add(":") . add(this password)
+		result := contents join("")
+		contents free()
 		result
 	}
-	parse: static func(data: Text) -> This {
+	parse: static func (data: String) -> This {
 		result: This
-		d := data take()
-		if (!d isEmpty) {
-			splitted := d split(t":")
-			newPassword := splitted count > 1 ? splitted remove() : Text empty
-			newName := splitted remove()
-			result = This new(newName take(), newPassword take())
+		if (!data empty()) {
+			splitted := data split(':')
+			newPassword := splitted count > 1 ? splitted[1] clone() : ""
+			newName := splitted[0] clone()
+			result = This new(newName, newPassword)
 			splitted free()
 		}
-		data free(Owner Receiver)
 		result
 	}
 }

--- a/test/uri/AuthorityTest.ooc
+++ b/test/uri/AuthorityTest.ooc
@@ -15,25 +15,30 @@ AuthorityTest: class extends Fixture {
 	init: func {
 		super("Authority")
 		this add("parse", func {
-			userText := Text new("name:password")
-			endpointText := Text new("one.two:123")
-			authorityText := userText + t"@" + endpointText
-			authority := Authority parse(authorityText take())
-			expect(authority user toText(), is equal to(userText))
-			expect(authority endpoint toText(), is equal to(endpointText))
-			expect(authority toText(), is equal to(authorityText))
+			userText := "name:password"
+			endpointText := "one.two:123"
+			authorityText := "name:password@one.two:123"
+			authority := Authority parse(authorityText)
+
+			(userString, endpointString, authorityString) := (authority user, authority endpoint, authority) toString()
+			expect(userString, is equal to(userText))
+			expect(endpointString, is equal to(endpointText))
+			expect(authorityString, is equal to(authorityText))
+			(userString, endpointString, authorityString) free()
 			authority free()
 		})
 		this add("empty", func {
-			authority := Authority parse(t"")
-			expect(authority, is equal to(null))
+			authority := Authority parse("")
+			expect(authority, is Null)
 		})
 		this add("only endpoint", func {
-			endpointText := Text new("one.two:123")
-			authority := Authority parse(endpointText take())
-			expect(authority user, is equal to(null))
-			expect(authority endpoint toText(), is equal to(endpointText))
-			expect(authority toText(), is equal to(endpointText))
+			endpointText := "one.two:123"
+			authority := Authority parse(endpointText)
+			expect(authority user, is Null)
+			(endPointString, authorityString) := (authority endpoint, authority) toString()
+			expect(endPointString, is equal to(endpointText))
+			expect(authorityString, is equal to(endpointText))
+			(endPointString, authorityString) free()
 			authority free()
 		})
 	}

--- a/test/uri/EndpointTest.ooc
+++ b/test/uri/EndpointTest.ooc
@@ -15,38 +15,37 @@ EndpointTest: class extends Fixture {
 	init: func {
 		super("Endpoint")
 		this add("parse", func {
-			one := t"one"
-			two := t"two"
-			three := t"three"
-			host := one + t"." + two + t"." + three
-			port := t"1232"
-			endpointText := (host + t":" + port) take()
+			one := "one"
+			two := "two"
+			three := "three"
+			port := "1232"
+			endpointText := "one.two.three:1232"
 			endpoint := Endpoint parse(endpointText)
 			list := endpoint host
 			expect(list[0] == one)
 			expect(list[1] == two)
 			expect(list[2] == three)
-			expect(endpoint port == port take() toInt())
-			expect(endpoint toText() == endpointText)
-			endpointText free(Owner Sender)
-			(list, endpoint) free()
+			expect(endpoint port == port toInt())
+			endpointString := endpoint toString()
+			expect(endpointString == endpointText)
+			(endpoint, endpointString) free()
 		})
 		this add("empty", func {
-			endpoint := Endpoint parse(t"")
+			endpoint := Endpoint parse("")
 			expect(endpoint, is Null)
 		})
-		this add("only host", func {
-			one := t"one"
-			two := t"two"
-			endpointText := (one + t"." + two) take()
+		this add("only hos", func {
+			one := "one"
+			two := "two"
+			endpointText := "one.two"
 			endpoint := Endpoint parse(endpointText)
 			list := endpoint host
 			expect(list[0] == one)
 			expect(list[1] == two)
 			expect(endpoint port == 0)
-			expect(endpoint toText() == endpointText)
-			endpointText free(Owner Sender)
-			(list, endpoint) free()
+			endpointString := endpoint toString()
+			expect(endpointString == endpointText)
+			(endpoint, endpointString) free()
 		})
 	}
 }

--- a/test/uri/LocatorTest.ooc
+++ b/test/uri/LocatorTest.ooc
@@ -15,216 +15,198 @@ LocatorTest: class extends Fixture {
 	init: func {
 		super("Locator")
 		this add("parse", func {
-			schemeText := Text new("http")
-			userText := Text new("name:password")
-			endpointText := Text new("one.two:123")
-			pathText1 := Text new("path")
-			pathText2 := Text new("something")
-			queryKey1 := Text new("key")
-			queryKey2 := Text new("key2")
-			queryValue1 := Text new("value")
-			queryValue2 := Text new("value2")
-			queryText := (queryKey1 + t"=" + queryValue1 + t";" + queryKey2 + t"=" + queryValue2) take()
-			fragmentText := Text new("frag")
-			locatorText := (schemeText + t"://" + userText + t"@" + endpointText + t"/" + pathText1 + t"/" + pathText2 + t"?" + queryText + t"#" + fragmentText) take()
+			userText := "name:password"
+			endpointText := "one.two:123"
+			pathText1 := "path"
+			pathText2 := "something"
+			queryKey1 := "key"
+			queryKey2 := "key2"
+			queryValue2 := "value2"
+			queryText := "key=value;key2=value2"
+			fragmentText := "frag"
+			locatorText := "http://name:password@one.two:123/path/something?key=value;key2=value2#frag"
 			locator := Locator parse(locatorText)
-			expect(locator scheme == schemeText)
-			expect(locator authority toText() == userText + t"@" + endpointText)
-			expect(locator authority user toText() == userText)
-			expect(locator authority endpoint toText() == endpointText)
-			path := locator path
-			expect(path[0] == pathText1)
-			expect(path[1] == pathText2)
-			expect(locator query toText() == queryText)
+			expect(locator scheme == "http")
+			(authorityString, userString, endpointString, queryString, locatorString) := (locator authority, locator authority user, locator authority endpoint, locator query, locator) toString()
+			expect(authorityString == "name:password@one.two:123")
+			expect(userString == userText)
+			expect(endpointString == endpointText)
+			expect(locator path[0] == pathText1)
+			expect(locator path[1] == pathText2)
+			expect(queryString == queryText)
 			expect(locator query contains(queryKey1) as Bool, is true)
 			expect(locator query getValue(queryKey2) == queryValue2, is true)
 			expect(locator fragment == fragmentText)
-			expect(locator toText() == locatorText)
-			queryText free(Owner Sender)
-			locatorText free(Owner Sender)
-			(path, locator) free()
+			expect(locatorString == locatorText)
+			(authorityString, userString, endpointString, queryString, locatorString, locator) free()
 		})
 		this add("empty", func {
-			locator := Locator parse(t"")
+			locator := Locator parse("")
 			expect(locator, is Null)
 		})
 		this add("no scheme", func {
-			userText := Text new("name:password")
-			endpointText := Text new("one.two:123")
-			pathText1 := Text new("path")
-			pathText2 := Text new("something")
-			queryKey1 := Text new("key")
-			queryKey2 := Text new("key2")
-			queryValue1 := Text new("value")
-			queryValue2 := Text new("value2")
-			queryText := (queryKey1 + t"=" + queryValue1 + t";" + queryKey2 + t"=" + queryValue2) take()
-			fragmentText := Text new("frag")
-			locatorText := (userText + t"@" + endpointText + t"/" + pathText1 + t"/" + pathText2 + t"?" + queryText + t"#" + fragmentText) take()
+			userText := "name:password"
+			endpointText := "one.two:123"
+			pathText1 := "path"
+			pathText2 := "something"
+			queryKey1 := "key"
+			queryKey2 := "key2"
+			queryValue2 := "value2"
+			queryText := "key=value;key2=value2"
+			fragmentText := "frag"
+			locatorText := "name:password@one.two:123/path/something?key=value;key2=value2#frag"
 			locator := Locator parse(locatorText)
-			expect(locator scheme == Text empty)
-			expect(locator authority toText() == userText + t"@" + endpointText)
-			expect(locator authority user toText() == userText)
-			expect(locator authority endpoint toText() == endpointText)
-			path := locator path
-			expect(path[0] == pathText1)
-			expect(path[1] == pathText2)
-			expect(locator query toText() == queryText)
+			expect(locator scheme == "")
+			(authorityString, userString, endpointString) := (locator authority, locator authority user, locator authority endpoint) toString()
+			expect(authorityString == "name:password@one.two:123")
+			expect(userString == userText)
+			expect(endpointString == endpointText)
+			expect(locator path[0] == pathText1)
+			expect(locator path[1] == pathText2)
+			(queryString, locatorString) := (locator query, locator) toString()
+			expect(queryString == queryText)
 			expect(locator query contains(queryKey1) as Bool, is true)
 			expect(locator query getValue(queryKey2) == queryValue2)
 			expect(locator fragment == fragmentText)
-			expect(locator toText() == locatorText)
-			queryText free(Owner Sender)
-			locatorText free(Owner Sender)
-			(path, locator) free()
+			expect(locatorString == locatorText)
+			(locator, authorityString, userString, endpointString, queryString, locatorString) free()
 		})
 		this add("no user", func {
-			schemeText := Text new("http")
-			endpointText := Text new("one.two:123")
-			pathText1 := Text new("path")
-			pathText2 := Text new("something")
-			queryKey1 := Text new("key")
-			queryKey2 := Text new("key2")
-			queryValue1 := Text new("value")
-			queryValue2 := Text new("value2")
-			queryText := (queryKey1 + t"=" + queryValue1 + t";" + queryKey2 + t"=" + queryValue2) take()
-			fragmentText := Text new("frag")
-			locatorText := (schemeText + t"://" + endpointText + t"/" + pathText1 + t"/" + pathText2 + t"?" + queryText + t"#" + fragmentText) take()
+			schemeText := "http"
+			endpointText := "one.two:123"
+			pathText1 := "path"
+			pathText2 := "something"
+			queryKey1 := "key"
+			queryKey2 := "key2"
+			queryValue2 := "value2"
+			queryText := "key=value;key2=value2"
+			fragmentText := "frag"
+			locatorText := "http://one.two:123/path/something?key=value;key2=value2#frag"
 			locator := Locator parse(locatorText)
 			expect(locator scheme == schemeText)
-			expect(locator authority toText() == endpointText)
+			(authorityString, endpointString, queryString, locatorString) := (locator authority, locator authority endpoint, locator query, locator) toString()
+			expect(authorityString == endpointText)
 			expect(locator authority user as User, is Null)
-			expect(locator authority endpoint toText() == endpointText)
-			path := locator path
-			expect(path[0] == pathText1)
-			expect(path[1] == pathText2)
-			expect(locator query toText() == queryText)
+			expect(endpointString == endpointText)
+			expect(locator path[0] == pathText1)
+			expect(locator path[1] == pathText2)
+			expect(queryString == queryText)
 			expect(locator query contains(queryKey1) as Bool, is true)
 			expect(locator query getValue(queryKey2) == queryValue2)
 			expect(locator fragment == fragmentText)
-			expect(locator toText() == locatorText)
-			queryText free(Owner Sender)
-			locatorText free(Owner Sender)
-			(path, locator) free()
+			expect(locatorString == locatorText)
+			(locator, authorityString, endpointString, queryString, locatorString) free()
 		})
 		this add("no authority", func {
-			schemeText := Text new("http")
-			pathText1 := Text new("path")
-			pathText2 := Text new("something")
-			queryKey1 := Text new("key")
-			queryKey2 := Text new("key2")
-			queryValue1 := Text new("value")
-			queryValue2 := Text new("value2")
-			queryText := (queryKey1 + t"=" + queryValue1 + t";" + queryKey2 + t"=" + queryValue2) take()
-			fragmentText := Text new("frag")
-			locatorText := (schemeText + t"://" + t"/" + pathText1 + t"/" + pathText2 + t"?" + queryText + t"#" + fragmentText) take()
+			schemeText := "http"
+			pathText1 := "path"
+			pathText2 := "something"
+			queryKey1 := "key"
+			queryKey2 := "key2"
+			queryValue2 := "value2"
+			queryText := "key=value;key2=value2"
+			fragmentText := "frag"
+			locatorText := "http:///path/something?key=value;key2=value2#frag"
 			locator := Locator parse(locatorText)
 			expect(locator scheme == schemeText)
 			expect(locator authority as Authority, is Null)
 			path := locator path
 			expect(path[0] == pathText1)
 			expect(path[1] == pathText2)
-			expect(locator query toText() == queryText)
+			(queryString, locatorString) := (locator query, locator) toString()
+			expect(queryString == queryText)
 			expect(locator query contains(queryKey1) as Bool, is true)
 			expect(locator query getValue(queryKey2) == queryValue2)
 			expect(locator fragment == fragmentText)
-			expect(locator toText() == locatorText)
-			queryText free(Owner Sender)
-			locatorText free(Owner Sender)
-			(path, locator) free()
+			expect(locatorString == locatorText)
+			(queryString, locatorString, locator) free()
 		})
 		this add("no path", func {
-			schemeText := Text new("http")
-			userText := Text new("name:password")
-			endpointText := Text new("one.two:123")
-			queryKey1 := Text new("key")
-			queryKey2 := Text new("key2")
-			queryValue1 := Text new("value")
-			queryValue2 := Text new("value2")
-			queryText := (queryKey1 + t"=" + queryValue1 + t";" + queryKey2 + t"=" + queryValue2) take()
-			fragmentText := Text new("frag")
-			locatorText := (schemeText + t"://" + userText + t"@" + endpointText + t"?" + queryText + t"#" + fragmentText) take()
+			schemeText := "http"
+			userText := "name:password"
+			endpointText := "one.two:123"
+			queryKey1 := "key"
+			queryKey2 := "key2"
+			queryValue2 := "value2"
+			queryText := "key=value;key2=value2"
+			fragmentText := "frag"
+			locatorText := "http://name:password@one.two:123?key=value;key2=value2#frag"
 			locator := Locator parse(locatorText)
 			expect(locator scheme == schemeText)
-			expect(locator authority toText() == userText + t"@" + endpointText)
-			expect(locator authority user toText() == userText)
-			expect(locator authority endpoint toText() == endpointText)
-			expect(locator path as VectorList<Text>, is Null)
-			expect(locator query toText() == queryText)
+			(authorityString, userString, endpointString, queryString, locatorString) := (locator authority, locator authority user, locator authority endpoint, locator query, locator) toString()
+			expect(authorityString == "name:password@one.two:123")
+			expect(userString == userText)
+			expect(endpointString == endpointText)
+			expect(locator path, is Null)
+			expect(queryString == queryText)
 			expect(locator query contains(queryKey1) as Bool, is true)
 			expect(locator query getValue(queryKey2) == queryValue2, is true)
 			expect(locator fragment == fragmentText)
-			expect(locator toText() == locatorText)
-			queryText free(Owner Sender)
-			locatorText free(Owner Sender)
-			locator free()
+			expect(locatorString == locatorText)
+			(locator, authorityString, userString, endpointString, queryString, locatorString) free()
 		})
 		this add("no query", func {
-			schemeText := Text new("http")
-			userText := Text new("name:password")
-			endpointText := Text new("one.two:123")
-			pathText1 := Text new("path")
-			pathText2 := Text new("something")
-			fragmentText := Text new("frag")
-			locatorText := (schemeText + t"://" + userText + t"@" + endpointText + t"/" + pathText1 + t"/" + pathText2 + t"#" + fragmentText) take()
+			schemeText := "http"
+			userText := "name:password"
+			endpointText := "one.two:123"
+			pathText1 := "path"
+			pathText2 := "something"
+			fragmentText := "frag"
+			locatorText := "http://name:password@one.two:123/path/something#frag"
 			locator := Locator parse(locatorText)
 			expect(locator scheme == schemeText)
-			expect(locator authority toText() == userText + t"@" + endpointText)
-			expect(locator authority user toText() == userText)
-			expect(locator authority endpoint toText() == endpointText)
-			path := locator path
-			expect(path[0] == pathText1)
-			expect(path[1] == pathText2)
+			(authorityString, userString, endpointString, locatorString) := (locator authority, locator authority user, locator authority endpoint, locator) toString()
+			expect(authorityString == "name:password@one.two:123")
+			expect(userString == userText)
+			expect(endpointString == endpointText)
+			expect(locator path[0] == pathText1)
+			expect(locator path[1] == pathText2)
 			expect(locator query as Query, is Null)
 			expect(locator fragment == fragmentText)
-			expect(locator toText() == locatorText)
-			locatorText free(Owner Sender)
-			(path, locator) free()
+			expect(locatorString == locatorText)
+			(locator, authorityString, userString, endpointString, locatorString) free()
 		})
 		this add("no fragment", func {
-			schemeText := Text new("http")
-			userText := Text new("name:password")
-			endpointText := Text new("one.two:123")
-			pathText1 := Text new("path")
-			pathText2 := Text new("something")
-			queryKey1 := Text new("key")
-			queryKey2 := Text new("key2")
-			queryValue1 := Text new("value")
-			queryValue2 := Text new("value2")
-			queryText := (queryKey1 + t"=" + queryValue1 + t";" + queryKey2 + t"=" + queryValue2) take()
-			locatorText := (schemeText + t"://" + userText + t"@" + endpointText + t"/" + pathText1 + t"/" + pathText2 + t"?" + queryText) take()
+			schemeText := "http"
+			userText := "name:password"
+			endpointText := "one.two:123"
+			pathText1 := "path"
+			pathText2 := "something"
+			queryKey1 := "key"
+			queryKey2 := "key2"
+			queryValue2 := "value2"
+			queryText := "key=value;key2=value2"
+			locatorText := "http://name:password@one.two:123/path/something?key=value;key2=value2"
 			locator := Locator parse(locatorText)
 			expect(locator scheme == schemeText)
-			expect(locator authority toText() == userText + t"@" + endpointText)
-			expect(locator authority user toText() == userText)
-			expect(locator authority endpoint toText() == endpointText)
-			path := locator path
-			expect(path[0] == pathText1)
-			expect(path[1] == pathText2)
-			expect(locator query toText() == queryText)
+			(authorityString, userString, endpointString, queryString, locatorString) := (locator authority, locator authority user, locator authority endpoint, locator query, locator) toString()
+			expect(authorityString == "name:password@one.two:123")
+			expect(userString == userText)
+			expect(endpointString == endpointText)
+			expect(locator path[0] == pathText1)
+			expect(locator path[1] == pathText2)
+			expect(queryString == queryText)
 			expect(locator query contains(queryKey1) as Bool, is true)
 			expect(locator query getValue(queryKey2) == queryValue2)
-			expect(locator fragment == Text empty)
-			expect(locator toText() == locatorText)
-			queryText free(Owner Sender)
-			locatorText free(Owner Sender)
-			(path, locator) free()
+			expect(locator fragment == "")
+			expect(locatorString == locatorText)
+			(locator, authorityString, userString, endpointString, queryString, locatorString) free()
 		})
 		this add("only path", func {
-			schemeText := Text new("http")
-			pathText1 := Text new("path")
-			pathText2 := Text new("something")
-			locatorText := (schemeText + t"://" + t"/" + pathText1 + t"/" + pathText2) take()
+			schemeText := "http"
+			pathText1 := "path"
+			pathText2 := "something"
+			locatorText := "http:///path/something"
 			locator := Locator parse(locatorText)
-			expect(locator scheme == schemeText)
+			expect(locator scheme == schemeText, "1")
 			expect(locator authority as Authority, is Null)
-			path := locator path
-			expect(path[0] == pathText1)
-			expect(path[1] == pathText2)
+			expect(locator path[0] == pathText1, "2")
+			expect(locator path[1] == pathText2, "3")
 			expect(locator query as Query, is Null)
-			expect(locator fragment == Text empty)
-			expect(locator toText() == locatorText)
-			locatorText free(Owner Sender)
-			(path, locator) free()
+			expect(locator fragment == "", "4")
+			locatorString := locator toString()
+			expect(locatorString == locatorText, "5")
+			(locator, locatorString) free()
 		})
 	}
 }

--- a/test/uri/QueryTest.ooc
+++ b/test/uri/QueryTest.ooc
@@ -15,13 +15,13 @@ QueryTest: class extends Fixture {
 	init: func {
 		super("Query")
 		this add("parse", func {
-			one := t"one"
-			two := t"two"
-			three := t"three"
-			valueOne := t"1"
-			valueTwo := t"2"
-			valueThree := t"3"
-			queryText := (one + t"=" + valueOne + t";" + two + t"=" + valueTwo + t";" + three + t"=" + valueThree) take()
+			one := "one"
+			two := "two"
+			three := "three"
+			valueOne := "1"
+			valueTwo := "2"
+			valueThree := "3"
+			queryText := "one=1;two=2;three=3"
 			query := Query parse(queryText)
 			attributes := query attributes
 			values := query values
@@ -31,25 +31,25 @@ QueryTest: class extends Fixture {
 			expect(values[0] == valueOne)
 			expect(values[1] == valueTwo)
 			expect(values[2] == valueThree)
-			expect(query toText() == queryText)
+			queryString := query toString()
+			expect(queryString == queryText)
 			expect(query contains(one) as Bool, is true)
-			expect(query contains(t"non existing") as Bool, is false)
+			expect(query contains("non existing") as Bool, is false)
 			expect(query getValue(two) == valueTwo)
-			expect(query getValue(t"four") == Text empty)
-			queryText free(Owner Sender)
-			(attributes, values, query) free()
+			expect(query getValue("four") == "")
+			(queryString, query) free()
 		})
 		this add("empty", func {
-			query := Query parse(t"")
+			query := Query parse("")
 			expect(query, is Null)
 		})
 		this add("missing values", func {
-			one := t"one"
-			two := t"two"
-			three := t"three"
-			valueOne := t"1"
-			valueThree := t"3"
-			queryText := (one + t"=" + valueOne + t";" + two + t";" + three + t"=" + valueThree) take()
+			one := "one"
+			two := "two"
+			three := "three"
+			valueOne := "1"
+			valueThree := "3"
+			queryText := "one=1;two;three=3"
 			query := Query parse(queryText)
 			attributes := query attributes
 			values := query values
@@ -57,15 +57,15 @@ QueryTest: class extends Fixture {
 			expect(attributes[1] == two)
 			expect(attributes[2] == three)
 			expect(values[0] == valueOne)
-			expect(values[1] == Text empty)
+			expect(values[1] == "")
 			expect(values[2] == valueThree)
-			expect(query toText() == queryText)
+			queryString := query toString()
+			expect(queryString == queryText)
 			expect(query contains(one) as Bool, is true)
 			expect(query contains(two) as Bool, is true)
-			expect(query getValue(two) == Text empty)
+			expect(query getValue(two) == "")
 			expect(query getValue(three) == valueThree)
-			queryText free(Owner Sender)
-			(attributes, values, query) free()
+			(queryString, query) free()
 		})
 	}
 }

--- a/test/uri/UserTest.ooc
+++ b/test/uri/UserTest.ooc
@@ -15,27 +15,28 @@ UserTest: class extends Fixture {
 	init: func {
 		super("User")
 		this add("parse", func {
-			name := t"name"
-			password := t"password"
-			userText := (name + t":" + password) take()
+			name := "name"
+			password := "password"
+			userText := "name:password"
 			user := User parse(userText)
 			expect(user name, is equal to(name))
 			expect(user password, is equal to(password))
-			expect(user toText(), is equal to(userText))
-			userText free(Owner Sender)
-			user free()
+			result := user toString()
+			expect(result, is equal to(userText))
+			(result, user) free()
 		})
 		this add("empty", func {
-			user := User parse(t"")
+			user := User parse("")
 			expect(user, is equal to(null))
 		})
 		this add("only name", func {
-			name := Text new("name")
+			name := "name"
 			user := User parse(name)
 			expect(user name, is equal to(name))
-			expect(user password, is equal to(Text empty))
-			expect(user toText(), is equal to(name))
-			user free()
+			expect(user password, is equal to(""))
+			result := user toString()
+			expect(result, is equal to(name))
+			(result, user) free()
 		})
 	}
 }


### PR DESCRIPTION
Since it's not used anywhere ( @jonathanudd ? ) this is easy to do without breaking the API for anyone.

Also fixed memory leak in `StringBuilder` and `String split(String)`.

Part of the work on #1724 