### PR TITLE
toText replaced with toString in DateTime and TimeSpan

### DIFF
--- a/source/base/DateTime.ooc
+++ b/source/base/DateTime.ooc
@@ -79,24 +79,43 @@ DateTime: cover {
 	//	%mm - minute
 	//	%ss - second
 	//	%zzz - millisecond
-	toText: func (format := This defaultFormat) -> Text {
-		result := format copy()
+	toString: func (format := This defaultFormat) -> String {
 		data := This _ticksToDateTimeHelper(this ticks)
-		result = result replaceAll(t"%yyyy", t"%04d" format(data year))
-		result = result replaceAll(t"%yy", t"%02d" format(data year % 100))
-		result = result replaceAll(t"%y", t"%d" format(data year))
-		result = result replaceAll(t"%MM", t"%02d" format(data month))
-		result = result replaceAll(t"%dd", t"%02d" format(data day))
-		result = result replaceAll(t"%M", t"%d" format(data month))
-		result = result replaceAll(t"%d", t"%d" format(data day))
-		result = result replaceAll(t"%hh", t"%02d" format(data hour))
-		result = result replaceAll(t"%mm", t"%02d" format(data minute))
-		result = result replaceAll(t"%ss", t"%02d" format(data second))
-		result = result replaceAll(t"%h", t"%d" format(data hour))
-		result = result replaceAll(t"%m", t"%d" format(data minute))
-		result = result replaceAll(t"%s", t"%d" format(data second))
-		result = result replaceAll(t"%zzz", t"%03d" format(data millisecond))
-		result replaceAll(t"%z", t"%d" format(data millisecond))
+		(year4String, year2String, yearString) := ("%04d" format(data year), "%02d" format(data year % 100), "%d" format(data year))
+		(month2String, monthString, day2String, dayString) := ("%02d" format(data month), "%d" format(data month), "%02d" format(data day), "%d" format(data day))
+		(hour2String, minute2String, second2String) := ("%02d" format(data hour), "%02d" format(data minute), "%02d" format(data second))
+		(hourString, minuteString, secondString) := ("%d" format(data hour), "%d" format(data minute), "%d" format(data second))
+		(millisecond3String, millisecondString) := ("%03d" format(data millisecond), "%d" format(data millisecond))
+		second := format replaceAll("%yyyy", year4String)
+		result := second replaceAll("%yy", year2String)
+		second free()
+		second = result replaceAll("%y", yearString)
+		result free()
+		result = second replaceAll("%MM", month2String)
+		second free()
+		second = result replaceAll("%dd", day2String)
+		result free()
+		result = second replaceAll("%M", monthString)
+		second free()
+		second = result replaceAll("%d", dayString)
+		result free()
+		result = second replaceAll("%hh", hour2String)
+		second free()
+		second = result replaceAll("%mm", minute2String)
+		result free()
+		result = second replaceAll("%ss", second2String)
+		second free()
+		second = result replaceAll("%h", hourString)
+		result free()
+		result = second replaceAll("%m", minuteString)
+		second free()
+		second = result replaceAll("%s", secondString)
+		result free()
+		result = second replaceAll("%zzz", millisecond3String)
+		second free()
+		second = result replaceAll("%z", millisecondString)
+		(result, year4String, year2String, yearString, month2String, monthString, day2String, dayString, hour2String, minute2String, second2String, hourString, minuteString, secondString, millisecond3String, millisecondString) free()
+		second
 	}
 	compareTo: func (other: This) -> Order {
 		if (this ticks > other ticks)
@@ -127,7 +146,7 @@ DateTime: cover {
 	ticksPerDay: static Long = This ticksPerHour * 24
 	ticksPerWeek: static Long = This ticksPerDay * 7
 	ticksPerFourYears: static Long = This daysPerFourYears * This ticksPerDay
-	defaultFormat: static Text = t"%yyyy-%MM-%dd %hh:%mm:%ss::%zzz"
+	defaultFormat: static String = "%yyyy-%MM-%dd %hh:%mm:%ss::%zzz"
 	now ::= static Time currentDateTime()
 
 	isLeapYear: static func (year: Int) -> Bool { (year % 100 == 0) ? (year % 400 == 0) : (year % 4 == 0) }

--- a/source/base/TimeSpan.ooc
+++ b/source/base/TimeSpan.ooc
@@ -24,7 +24,7 @@ TimeSpan: cover {
 	toDays: func -> Long { this ticks / DateTime ticksPerDay }
 	toWeeks: func -> Long { this ticks / DateTime ticksPerWeek }
 
-	defaultFormat: static Text = t"%w weeks, %d days, %h hours, %m minutes, %s seconds, %z milliseconds"
+	defaultFormat: static String = "%w weeks, %d days, %h hours, %m minutes, %s seconds, %z milliseconds"
 	// Supported formatting expressions:
 	//  %w - weeks (rounded down)
 	//  %d - days (<7)
@@ -37,19 +37,33 @@ TimeSpan: cover {
 	//  %M - minutes (based on total ticks)
 	//  %S - seconds (based on total ticks)
 	//  %Z - milliseconds (based on total ticks)
-	toText: func (format := This defaultFormat) -> Text {
-		result := format copy()
-		result = result replaceAll(t"%w", t"%d" format(this toWeeks()))
-		result = result replaceAll(t"%D", t"%d" format(this toDays()))
-		result = result replaceAll(t"%H", t"%d" format(this toHours()))
-		result = result replaceAll(t"%M", t"%d" format(this toMinutes()))
-		result = result replaceAll(t"%S", t"%d" format(this toSeconds()))
-		result = result replaceAll(t"%Z", t"%d" format(this toMilliseconds()))
-		result = result replaceAll(t"%d", t"%d" format(this toDays() modulo(7)))
-		result = result replaceAll(t"%h", t"%d" format(this toHours() modulo(24)))
-		result = result replaceAll(t"%m", t"%d" format(this toMinutes() modulo(60)))
-		result = result replaceAll(t"%s", t"%d" format(this toSeconds() modulo(60)))
-		result replaceAll(t"%z", t"%d" format(this toMilliseconds() modulo(1000)))
+	toString: func (format := This defaultFormat) -> String {
+		(weekString, dayString, hourString) := (this toWeeks(), this toDays(), this toHours()) toString()
+		(minuteString, secondString, milliString) := (this toMinutes(), this toSeconds(), this toMilliseconds()) toString()
+		(dayModString, hourModString, minuteModString) := (this toDays() modulo(7), this toHours() modulo(24), this toMinutes() modulo(60)) toString()
+		(secondModString, milliModString) := (this toSeconds() modulo(60), this toMilliseconds() modulo(1000)) toString()
+		second := format replaceAll("%w", weekString)
+		result := second replaceAll("%D", dayString)
+		second free()
+		second = result replaceAll("%H", hourString)
+		result free()
+		result = second replaceAll("%M", minuteString)
+		second free()
+		second = result replaceAll("%S", secondString)
+		result free()
+		result = second replaceAll("%Z", milliString)
+		second free()
+		second = result replaceAll("%d", dayModString)
+		result free()
+		result = second replaceAll("%h", hourModString)
+		second free()
+		second = result replaceAll("%m", minuteModString)
+		result free()
+		result = second replaceAll("%s", secondModString)
+		second free()
+		second = result replaceAll("%z", milliModString)
+		(result, weekString, dayString, hourString, minuteString, secondString, milliString, dayModString, hourModString, minuteModString, secondModString, milliModString) free()
+		second
 	}
 	compareTo: func (other: This) -> Order {
 		if (this ticks > other ticks)

--- a/source/system/CharBuffer.ooc
+++ b/source/system/CharBuffer.ooc
@@ -269,28 +269,31 @@ CharBuffer: class {
 	replaceAll: func ~buf (what, with: This, searchCaseSensitive := true) {
 		findResults := this findAll(what, searchCaseSensitive)
 		if (findResults != null && findResults count != 0) {
-			newlen := this size + (with size * findResults count) - (what size * findResults count)
-			result := This new(newlen)
-			result setLength(newlen)
-
+			newlen := this size + (with size * findResults count) - (what size * findResults count) + 1
+			result := calloc(newlen, Char size) as Char*
 			sstart := 0 // source (this) start pos
 			rstart := 0 // result start pos
-
-			for (item in findResults) {
+			for (i in 0 .. findResults count) {
+				item := findResults[i]
 				sdist := item - sstart // bytes to copy
-				memcpy(result data + rstart, this data + sstart, sdist)
+				memcpy(result[rstart]&, this data + sstart, sdist)
 				sstart += sdist
 				rstart += sdist
-
-				memcpy(result data + rstart, with data, with size)
+				memcpy(result[rstart]&, with data, with size)
 				sstart += what size
 				rstart += with size
 			}
 			// copy remaining last piece of source
 			sdist := this size - sstart
-			memcpy(result data + rstart, this data + sstart, sdist + 1) // +1 to copy the trailing zero as well
-			this setBuffer(result)
+			memcpy(result[rstart]&, this data + sstart, sdist + 1) // +1 to copy the trailing zero as well
+			memfree(this data)
+			this data = result
+			this mallocAddr = result
+			this capacity = newlen
+			this size = newlen - 1
 		}
+		if (findResults != null)
+			findResults free()
 	}
 	replaceAll: func ~char (oldie, kiddo: Char) {
 		for (i in 0 .. this size)

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -32,7 +32,7 @@ Fixture: abstract class {
 	run: func -> Bool {
 		failures := VectorList<TestFailedException> new(32, false)
 		result := true
-		This _print((DateTime now toText(t"%hh:%mm:%ss ") toString() >> this name) >> " ", true)
+		This _print((DateTime now toString("%hh:%mm:%ss ") >> this name) >> " ", true)
 		timer := WallTimer new() . start()
 		for (i in 0 .. this tests count) {
 			test := this tests[i]

--- a/test/base/DateTimeTest.ooc
+++ b/test/base/DateTimeTest.ooc
@@ -157,17 +157,29 @@ DateTimeTest: class extends Fixture {
 			d1 -= TimeSpan week()
 			expect((d2 - d1) toDays() == 6)
 		})
-		this add("toText", func {
+		this add("toString", func {
 			date := DateTime new(1643, 12, 31, 23, 58, 59, 999)
-			expect(date toText(t"%yyyy-%MM-%dd %hh:%mm:%ss.%zzz"), is equal to(t"1643-12-31 23:58:59.999"))
-			expect(date toText(t"%yy-%M-%d %h:%m:%s.%z"), is equal to(t"43-12-31 23:58:59.999"))
+			Astring := date toString("%yyyy-%MM-%dd %hh:%mm:%ss.%zzz")
+			Bstring := date toString("%yy-%M-%d %h:%m:%s.%z")
+			expect(Astring, is equal to("1643-12-31 23:58:59.999"))
+			expect(Bstring, is equal to("43-12-31 23:58:59.999"))
+
 			date = DateTime new(1998, 7, 18, 1, 44, 31, 742)
-			expect(date toText(t"date is : %yy, %M, %dd; hour: %hh-%mm-%ss"), is equal to(t"date is : 98, 7, 18; hour: 01-44-31"))
-			expect(date toText(t"%yyyy/%dd/%MM"), is equal to(t"1998/18/07"))
-			expect(date toText() == date toText(DateTime defaultFormat))
+			Cstring := date toString("date is : %yy, %M, %dd; hour: %hh-%mm-%ss")
+			Dstring := date toString("%yyyy/%dd/%MM")
+			Estring := date toString()
+			Estringcompare := date toString(DateTime defaultFormat)
+			expect(Cstring, is equal to("date is : 98, 7, 18; hour: 01-44-31"))
+			expect(Dstring, is equal to("1998/18/07"))
+			expect(Estring == Estringcompare)
+
 			date = DateTime new ~fromYearMonthDay(1, 1, 1)
-			expect(date toText(t"start date is: %yy %M %d, %hh-%mm-%ss-%zzz"), is equal to(t"start date is: 01 1 1, 00-00-00-000"))
-			expect(date toText(t"%h-%m-%s-%z"), is equal to(t"0-0-0-0"))
+			Fstring := date toString("start date is: %yy %M %d, %hh-%mm-%ss-%zzz")
+			Gstring := date toString("%h-%m-%s-%z")
+			expect(Fstring, is equal to("start date is: 01 1 1, 00-00-00-000"))
+			expect(Gstring, is equal to("0-0-0-0"))
+
+			(Astring, Bstring, Cstring, Dstring, Estring, Fstring, Gstring, Estringcompare) free()
 		})
 		this add("current time", func {
 			d := DateTime now

--- a/test/base/TimeSpanTest.ooc
+++ b/test/base/TimeSpanTest.ooc
@@ -116,12 +116,17 @@ TimeSpanTest: class extends Fixture {
 			expect(TimeSpan weeks(2) toDays() == 14)
 			expect(TimeSpan milliseconds(13) toNanoseconds() == 13_000_000)
 		})
-		this add("toText", func {
+		this add("toString", func {
 			span := TimeSpan millisecond() + TimeSpan second() + TimeSpan minute() + TimeSpan hour() + TimeSpan day() + TimeSpan week()
-			expect(span toText() == t"1 weeks, 1 days, 1 hours, 1 minutes, 1 seconds, 1 milliseconds")
-			expect(span toText(t"%D") == t"8")
-			expect(TimeSpan day() toText(t"%H %M %S %h %m %s") == t"24 1440 86400 0 0 0")
-			expect(TimeSpan hour() toText(t"%d %D text %m %M") == t"0 0 text 0 60")
+			defaultString := span toString()
+			expect(defaultString == "1 weeks, 1 days, 1 hours, 1 minutes, 1 seconds, 1 milliseconds")
+			dayString := span toString("%D")
+			expect(dayString == "8")
+			Astring := TimeSpan day() toString("%H %M %S %h %m %s")
+			expect(Astring == "24 1440 86400 0 0 0")
+			Bstring := TimeSpan hour() toString("%d %D text %m %M")
+			expect(Bstring == "0 0 text 0 60")
+			(defaultString, dayString, Astring, Bstring) free()
 		})
 	}
 }


### PR DESCRIPTION
Not used in other projects, so doesn't break the API. :)
Also fixes `replaceAll` in `String`, it used to leak badly.