### PR TITLE
Replaced Text with String in source/math

### DIFF
--- a/source/math/BoolVectorList.ooc
+++ b/source/math/BoolVectorList.ooc
@@ -75,18 +75,10 @@ BoolVectorList: class extends VectorList<Bool> {
 		result
 	}
 	toString: func -> String {
-		result := ""
-		for (i in 0 .. this _count)
-			result = result >> this[i] toString() >> "\n"
-		result
-	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		for (i in 0 .. this _count)
-			textBuilder append(this[i] toText())
-		result = textBuilder join(t"\n")
-		textBuilder free()
+		result := this _count > 0 ? this[0] toString() : ""
+		result = this _count > 1 ? (result + "\n") >> this[1] toString() : result
+		for (i in 2 .. this _count)
+			result = (result >> "\n") & this[i] toString()
 		result
 	}
 

--- a/source/math/FloatComplex.ooc
+++ b/source/math/FloatComplex.ooc
@@ -19,9 +19,6 @@ FloatComplex: cover {
 	toString: func -> String {
 		this real toString() >> (this imaginary > 0 ? " +" : " ") & this imaginary toString() >> "i"
 	}
-	toText: func -> Text {
-		this real toText() + (this imaginary > 0 ? t" +" : t" ") + this imaginary toText() + t"i"
-	}
 	exponential: func -> This {
 		(this real) exp() * This new((this imaginary) cos(), (this imaginary) sin())
 	}
@@ -39,8 +36,8 @@ FloatComplex: cover {
 	operator * (other: Float) -> This { This new(other * this real, other * this imaginary) }
 	operator / (other: Float) -> This { This new(this real / other, this imaginary / other) }
 
-	parse: static func (input: Text) -> This {
-		parts := input find('+') >= 0 ? input split('+') : input split(' ')
+	parse: static func (input: String) -> This {
+		parts := input find("+") >= 0 ? input split('+') : input split(' ')
 		result := This new(parts[0] toFloat(), parts[1] toFloat())
 		parts free()
 		result

--- a/source/math/FloatComplexVectorList.ooc
+++ b/source/math/FloatComplexVectorList.ooc
@@ -70,18 +70,9 @@ FloatComplexVectorList: class extends VectorList<FloatComplex> {
 		}
 	}
 	toString: func -> String {
-		result := ""
-		for (i in 0 .. this _count)
-			result = result >> this[i] toString() >> "\n"
-		result
-	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		for (i in 0 .. this _count)
-			textBuilder append(this[i] toText())
-		result = textBuilder join(t"\n")
-		textBuilder free()
+		result := this _count > 0 ? this[0] toString() : ""
+		for (i in 1 .. this _count)
+			result = (result >> "\n") & this[i] toString()
 		result
 	}
 

--- a/source/math/FloatMatrix.ooc
+++ b/source/math/FloatMatrix.ooc
@@ -137,19 +137,6 @@ FloatMatrix: cover {
 		this free(Owner Receiver)
 		result
 	}
-	toText: func -> Text {
-		t := this take()
-		result: Text
-		textBuilder := TextBuilder new()
-		for (y in 0 .. t height) {
-			for (x in 0 .. t width - 1)
-				textBuilder append(t[x, y] toText() + t", ")
-			textBuilder append(t[t width - 1, y] toText() + t"; ")
-		}
-		result = textBuilder toText()
-		textBuilder free()
-		result
-	}
 	// Lup decomposition of the current matrix. Recall that Lup decomposition is A = LUP,
 	// where L is lower triangular, U is upper triangular, and P is a permutation matrix.
 	// See http://en.wikipedia.org/wiki/LUP_decomposition.

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -98,18 +98,9 @@ FloatVectorList: class extends VectorList<Float> {
 			this[i] = this[i] + other[i]
 	}
 	toString: func -> String {
-		result := ""
-		for (i in 0 .. this _count)
-			result = (result & this[i] toString()) >> "\n"
-		result
-	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		for (i in 0 .. this _count)
-			textBuilder append(this[i] toText())
-		result = textBuilder join(t"\n")
-		textBuilder free()
+		result := this _count > 0 ? this[0] toString() : ""
+		for (i in 1 .. this _count)
+			result = (result >> "\n") & this[i] toString()
 		result
 	}
 	divideByMaxValue: func -> This {

--- a/source/math/IntVectorList.ooc
+++ b/source/math/IntVectorList.ooc
@@ -67,18 +67,9 @@ IntVectorList: class extends VectorList<Int> {
 		result
 	}
 	toString: func -> String {
-		result := ""
-		for (i in 0 .. this _count)
-			result = result >> this[i] toString() >> "\n"
-		result
-	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		for (i in 0 .. this _count)
-			textBuilder append(this[i] toText())
-		result = textBuilder join(t"\n")
-		textBuilder free()
+		result := this _count > 0 ? this[0] toString() : ""
+		for (i in 1 .. this _count)
+			result = (result >> "\n") & this[i] toString()
 		result
 	}
 

--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -56,7 +56,7 @@ String: class {
 	startsWith: func ~char (c: Char) -> Bool { this _buffer startsWith(c) }
 	endsWith: func (s: This) -> Bool { this _buffer endsWith(s _buffer) }
 	endsWith: func ~char (c: Char) -> Bool { this _buffer endsWith(c) }
-	find: func (what: This, offset: Int, searchCaseSensitive := true) -> Int { this _buffer find(what _buffer, offset, searchCaseSensitive) }
+	find: func (what: This, offset: Int = 0, searchCaseSensitive := true) -> Int { this _buffer find(what _buffer, offset, searchCaseSensitive) }
 	findAll: func (what: This, searchCaseSensitive := true) -> VectorList <Int> { this _buffer findAll(what _buffer, searchCaseSensitive) }
 	replaceAll: func ~str (what, with: This, searchCaseSensitive := true) -> This { (this _buffer clone()) replaceAll(what _buffer, with _buffer, searchCaseSensitive) . toString() }
 	replaceAll: func ~char (oldie, kiddo: Char) -> This { (this _buffer clone()) replaceAll~char(oldie, kiddo) . toString() }

--- a/test/math/BoolVectorListTest.ooc
+++ b/test/math/BoolVectorListTest.ooc
@@ -30,7 +30,7 @@ BoolVectorListTest: class extends Fixture {
 			(list, reversed) free()
 		})
 		this add("dilation", func {
-			list := this _createFromText(t"1100 0011 1000 1110")
+			list := this _createFromString("1100 0011 1000 1110")
 			dilated := list dilation(3)
 			expect(dilated[2])
 			expect(!dilated[3])
@@ -42,7 +42,7 @@ BoolVectorListTest: class extends Fixture {
 			(list, dilated) free()
 		})
 		this add("erosion", func {
-			list := this _createFromText(t"1100 0011 1000 1110")
+			list := this _createFromString("1100 0011 1000 1110")
 			eroded := list erosion(3)
 			expect(!eroded[1])
 			expect(!eroded[2])
@@ -58,7 +58,7 @@ BoolVectorListTest: class extends Fixture {
 			(list, eroded) free()
 		})
 		this add("opening", func {
-			list := this _createFromText(t"1101 1001")
+			list := this _createFromString("1101 1001")
 			opened := list opening(3)
 			expect(opened[0])
 			expect(opened[1])
@@ -71,7 +71,7 @@ BoolVectorListTest: class extends Fixture {
 			(list, opened) free()
 		})
 		this add("closing", func {
-			list := this _createFromText(t"1101 1001")
+			list := this _createFromString("1101 1001")
 			closed := list closing(3)
 			expect(closed[0])
 			expect(closed[1])
@@ -84,8 +84,8 @@ BoolVectorListTest: class extends Fixture {
 			(list, closed) free()
 		})
 		this add("logical operators", func {
-			list := this _createFromText(t"11010")
-			other := this _createFromText(t"10001")
+			list := this _createFromString("11010")
+			other := this _createFromString("10001")
 			listAndOther := list && other
 			listOrOther := list || other
 			expect(listAndOther tally(true), is equal to(1))
@@ -93,21 +93,21 @@ BoolVectorListTest: class extends Fixture {
 			(list, other, listAndOther, listOrOther) free()
 		})
 		this add("toFloatVectorList", func {
-			list := this _createFromText(t"11001")
+			list := this _createFromString("11001")
 			floatList := list toFloatVectorList()
 			expect(floatList sum, is equal to(3.0f) within(0.01f))
 			(floatList, list) free()
 		})
-		this add("toText", func {
-			list := this _createFromText(t"101")
-			text := list toText() take()
-			expect(text, is equal to(t"true\nfalse\ntrue"))
+		this add("toString", func {
+			list := this _createFromString("101")
+			text := list toString()
+			expect(text, is equal to("true\nfalse\ntrue"))
 			(text, list) free()
 		})
 	}
-	_createFromText: func (content: Text) -> BoolVectorList {
+	_createFromString: func (content: String) -> BoolVectorList {
 		result := BoolVectorList new()
-		for (i in 0 .. content count) {
+		for (i in 0 .. content size) {
 			if (content[i] == '1')
 				result add(true)
 			else if (content[i] == '0')

--- a/test/math/FloatComplexTest.ooc
+++ b/test/math/FloatComplexTest.ooc
@@ -64,22 +64,22 @@ FloatComplexTest: class extends Fixture {
 		this add("toString and parse", func {
 			string := this complexNumber0 toString()
 			expect(string, is equal to("2.00 +1.00i"))
-			expect((FloatComplex parse(t"2.00 +1.00i")) == this complexNumber0, is true)
+			expect((FloatComplex parse("2.00 +1.00i")) == this complexNumber0, is true)
 
 			string free()
 			string = this complexNumber3 toString()
 			expect(string, is equal to("-2.00 -1.00i"))
-			expect((FloatComplex parse(t"-2.00 -1.00i")) == this complexNumber3, is true)
+			expect((FloatComplex parse("-2.00 -1.00i")) == this complexNumber3, is true)
 
 			string free()
 			string = FloatComplex new (2, -1) toString()
 			expect(string, is equal to("2.00 -1.00i"))
-			expect((FloatComplex parse(t"2.00 -1.00i")) == FloatComplex new (2, -1), is true)
+			expect((FloatComplex parse("2.00 -1.00i")) == FloatComplex new (2, -1), is true)
 
 			string free()
 			string = FloatComplex new (-2, 1) toString()
 			expect(string, is equal to("-2.00 +1.00i"))
-			expect((FloatComplex parse(t"-2.00 +1.00i")) == FloatComplex new (-2, 1), is true)
+			expect((FloatComplex parse("-2.00 +1.00i")) == FloatComplex new (-2, 1), is true)
 			string free()
 		})
 		this add("exponential", func {
@@ -106,10 +106,10 @@ FloatComplexTest: class extends Fixture {
 			expect(FloatComplex rootOfUnity(5, 4) real, is equal to(0.309f) within(0.01f))
 			expect(FloatComplex rootOfUnity(5, 4) imaginary, is equal to(-0.951f) within(0.01f))
 		})
-		this add("toText", func {
+		this add("toString", func {
 			complex := FloatComplex new(10, 5)
-			text := complex toText() take()
-			expect(text, is equal to(t"10.00 +5.00i"))
+			text := complex toString()
+			expect(text, is equal to("10.00 +5.00i"))
 			text free()
 		})
 	}

--- a/test/math/FloatComplexVectorListTest.ooc
+++ b/test/math/FloatComplexVectorListTest.ooc
@@ -104,13 +104,13 @@ FloatComplexVectorListTest: class extends Fixture {
 
 			(added, subtracted, list, other) free()
 		})
-		this add("toText", func {
+		this add("toString", func {
 			list := FloatComplexVectorList new()
 			list add(FloatComplex new(-1, 2))
 			list add(FloatComplex new(3, -4))
 			list add(FloatComplex new(-5, 6))
-			text := list toText() take()
-			expect(text, is equal to(t"-1.00 +2.00i\n3.00 -4.00i\n-5.00 +6.00i"))
+			text := list toString()
+			expect(text, is equal to("-1.00 +2.00i\n3.00 -4.00i\n-5.00 +6.00i"))
 			(text, list) free()
 		})
 		this add("getZeros", func {

--- a/test/math/FloatMatrixTest.ooc
+++ b/test/math/FloatMatrixTest.ooc
@@ -158,11 +158,11 @@ FloatMatrixTest: class extends Fixture {
 			m := this createMatrix(4, 4, [1.f, -1.f, 2.f, -3.f, 2.f, -3.f, -3.f, 1.f, -1.f, 2.f, 3.f, 1.f, 1.f, 2.f, -1.f, 2.f])
 			this checkAllElements(m inverse(), [23.f / 68.f, 13.f / 68.f, 6.f / 68.f, 25.f / 68.f, 3.f / 68.f, -19.f / 68.f, -14.f / 68.f, 21.f / 68.f, 9.f / 68.f, 11.f / 68.f, 26.f / 68.f, -5.f / 68.f, -10.f / 68.f, 18.f / 68.f, 24.f / 68.f, -2.f / 68.f])
 		})
-		this add("toText", func {
+		this add("toString", func {
 			matrix := FloatMatrix identity(3)
-			text := matrix toText() take()
-			expect(text, is equal to(t"1.00, 0.00, 0.00; 0.00, 1.00, 0.00; 0.00, 0.00, 1.00; "))
-			(text, matrix) free()
+			text := matrix toString()
+			expect(text, is equal to("1.00, 0.00, 0.00; 0.00, 1.00, 0.00; 0.00, 0.00, 1.00; "))
+			text free()
 		})
 		this add("equality", func {
 			m := this createMatrix(3, 3, [1.f, 5.f, 3.f, 7.f, 6.f, 8.f, 9.f, 2.f, 4.f]) take()

--- a/test/math/FloatVectorListTest.ooc
+++ b/test/math/FloatVectorListTest.ooc
@@ -391,11 +391,11 @@ FloatVectorListTest: class extends Fixture {
 			expect(maxValue2, is equal to(1.0f) within(tolerance))
 			(list, shiftedList0, shiftedList1, shiftedList2, crossCorrelationList0, crossCorrelationList1, crossCorrelationList2, offsetValues0, offsetValues1, offsetValues2) free()
 		})
-		this add("toText", func {
+		this add("toString", func {
 			list := FloatVectorList new()
 			list add(1.0f) . add(2.0f) . add(3.0f)
-			text := list toText() take()
-			expect(text, is equal to(t"1.00\n2.00\n3.00"))
+			text := list toString()
+			expect(text, is equal to("1.00\n2.00\n3.00"))
 			(text, list) free()
 		})
 		this add("clamp", func {

--- a/test/math/IntVectorListTest.ooc
+++ b/test/math/IntVectorListTest.ooc
@@ -60,11 +60,11 @@ IntVectorListTest: class extends Fixture {
 			expect(compressed[4], is equal to(7))
 			(list, compressed) free()
 		})
-		this add("toText", func {
+		this add("toString", func {
 			list := IntVectorList new()
 			list add(1) . add(2) . add(3)
-			text := list toText()
-			expect(text take(), is equal to(t"1\n2\n3"))
+			text := list toString()
+			expect(text, is equal to("1\n2\n3"))
 			(text, list) free()
 		})
 	}


### PR DESCRIPTION
Also fixes leaks in `toString` of some `*List` classes.

0 leaks from these tests now.