### PR TITLE
Removed usage of Text in Fixture and Cell

### DIFF
--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -192,5 +192,5 @@ FloatBox2D: cover {
 }
 
 extend Cell<FloatBox2D> {
-	toText: func ~floatbox2d -> Text { (this val as FloatBox2D) toText() }
+	toString: func ~floatbox2d -> String { (this val as FloatBox2D) toString() }
 }

--- a/source/geometry/FloatEuclidTransform.ooc
+++ b/source/geometry/FloatEuclidTransform.ooc
@@ -65,5 +65,5 @@ FloatEuclidTransform: cover {
 }
 
 extend Cell<FloatEuclidTransform> {
-	toText: func ~floateuclidtransform -> Text { (this val as FloatEuclidTransform) toText() }
+	toString: func ~floateuclidtransform -> String { (this val as FloatEuclidTransform) toString() }
 }

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -81,5 +81,5 @@ operator * (left: Int, right: FloatPoint2D) -> FloatPoint2D { FloatPoint2D new(l
 operator / (left: Int, right: FloatPoint2D) -> FloatPoint2D { FloatPoint2D new(left / right x, left / right y) }
 
 extend Cell<FloatPoint2D> {
-	toText: func ~floatpoint2d -> Text { (this val as FloatPoint2D) toText() }
+	toString: func ~floatpoint2d -> String { (this val as FloatPoint2D) toString() }
 }

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -88,5 +88,5 @@ operator * (left: Int, right: FloatPoint3D) -> FloatPoint3D { FloatPoint3D new(l
 operator / (left: Int, right: FloatPoint3D) -> FloatPoint3D { FloatPoint3D new(left / right x, left / right y, left / right z) }
 
 extend Cell<FloatPoint3D> {
-	toText: func ~floatpoint3d -> Text { (this val as FloatPoint3D) toText() }
+	toString: func ~floatpoint3d -> String { (this val as FloatPoint3D) toString() }
 }

--- a/source/geometry/FloatRotation3D.ooc
+++ b/source/geometry/FloatRotation3D.ooc
@@ -43,5 +43,5 @@ FloatRotation3D: cover {
 }
 
 extend Cell<FloatRotation3D> {
-	toText: func ~floatrotation3d -> Text { (this val as FloatRotation3D) toText() }
+	toString: func ~floatrotation3d -> String { (this val as FloatRotation3D) toString() }
 }

--- a/source/geometry/FloatShell2D.ooc
+++ b/source/geometry/FloatShell2D.ooc
@@ -57,5 +57,5 @@ FloatShell2D: cover {
 }
 
 extend Cell<FloatShell2D> {
-	toText: func ~floatshell2d -> Text { (this val as FloatShell2D) toText() }
+	toString: func ~floatshell2d -> String { (this val as FloatShell2D) toString() }
 }

--- a/source/geometry/FloatTransform2D.ooc
+++ b/source/geometry/FloatTransform2D.ooc
@@ -200,5 +200,5 @@ FloatTransform2D: cover {
 }
 
 extend Cell<FloatTransform2D> {
-	toText: func ~floattransform2d -> Text { (this val as FloatTransform2D) toText() }
+	toString: func ~floattransform2d -> String { (this val as FloatTransform2D) toString() }
 }

--- a/source/geometry/FloatTransform3D.ooc
+++ b/source/geometry/FloatTransform3D.ooc
@@ -258,5 +258,5 @@ FloatTransform3D: cover {
 }
 
 extend Cell<FloatTransform3D> {
-	toText: func ~floattransform3d -> Text { (this val as FloatTransform3D) toText() }
+	toString: func ~floattransform3d -> String { (this val as FloatTransform3D) toString() }
 }

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -88,5 +88,5 @@ operator * (left: Int, right: FloatVector2D) -> FloatVector2D { FloatVector2D ne
 operator / (left: Int, right: FloatVector2D) -> FloatVector2D { FloatVector2D new(left / right x, left / right y) }
 
 extend Cell<FloatVector2D> {
-	toText: func ~floatvector2d -> Text { (this val as FloatVector2D) toText() }
+	toString: func ~floatvector2d -> String { (this val as FloatVector2D) toString() }
 }

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -92,5 +92,5 @@ operator * (left: Int, right: FloatVector3D) -> FloatVector3D { FloatVector3D ne
 operator / (left: Int, right: FloatVector3D) -> FloatVector3D { FloatVector3D new(left / right x, left / right y, left / right z) }
 
 extend Cell<FloatVector3D> {
-	toText: func ~floatvector3d -> Text { (this val as FloatVector3D) toText() }
+	toString: func ~floatvector3d -> String { (this val as FloatVector3D) toString() }
 }

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -158,5 +158,5 @@ IntBox2D: cover {
 }
 
 extend Cell<IntBox2D> {
-	toText: func ~intbox2d -> Text { (this val as IntBox2D) toText() }
+	toString: func ~intbox2d -> String { (this val as IntBox2D) toString() }
 }

--- a/source/geometry/IntPoint2D.ooc
+++ b/source/geometry/IntPoint2D.ooc
@@ -57,5 +57,5 @@ operator * (left: Float, right: IntPoint2D) -> IntPoint2D { IntPoint2D new(left 
 operator / (left: Float, right: IntPoint2D) -> IntPoint2D { IntPoint2D new(left / right x, left / right y) }
 
 extend Cell<IntPoint2D> {
-	toText: func ~intpoint2d -> Text { (this val as IntPoint2D) toText() }
+	toString: func ~intpoint2d -> String { (this val as IntPoint2D) toString() }
 }

--- a/source/geometry/IntPoint3D.ooc
+++ b/source/geometry/IntPoint3D.ooc
@@ -56,5 +56,5 @@ operator * (left: Float, right: IntPoint3D) -> IntPoint3D { IntPoint3D new(left 
 operator / (left: Float, right: IntPoint3D) -> IntPoint3D { IntPoint3D new(left / right x, left / right y, left / right z) }
 
 extend Cell<IntPoint3D> {
-	toText: func ~intpoint3d -> Text { (this val as IntPoint3D) toText() }
+	toString: func ~intpoint3d -> String { (this val as IntPoint3D) toString() }
 }

--- a/source/geometry/IntShell2D.ooc
+++ b/source/geometry/IntShell2D.ooc
@@ -56,5 +56,5 @@ IntShell2D: cover {
 }
 
 extend Cell<IntShell2D> {
-	toText: func ~intshell2d -> Text { (this val as IntShell2D) toText() }
+	toString: func ~intshell2d -> String { (this val as IntShell2D) toString() }
 }

--- a/source/geometry/IntVector2D.ooc
+++ b/source/geometry/IntVector2D.ooc
@@ -71,5 +71,5 @@ operator * (left: Float, right: IntVector2D) -> IntVector2D { IntVector2D new(le
 operator / (left: Float, right: IntVector2D) -> IntVector2D { IntVector2D new(left / right x, left / right y) }
 
 extend Cell<IntVector2D> {
-	toText: func ~intvector2d -> Text { (this val as IntVector2D) toText() }
+	toString: func ~intvector2d -> String { (this val as IntVector2D) toString() }
 }

--- a/source/geometry/IntVector3D.ooc
+++ b/source/geometry/IntVector3D.ooc
@@ -63,5 +63,5 @@ operator * (left: Float, right: IntVector3D) -> IntVector3D { IntVector3D new(le
 operator / (left: Float, right: IntVector3D) -> IntVector3D { IntVector3D new(left / right x, left / right y, left / right z) }
 
 extend Cell<IntVector3D> {
-	toText: func ~intvector3d -> Text { (this val as IntVector3D) toText() }
+	toString: func ~intvector3d -> String { (this val as IntVector3D) toString() }
 }

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -296,5 +296,5 @@ Quaternion: cover {
 operator * (value: Float, other: Quaternion) -> Quaternion { other * value }
 
 extend Cell<Quaternion> {
-	toText: func ~quaternion -> Text { (this val as Quaternion) toText() }
+	toString: func ~quaternion -> String { (this val as Quaternion) toString() }
 }

--- a/source/math/FloatComplex.ooc
+++ b/source/math/FloatComplex.ooc
@@ -53,5 +53,5 @@ operator * (left: Float, right: FloatComplex) -> FloatComplex { FloatComplex new
 operator / (left: Float, right: FloatComplex) -> FloatComplex { (left * right conjugate) / (right absoluteValue pow(2)) }
 
 extend Cell<FloatComplex> {
-	toText: func ~floatcomplex -> Text { (this val as FloatComplex) toText() }
+	toString: func ~floatcomplex -> String { (this val as FloatComplex) toString() }
 }

--- a/source/math/FloatMatrix.ooc
+++ b/source/math/FloatMatrix.ooc
@@ -521,5 +521,5 @@ FloatMatrix: cover {
 operator * (left: Float, right: FloatMatrix) -> FloatMatrix { right * left }
 
 extend Cell<FloatMatrix> {
-	toText: func ~floatmatrix -> Text { (this val as FloatMatrix) toText() }
+	toString: func ~floatmatrix -> String { (this val as FloatMatrix) toString() }
 }

--- a/source/system/Cell.ooc
+++ b/source/system/Cell.ooc
@@ -20,38 +20,38 @@ Cell: class <T> {
 	set: func (=val)
 	get: func -> T { this val }
 
-	toText: func -> Text {
-		result: Text
+	toString: func -> String {
+		result: String
 		if (T inheritsFrom(Text))
-			result = (this val as Text)
+			result = (this val as Text) take() toString()
 		else if (T inheritsFrom(String))
-			result = Text new(this val as String)
+			result = this val as String
 		else if (T inheritsFrom(Bool))
-			result = (this val as Bool) toText()
+			result = (this val as Bool) toString()
 		else if (T inheritsFrom(Char))
-			result = Text new((this val as Char) toString())
+			result = (this val as Char) toString()
 		else if (T inheritsFrom(Int))
-			result = (this val as Int) toText()
+			result = (this val as Int) toString()
 		else if (T inheritsFrom(Long))
-			result = (this val as Long) toText()
+			result = (this val as Long) toString()
 		else if (T inheritsFrom(LLong))
-			result = (this val as LLong) toText()
+			result = (this val as LLong) toString()
 		else if (T inheritsFrom(UInt))
-			result = (this val as UInt) toText()
+			result = (this val as UInt) toString()
 		else if (T inheritsFrom(ULong))
-			result = (this val as ULong) toText()
+			result = (this val as ULong) toString()
 		else if (T inheritsFrom(ULLong))
-			result = (this val as ULLong) toText()
+			result = (this val as ULLong) toString()
 		else if (T inheritsFrom(Float))
-			result = (this val as Float) toText()
+			result = (this val as Float) toString()
 		else if (T inheritsFrom(Double))
-			result = (this val as Double) toText()
+			result = (this val as Double) toString()
 		else if (T inheritsFrom(LDouble))
-			result = (this val as LDouble) toText()
+			result = (this val as LDouble) toString()
 		else if (T inheritsFrom(Range))
-			result = (this val as Range) toText()
+			result = (this val as Range) toString()
 		else
-			raise("[Cell] toText() is not implemented on the specified type")
+			raise("[Cell] toString() is not implemented for the specified type")
 		result
 	}
 }

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -56,14 +56,15 @@ Fixture: abstract class {
 		testTime := timer stop() / 1_000_000.0
 		This totalTime += testTime
 		if (testTime > 0.1)
-			This _print(" in %.2fs\n" format(testTime), true)
-		else
-			This _print("\n")
+			This _print(" in %.2fs" format(testTime), true)
+		This _print("\n")
 		if (!result) {
 			for (i in 0 .. failures count) {
 				f := failures[i]
 				if (f constraint instanceOf(CompareConstraint) && f value instanceOf(Cell))
 					This _print(this createCompareFailureMessage(f) + "\n")
+				else if (f constraint instanceOf(CompareConstraint) && f value instanceOf(String))
+					This _print("  -> %s : expected equal to %s was %s\n" format(f message, f value as String, (f constraint as CompareConstraint) correct as String))
 				else if (f constraint instanceOf(NullConstraint))
 					This _print("  -> %s : expected null was %p\n" format(f message, f value&))
 				else if (f constraint instanceOf(NotNullConstraint))
@@ -98,30 +99,30 @@ Fixture: abstract class {
 			case ComparisonType Within => result add("equal to")
 			case ComparisonType NotWithin => result add("not equal to")
 		}
-		expectedText, testedText: Text
+		expectedText, testedText: String
 		match (expectedValue T) {
-			case FloatVector2D => (expectedText, testedText) = (expectedValue toText~floatvector2d(), testedValue toText~floatvector2d())
-			case FloatVector3D => (expectedText, testedText) = (expectedValue toText~floatvector3d(), testedValue toText~floatvector3d())
-			case FloatPoint2D => (expectedText, testedText) = (expectedValue toText~floatpoint2d(), testedValue toText~floatpoint2d())
-			case FloatPoint3D => (expectedText, testedText) = (expectedValue toText~floatpoint3d(), testedValue toText~floatpoint3d())
-			case Quaternion => (expectedText, testedText) = (expectedValue toText~quaternion(), testedValue toText~quaternion())
-			case FloatEuclidTransform => (expectedText, testedText) = (expectedValue toText~floateuclidtransform(), testedValue toText~floateuclidtransform())
-			case FloatRotation3D => (expectedText, testedText) = (expectedValue toText~floatrotation3d(), testedValue toText~floatrotation3d())
-			case FloatTransform2D => (expectedText, testedText) = (expectedValue toText~floattransform2d(), testedValue toText~floattransform2d())
-			case FloatTransform3D => (expectedText, testedText) = (expectedValue toText~floattransform3d(), testedValue toText~floattransform3d())
-			case IntVector2D => (expectedText, testedText) = (expectedValue toText~intvector2d(), testedValue toText~intvector2d())
-			case IntVector3D => (expectedText, testedText) = (expectedValue toText~intvector3d(), testedValue toText~intvector3d())
-			case IntPoint2D => (expectedText, testedText) = (expectedValue toText~intpoint2d(), testedValue toText~intpoint2d())
-			case IntPoint3D => (expectedText, testedText) = (expectedValue toText~intpoint3d(), testedValue toText~intpoint3d())
-			case FloatComplex => (expectedText, testedText) = (expectedValue toText~floatcomplex(), testedValue toText~floatcomplex())
-			case FloatMatrix => (expectedText, testedText) = (expectedValue toText~floatmatrix(), testedValue toText~floatmatrix())
-			case FloatBox2D => (expectedText, testedText) = (expectedValue toText~floatbox2d(), testedValue toText~floatbox2d())
-			case IntBox2D => (expectedText, testedText) = (expectedValue toText~intbox2d(), testedValue toText~intbox2d())
-			case FloatShell2D => (expectedText, testedText) = (expectedValue toText~floatshell2d(), testedValue toText~floatshell2d())
-			case IntShell2D => (expectedText, testedText) = (expectedValue toText~intshell2d(), testedValue toText~intshell2d())
-			case => (expectedText, testedText) = (expectedValue toText(), testedValue toText())
+			case FloatVector2D => (expectedText, testedText) = (expectedValue toString~floatvector2d(), testedValue toString~floatvector2d())
+			case FloatVector3D => (expectedText, testedText) = (expectedValue toString~floatvector3d(), testedValue toString~floatvector3d())
+			case FloatPoint2D => (expectedText, testedText) = (expectedValue toString~floatpoint2d(), testedValue toString~floatpoint2d())
+			case FloatPoint3D => (expectedText, testedText) = (expectedValue toString~floatpoint3d(), testedValue toString~floatpoint3d())
+			case Quaternion => (expectedText, testedText) = (expectedValue toString~quaternion(), testedValue toString~quaternion())
+			case FloatEuclidTransform => (expectedText, testedText) = (expectedValue toString~floateuclidtransform(), testedValue toString~floateuclidtransform())
+			case FloatRotation3D => (expectedText, testedText) = (expectedValue toString~floatrotation3d(), testedValue toString~floatrotation3d())
+			case FloatTransform2D => (expectedText, testedText) = (expectedValue toString~floattransform2d(), testedValue toString~floattransform2d())
+			case FloatTransform3D => (expectedText, testedText) = (expectedValue toString~floattransform3d(), testedValue toString~floattransform3d())
+			case IntVector2D => (expectedText, testedText) = (expectedValue toString~intvector2d(), testedValue toString~intvector2d())
+			case IntVector3D => (expectedText, testedText) = (expectedValue toString~intvector3d(), testedValue toString~intvector3d())
+			case IntPoint2D => (expectedText, testedText) = (expectedValue toString~intpoint2d(), testedValue toString~intpoint2d())
+			case IntPoint3D => (expectedText, testedText) = (expectedValue toString~intpoint3d(), testedValue toString~intpoint3d())
+			case FloatComplex => (expectedText, testedText) = (expectedValue toString~floatcomplex(), testedValue toString~floatcomplex())
+			case FloatMatrix => (expectedText, testedText) = (expectedValue toString~floatmatrix(), testedValue toString~floatmatrix())
+			case FloatBox2D => (expectedText, testedText) = (expectedValue toString~floatbox2d(), testedValue toString~floatbox2d())
+			case IntBox2D => (expectedText, testedText) = (expectedValue toString~intbox2d(), testedValue toString~intbox2d())
+			case FloatShell2D => (expectedText, testedText) = (expectedValue toString~floatshell2d(), testedValue toString~floatshell2d())
+			case IntShell2D => (expectedText, testedText) = (expectedValue toString~intshell2d(), testedValue toString~intshell2d())
+			case => (expectedText, testedText) = (expectedValue toString(), testedValue toString())
 		}
-		result add(expectedText toString()) . add("was") . add(testedText toString())
+		result add(expectedText) . add("was") . add(testedText)
 		if (constraint type == ComparisonType Within)
 			result add(" [tolerance: %.8f]" formatDouble((constraint parent as CompareWithinConstraint) precision))
 		result join(" ")
@@ -134,7 +135,7 @@ Fixture: abstract class {
 			case 0 => result add(constraint intMin toString()) . add("and") . add(constraint intMax toString())
 			case 1 => result add(constraint floatMin toString()) . add("and") . add(constraint floatMax toString())
 		}
-		result add("was") . add(testedValue toText() toString())
+		result add("was") . add(testedValue toString())
 		result join(' ')
 	}
 	hideDebugOutput: func {


### PR DESCRIPTION
The net result is actually less code.

We're stuck with some `toText() toString()` from `DateTime` but that is fixed in another PR.

`is equal to` now finally works for `String` as well.