### PR TITLE
Removed Text from source/geometry

### DIFF
--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -123,7 +123,6 @@ FloatBox2D: cover {
 		This createAround(newCenter, newSize)
 	}
 	toString: func -> String { (this leftTop toString() >> ", ") & this size toString() }
-	toText: func -> Text { this leftTop toText() + t", " + this size toText() }
 	toIntBox2D: func -> IntBox2D { IntBox2D new(this left, this top, this width, this height) }
 
 	operator + (other: This) -> This {
@@ -149,7 +148,7 @@ FloatBox2D: cover {
 	operator / (other: FloatVector2D) -> This { This new(this leftTop / other, this size / other) }
 	operator - (other: FloatVector2D) -> This { This new(this leftTop, this size - other) }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toFloat(), parts[1] toFloat(), parts[2] toFloat(), parts[3] toFloat())
 		parts free()

--- a/source/geometry/FloatConvexHull2D.ooc
+++ b/source/geometry/FloatConvexHull2D.ooc
@@ -132,17 +132,6 @@ FloatConvexHull2D: class {
 			result = result >> "(" & this _points[i] toString() >> ") "
 		result
 	}
-
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		for (i in 0 .. this count)
-			textBuilder append(t"(" + this _points[i] toText() + t")")
-		result = textBuilder join(t" ")
-		textBuilder free()
-		result
-	}
-
 	_pointsLinePseudoDistance: static func (leftPoint, rightPoint, queryPoint: FloatPoint2D) -> Float {
 		((rightPoint y - leftPoint y) * (leftPoint x - queryPoint x)) - ((rightPoint x - leftPoint x) * (leftPoint y - queryPoint y))
 	}

--- a/source/geometry/FloatEuclidTransform.ooc
+++ b/source/geometry/FloatEuclidTransform.ooc
@@ -33,9 +33,6 @@ FloatEuclidTransform: cover {
 	toString: func -> String {
 		"Translation: " << this translation toString() >> " Rotation: " & this rotation toString() >> " Scaling: " & this scaling toString()
 	}
-	toText: func -> Text {
-		t"Translation: " + this translation toText() + t" Rotation: " + this rotation toText() + t" Scaling: " + this scaling toText()
-	}
 
 	operator * (other: This) -> This { This new(this translation + other translation, this rotation * other rotation, this scaling * other scaling) }
 	operator == (other: This) -> Bool {

--- a/source/geometry/FloatEuclidTransformVectorList.ooc
+++ b/source/geometry/FloatEuclidTransformVectorList.ooc
@@ -106,15 +106,6 @@ FloatEuclidTransformVectorList: class extends VectorList<FloatEuclidTransform> {
 			result = result >> this[i] toString() >> "\n"
 		result
 	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		for (i in 0 .. this _count)
-			textBuilder append(this[i] toText())
-		result = textBuilder join(t"\n")
-		textBuilder free()
-		result
-	}
 
 	operator [] (index: Int) -> FloatEuclidTransform {
 		this _vector[index]

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -42,7 +42,6 @@ FloatPoint2D: cover {
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x as Int, this y as Int) }
 	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x, this y) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }
-	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y) }
@@ -65,7 +64,7 @@ FloatPoint2D: cover {
 	basisX: static This { get { This new(1, 0) } }
 	basisY: static This { get { This new(0, 1) } }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toFloat(), parts[1] toFloat())
 		parts free()

--- a/source/geometry/FloatPoint2DVectorList.ooc
+++ b/source/geometry/FloatPoint2DVectorList.ooc
@@ -83,15 +83,6 @@ FloatPoint2DVectorList: class extends VectorList<FloatPoint2D> {
 			result = result >> this[i] toString() >> "\n"
 		result
 	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		for (i in 0 .. this _count)
-			textBuilder append(this[i] toText())
-		result = textBuilder join(t"\n")
-		textBuilder free()
-		result
-	}
 	resampleLinear: func (start, end, interval: Float) -> This {
 		// Assumes list is sorted by x values.
 		resultCount := ((end - start) / interval) ceil() as Int + 1

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -48,7 +48,6 @@ FloatPoint3D: cover {
 	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x as Int, this y as Int, this z as Int) }
 	toFloatVector3D: func -> FloatVector3D { FloatVector3D new(this x, this y, this z) }
 	toString: func -> String { "%.8f" formatFloat(this x) >> ", " & "%.8f" formatFloat(this y) >> ", " & "%.8f" formatFloat(this z) }
-	toText: func -> Text { this x toText() + t", " + this y toText() + t", " + this z toText() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y, this z + other z) }
@@ -71,7 +70,7 @@ FloatPoint3D: cover {
 	spherical: static func (radius, azimuth, elevation: Float) -> This {
 		This new(radius * (azimuth cos()) * (elevation sin()), radius * (azimuth sin()) * (elevation sin()), radius * (elevation cos()))
 	}
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toFloat(), parts[1] toFloat(), parts[2] toFloat())
 		parts free()

--- a/source/geometry/FloatRotation3D.ooc
+++ b/source/geometry/FloatRotation3D.ooc
@@ -26,7 +26,6 @@ FloatRotation3D: cover {
 	}
 	angle: func (other: This) -> Float { this _quaternion angle(other _quaternion) }
 	toString: func -> String { this _quaternion toString() }
-	toText: func -> Text { this _quaternion toText() }
 
 	operator * (other: This) -> This { This new(this _quaternion * other _quaternion) }
 	operator == (other: This) -> Bool { this _quaternion == other _quaternion }

--- a/source/geometry/FloatShell2D.ooc
+++ b/source/geometry/FloatShell2D.ooc
@@ -40,7 +40,6 @@ FloatShell2D: cover {
 		This new(this left minimum(other left), this right minimum(other right), this top minimum(other top), this bottom minimum(other bottom))
 	}
 	toString: func -> String { (this left toString() >> ", ") & (this right toString() >> ", ") & (this top toString() >> ", ") & (this bottom toString() >> ", ") }
-	toText: func -> Text { this left toText() + t", " + this right toText() + t", " + this top toText() + t", " + this bottom toText() }
 
 	operator + (other: This) -> This { This new(this left + other left, this right + other right, this top + other top, this bottom + other bottom) }
 	operator - (other: This) -> This { This new(this left - other left, this right - other right, this top - other top, this bottom - other bottom) }
@@ -48,7 +47,7 @@ FloatShell2D: cover {
 	operator != (other: This) -> Bool { !(this == other) }
 	operator / (other: Float) -> This { This new(this left / other, this right / other, this top / other, this bottom / other) }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toFloat(), parts[1] toFloat(), parts[2] toFloat(), parts[3] toFloat())
 		parts free()

--- a/source/geometry/FloatTransform2D.ooc
+++ b/source/geometry/FloatTransform2D.ooc
@@ -75,16 +75,6 @@ FloatTransform2D: cover {
 		"%8f" formatFloat(this d) >> ", " & "%8f" formatFloat(this e) >> ", " & "%8f" formatFloat(this f) >> "\t" & \
 		"%8f" formatFloat(this g) >> ", " & "%8f" formatFloat(this h) >> ", " & "%8f" formatFloat(this i) >> "\t"
 	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		textBuilder append(this a toText() + t", " + this b toText() + t", " + this c toText())
-		textBuilder append(this d toText() + t", " + this e toText() + t", " + this f toText())
-		textBuilder append(this g toText() + t", " + this h toText() + t", " + this i toText())
-		result = textBuilder join(t"\t")
-		textBuilder free()
-		result
-	}
 
 	operator * (other: This) -> This {
 		This new(

--- a/source/geometry/FloatTransform3D.ooc
+++ b/source/geometry/FloatTransform3D.ooc
@@ -98,17 +98,6 @@ FloatTransform3D: cover {
 		"%.8f" formatFloat(this c) >> ", " & "%.8f" formatFloat(this g) >> ", " & "%.8f" formatFloat(this k) >> ", " & "%.8f" formatFloat(this o) >> "\n" & \
 		"%.8f" formatFloat(this d) >> ", " & "%.8f" formatFloat(this h) >> ", " & "%.8f" formatFloat(this l) >> ", " & "%.8f" formatFloat(this p)
 	}
-	toText: func -> Text {
-		result: Text
-		textBuilder := TextBuilder new()
-		textBuilder append(this a toText() + t", " + this e toText() + t", " + this i toText() + t", " + this m toText())
-		textBuilder append(this b toText() + t", " + this f toText() + t", " + this j toText() + t", " + this n toText())
-		textBuilder append(this c toText() + t", " + this g toText() + t", " + this k toText() + t", " + this o toText())
-		textBuilder append(this d toText() + t", " + this h toText() + t", " + this l toText() + t", " + this p toText())
-		result = textBuilder join(t"\n")
-		textBuilder free()
-		result
-	}
 	transformAndProject: func ~FloatPoint2D (point: FloatPoint2D, focalLength: Float) -> FloatPoint2D {
 		transformedWorldPoint := this * FloatPoint3D new(point x, point y, focalLength)
 		focalLength < Float epsilon ? FloatPoint2D new(transformedWorldPoint x, transformedWorldPoint y) : this project(transformedWorldPoint, focalLength)

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -46,7 +46,6 @@ FloatVector2D: cover {
 	toIntVector2D: func -> IntVector2D { IntVector2D new(this x as Int, this y as Int) }
 	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x, this y) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }
-	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y) }
@@ -72,7 +71,7 @@ FloatVector2D: cover {
 	basisY: static This { get { This new(0, 1) } }
 
 	polar: static func (radius, azimuth: Float) -> This { This new(radius * cos(azimuth), radius * sin(azimuth)) }
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new (parts[0] toFloat(), parts[1] toFloat())
 		parts free()

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -50,7 +50,6 @@ FloatVector3D: cover {
 	toIntVector3D: func -> IntVector3D { IntVector3D new(this x as Int, this y as Int, this z as Int) }
 	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x, this y, this z) }
 	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
-	toText: func -> Text { this x toText() + t", " + this y toText() + t", " + this z toText() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y, this z + other z) }
@@ -76,7 +75,7 @@ FloatVector3D: cover {
 	basisY: static This { get { This new(0, 1, 0) } }
 	basisZ: static This { get { This new(0, 0, 1) } }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new (parts[0] toFloat(), parts[1] toFloat(), parts[2] toFloat())
 		parts free()

--- a/source/geometry/IntBox2D.ooc
+++ b/source/geometry/IntBox2D.ooc
@@ -98,7 +98,6 @@ IntBox2D: cover {
 	contains: func ~box (box: This) -> Bool { this intersection(box) == box }
 	toFloatBox2D: func -> FloatBox2D { FloatBox2D new(this left, this top, this width, this height) }
 	toString: func -> String { (this leftTop toString() >> ", ") & this size toString() }
-	toText: func -> Text { this leftTop toText() + t", " + this size toText() }
 
 	operator + (other: This) -> This {
 		if (this hasZeroArea)
@@ -118,7 +117,7 @@ IntBox2D: cover {
 	operator * (scale: Int) -> This { This new(this leftTop * scale, this size * scale) }
 	operator / (divisor: Int) -> This { This new(this leftTop / divisor, this size / divisor) }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toInt(), parts[1] toInt(), parts[2] toInt(), parts[3] toInt())
 		parts free()

--- a/source/geometry/IntPoint2D.ooc
+++ b/source/geometry/IntPoint2D.ooc
@@ -24,7 +24,6 @@ IntPoint2D: cover {
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y)) }
 	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x as Float, this y as Float) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }
-	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y) }
@@ -44,7 +43,7 @@ IntPoint2D: cover {
 	operator * (other: Int) -> This { This new(this x * other, this y * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other) }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toInt(), parts[1] toInt())
 		parts free()

--- a/source/geometry/IntPoint3D.ooc
+++ b/source/geometry/IntPoint3D.ooc
@@ -23,7 +23,6 @@ IntPoint3D: cover {
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
 	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x as Float, this y as Float, this z as Float) }
 	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
-	toText: func -> Text { this x toText() + t", " + this y toText() + t", " + this z toText() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y, this z + other z) }
@@ -43,7 +42,7 @@ IntPoint3D: cover {
 	operator * (other: Int) -> This { This new(this x * other, this y * other, this z * other) }
 	operator / (other: Int) -> This { This new(this x / other, this y / other, this z / other) }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toInt(), parts[1] toInt(), parts[2] toInt())
 		parts free()

--- a/source/geometry/IntShell2D.ooc
+++ b/source/geometry/IntShell2D.ooc
@@ -39,7 +39,6 @@ IntShell2D: cover {
 		This new(this left minimum(other left), this right minimum(other right), this top minimum(other top), this bottom minimum(other bottom))
 	}
 	toString: func -> String { (this left toString() >> ", ") & (this right toString() >> ", ") & (this top toString() >> ", ") & (this bottom toString() >> ", ") }
-	toText: func -> Text { this left toText() + t", " + this right toText() + t", " + this top toText() + t", " + this bottom toText() }
 
 	operator + (other: This) -> This { This new(this left + other left, this right + other right, this top + other top, this bottom + other bottom) }
 	operator - (other: This) -> This { This new(this left - other left, this right - other right, this top - other top, this bottom - other bottom) }
@@ -47,7 +46,7 @@ IntShell2D: cover {
 	operator != (other: This) -> Bool { !(this == other) }
 	operator / (other: Int) -> This { This new(this left / other, this right / other, this top / other, this bottom / other) }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new(parts[0] toInt(), parts[1] toInt(), parts[2] toInt(), parts[3] toInt())
 		parts free()

--- a/source/geometry/IntVector2D.ooc
+++ b/source/geometry/IntVector2D.ooc
@@ -33,7 +33,6 @@ IntVector2D: cover {
 	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x as Float, this y as Float) }
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x, this y) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }
-	toText: func -> Text { this x toText() + t", " + this y toText() }
 
 	operator - -> This { This new(-this x, -this y) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y) }
@@ -58,7 +57,7 @@ IntVector2D: cover {
 	basisX: static This { get { This new(1, 0) } }
 	basisY: static This { get { This new(0, 1) } }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new (parts[0] toInt(), parts[1] toInt())
 		parts free()

--- a/source/geometry/IntVector3D.ooc
+++ b/source/geometry/IntVector3D.ooc
@@ -24,7 +24,6 @@ IntVector3D: cover {
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
 	toFloatVector3D: func -> FloatVector3D { FloatVector3D new(this x as Float, this y as Float, this z as Float) }
 	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
-	toText: func -> Text { this x toText() + t", " + this y toText() + t", " + this z toText() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y, this z + other z) }
@@ -50,7 +49,7 @@ IntVector3D: cover {
 	basisY: static This { get { This new(0, 1, 0) } }
 	basisZ: static This { get { This new(0, 0, 1) } }
 
-	parse: static func (input: Text) -> This {
+	parse: static func (input: String) -> This {
 		parts := input split(',')
 		result := This new (parts[0] toInt(), parts[1] toInt(), parts[2] toInt())
 		parts free()

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -173,9 +173,6 @@ Quaternion: cover {
 		"Real: " << "%8f" formatFloat(this real) >>
 		" Imaginary: " & "%8f" formatFloat(this imaginary x) >> " " & "%8f" formatFloat(this imaginary y) >> " " & "%8f" formatFloat(this imaginary z)
 	}
-	toText: func -> Text {
-		t"Real: " + this real toText() + t" Imaginary: " + this imaginary x toText() + t" " + this imaginary y toText() + t" " + this imaginary z toText()
-	}
 
 	operator * (other: This) -> This {
 		realResult := this real * other real - this imaginary scalarProduct(other imaginary)

--- a/source/system/Numbers.ooc
+++ b/source/system/Numbers.ooc
@@ -79,12 +79,6 @@ UInt: cover from uint32_t extends ULLong {
 	maximumValue ::= static UINT32_MAX
 	minimumValue ::= static 0
 	toString: func -> String { "%u" formatUInt(this) }
-	toText: func -> Text {
-		string := this toString()
-		result := Text new(string) copy()
-		string free()
-		result
-	}
 }
 
 UShort: cover from uint16_t extends ULLong {
@@ -149,11 +143,5 @@ Range: cover {
 	}
 	toString: func -> String {
 		"%d, %d" format(this min, this max)
-	}
-	toText: func -> Text {
-		string := this toString()
-		result := Text new(string) copy()
-		string free()
-		result
 	}
 }

--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -153,6 +153,17 @@ String: class {
 	split: func ~str (delimiter: This, maxTokens: SSizeT) -> VectorList<This> {
 		this _bufVectorListToStrVectorList(this _buffer split(delimiter _buffer, maxTokens))
 	}
+
+	operator + (other: Float) -> This { this << other toString() }
+	operator + (other: Double) -> This { this << other toString() }
+	operator + (other: UInt) -> This { this << other toString() }
+	operator + (other: Int) -> This { this << other toString() }
+
+	operator & (other: Float) -> This { this & other toString() }
+	operator & (other: Double) -> This { this & other toString() }
+	operator & (other: UInt) -> This { this & other toString() }
+	operator & (other: Int) -> This { this & other toString() }
+
 	free: static func ~all {
 		string_literal_free_all()
 	}

--- a/source/system/Text.ooc
+++ b/source/system/Text.ooc
@@ -278,10 +278,6 @@ Text: cover {
 	operator [] (range: Range) -> This { this slice(range min, range count) }
 	operator == (string: String) -> Bool { this == This new(string) }
 	operator != (other: String) -> Bool { !(this == other) }
-	operator + (other: Float) -> This { this + other toText() }
-	operator + (other: Double) -> This { this + other toText() }
-	operator + (other: UInt) -> This { this + other toText() }
-	operator + (other: Int) -> This { this + other toText() }
 	operator [] (index: Int) -> Char {
 		result := this _buffer[index]
 		this free(Owner Receiver)

--- a/source/system/types.ooc
+++ b/source/system/types.ooc
@@ -95,7 +95,6 @@ Pointer: cover from Void* {
 
 Bool: cover from bool {
 	toString: func -> String { this ? "true" : "false" }
-	toText: func -> Text { this ? t"true" : t"false" }
 }
 
 Closure: cover {

--- a/test/geometry/FloatBox2DTest.ooc
+++ b/test/geometry/FloatBox2DTest.ooc
@@ -126,11 +126,6 @@ FloatBox2DTest: class extends Fixture {
 			expect(string, is equal to("1.00, 2.00, 3.00, 4.00"))
 			string free()
 		})
-		this add("toText", func {
-			text := this box0 toText() take()
-			expect(text, is equal to(t"1.00, 2.00, 3.00, 4.00"))
-			text free()
-		})
 		this add("bounds", func {
 			points := VectorList<FloatPoint2D> new()
 			points add(FloatPoint2D new(1.0f, 2.0f))
@@ -147,7 +142,7 @@ FloatBox2DTest: class extends Fixture {
 			points free()
 		})
 		this add("parse", func {
-			box := FloatBox2D parse(t"1.0, 2.0, 3.0, 4.0")
+			box := FloatBox2D parse("1.0, 2.0, 3.0, 4.0")
 			expect(box left, is equal to(1.0f) within(tolerance))
 			expect(box top, is equal to(2.0f) within(tolerance))
 			expect(box right, is equal to(1.0f + 3.0f) within(tolerance))

--- a/test/geometry/FloatConvexHull2DTest.ooc
+++ b/test/geometry/FloatConvexHull2DTest.ooc
@@ -76,13 +76,6 @@ FloatConvexHull2DTest: class extends Fixture {
 			expect(string == "(1.00, 1.00) (1.00, 5.00) (4.00, 5.00) (4.00, 1.00) ")
 			(string, hull) free()
 		})
-		this add("toText", func {
-			square := FloatBox2D new(1.0f, 1.0f, 3.0f, 4.0f)
-			hull := FloatConvexHull2D new(square)
-			text := hull toText() take()
-			expect(text, is equal to(t"(1.00, 1.00) (1.00, 5.00) (4.00, 5.00) (4.00, 1.00)"))
-			(hull, text) free()
-		})
 	}
 }
 

--- a/test/geometry/FloatEuclidTransformTest.ooc
+++ b/test/geometry/FloatEuclidTransformTest.ooc
@@ -68,12 +68,6 @@ FloatEuclidTransformTest: class extends Fixture {
 
 			(kernel, quaternions, euclidTransforms) free()
 		})
-		this add("toText", func {
-			euclidTransform := FloatEuclidTransform new()
-			text := euclidTransform toText() take()
-			expect(text, is equal to(t"Translation: 0.00, 0.00, 0.00 Rotation: Real: 1.00 Imaginary: 0.00 0.00 0.00 Scaling: 1.00"))
-			text free()
-		})
 		this add("inverse", func {
 			transform := FloatEuclidTransform new(FloatVector3D new(), FloatRotation3D createRotationZ(3))
 			inverse := transform inverse

--- a/test/geometry/FloatEuclidTransformVectorListTest.ooc
+++ b/test/geometry/FloatEuclidTransformVectorListTest.ooc
@@ -75,16 +75,6 @@ FloatEuclidTransformVectorListTest: class extends Fixture {
 			expect(scaling[1], is equal to(scaling2) within(tolerance))
 			(list, translation, translationX, translationY, translationZ, rotation, rotationX, rotationY, rotationZ, scaling) free()
 		})
-		this add("toText", func {
-			list := FloatEuclidTransformVectorList new()
-			translation := FloatVector3D new(1.11f, 2.31f, 3.64f)
-			rotation := FloatRotation3D new(Quaternion new(1.21f, 2.31f, 3.14f, 4.23f))
-			scaling := 5.72f
-			list add(FloatEuclidTransform new(translation, rotation, scaling))
-			text := list toText() take()
-			expect(text, is equal to(t"Translation: 1.11, 2.31, 3.64 Rotation: Real: 1.21 Imaginary: 2.31 3.14 4.23 Scaling: 5.72"))
-			(text, list) free()
-		})
 		this add("convolve", func {
 			list := FloatEuclidTransformVectorList new()
 			kernel := FloatVectorList gaussianKernel(3)

--- a/test/geometry/FloatPoint2DTest.ooc
+++ b/test/geometry/FloatPoint2DTest.ooc
@@ -55,10 +55,10 @@ FloatPoint2DTest: class extends Fixture {
 			expect(result y, is equal to(this point0 x))
 		})
 		this add("casting", func {
-			value := t"10.00, 20.00"
-			(valueString, string) := (value toString(), this point3 toString())
-			expect(string, is equal to(valueString))
-			(string, valueString) free()
+			value := "10.00, 20.00"
+			string := this point3 toString()
+			expect(string, is equal to(value))
+			string free()
 			expect(FloatPoint2D parse(value) x, is equal to(this point3 x))
 			expect(FloatPoint2D parse(value) y, is equal to(this point3 y))
 		})
@@ -167,11 +167,6 @@ FloatPoint2DTest: class extends Fixture {
 			expect(interpolate2 y, is equal to(5.0f) within(0.01f))
 			expect(interpolate3 x, is equal to(this point1 x) within(tolerance))
 			expect(interpolate3 y, is equal to(this point1 y) within(tolerance))
-		})
-		this add("toText", func {
-			text := FloatPoint2D new (10.92f, -30.12f) toText() take()
-			expect(text, is equal to(t"10.92, -30.12"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/FloatPoint2DVectorListTest.ooc
+++ b/test/geometry/FloatPoint2DVectorListTest.ooc
@@ -134,14 +134,6 @@ FloatPoint2DVectorListTest: class extends Fixture {
 			expect(min y, is equal to(1.0f) within(tolerance))
 			list free()
 		})
-		this add("toText", func {
-			list := FloatPoint2DVectorList new()
-			list add(FloatPoint2D new(1.0f, 2.0f))
-			list add(FloatPoint2D new(3.0f, 4.0f))
-			text := list toText() take()
-			expect(text, is equal to(t"1.00, 2.00\n3.00, 4.00"))
-			(text, list) free()
-		})
 		this add("median and mean", func {
 			list := FloatPoint2DVectorList new()
 			list add(FloatPoint2D new(2.0f, 1.0f))

--- a/test/geometry/FloatPoint3DTest.ooc
+++ b/test/geometry/FloatPoint3DTest.ooc
@@ -59,13 +59,13 @@ FloatPoint3DTest: class extends Fixture {
 			expect(this point0 z, is equal to(10.0f))
 		})
 		this add("casting", func {
-			value := t"12.00000000, 13.00000000, 20.00000000"
-			(point1String, valueString) := (this point1 toString(), value toString())
-			expect(point1String, is equal to(valueString))
+			value := "12.00000000, 13.00000000, 20.00000000"
+			point1String := this point1 toString()
+			expect(point1String, is equal to(value))
 			expect(FloatPoint3D parse(value) x, is equal to(this point1 x))
 			expect(FloatPoint3D parse(value) y, is equal to(this point1 y))
 			expect(FloatPoint3D parse(value) z, is equal to(this point1 z))
-			(point1String, valueString) free()
+			point1String free()
 		})
 		this add("p norm", func {
 			oneNorm := this point0 pNorm(1.0f)
@@ -141,11 +141,6 @@ FloatPoint3DTest: class extends Fixture {
 		this add("azimuth", func {
 			mypoint := FloatPoint3D new(1.0, 5.5, 0.1)
 			expect(mypoint azimuth, is equal to(5.5f atan2(1.0f)) within(tolerance))
-		})
-		this add("toText", func {
-			text := FloatPoint3D new (10.92f, -30.12f, 0.52f) toText() take()
-			expect(text, is equal to(t"10.92, -30.12, 0.52"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/FloatRotation3DTest.ooc
+++ b/test/geometry/FloatRotation3DTest.ooc
@@ -86,12 +86,6 @@ FloatRotation3DTest: class extends Fixture {
 			expect(y, is equal to(rotation y) within(tolerance))
 			expect(z, is equal to(rotation z) within(tolerance))
 		})
-		this add("toText", func {
-			quaternion := Quaternion new(33.0f, 10.0f, -12.0f, 54.5f)
-			text := FloatRotation3D new(quaternion) toText() take()
-			expect(text, is equal to(t"Real: 33.00 Imaginary: 10.00 -12.00 54.50"))
-			text free()
-		})
 	}
 }
 

--- a/test/geometry/FloatShell2DTest.ooc
+++ b/test/geometry/FloatShell2DTest.ooc
@@ -90,16 +90,11 @@ FloatShell2DTest: class extends Fixture {
 			expect(decreased bottom, is equal to(1.0f) within(tolerance))
 		})
 		this add("parse", func {
-			shell := FloatShell2D parse(t"1.0, 2.0, 3.0, 4.0")
+			shell := FloatShell2D parse("1.0, 2.0, 3.0, 4.0")
 			expect(shell left, is equal to(1.0f) within(tolerance))
 			expect(shell right, is equal to(2.0f) within(tolerance))
 			expect(shell top, is equal to(3.0f) within(tolerance))
 			expect(shell bottom, is equal to(4.0f) within(tolerance))
-		})
-		this add("toText", func {
-			text := FloatShell2D new(10.12f) toText() take()
-			expect(text, is equal to(t"10.12, 10.12, 10.12, 10.12"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/FloatTransform2DTest.ooc
+++ b/test/geometry/FloatTransform2DTest.ooc
@@ -170,11 +170,6 @@ FloatTransform2DTest: class extends Fixture {
 			expect(translation x, is equal to(5.0f) within(tolerance))
 			expect(translation y, is equal to(7.0f) within(tolerance))
 		})
-		this add("toText", func {
-			text := FloatTransform2D new(3.0f, 1.0f, 2.0f, 1.0f, 5.0f, 7.0f) toText() take()
-			expect(text, is equal to(t"3.00, 1.00, 0.00\t2.00, 1.00, 0.00\t5.00, 7.00, 1.00"))
-			text free()
-		})
 		this add("setTranslation", func {
 			transform := this transform0 setTranslation(FloatVector2D new(-7.0f, 3.0f))
 			expect(transform a, is equal to(3.0f) within(tolerance))

--- a/test/geometry/FloatTransform3DTest.ooc
+++ b/test/geometry/FloatTransform3DTest.ooc
@@ -270,11 +270,6 @@ FloatTransform3DTest: class extends Fixture {
 			expect(string, is equal to(value))
 			string free()
 		})
-		this add("toText", func {
-			text := FloatTransform3D new(1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3) toText() take()
-			expect(text, is equal to(t"1.00, 4.00, 7.00, 1.00\n2.00, 5.00, 8.00, 2.00\n3.00, 6.00, 9.00, 3.00\n0.00, 0.00, 0.00, 1.00"))
-			text free()
-		})
 		this add("setScaling", func {
 			transform := this transform0 setScaling(4.0f)
 			expect(transform a, is equal to (-0.45377181f) within (tolerance))

--- a/test/geometry/FloatVector2DTest.ooc
+++ b/test/geometry/FloatVector2DTest.ooc
@@ -55,10 +55,10 @@ FloatVector2DTest: class extends Fixture {
 			expect(result y, is equal to(this vector0 x) within(tolerance))
 		})
 		this add("casting", func {
-			value := t"10.00, 20.00"
-			(valueString, string) := (value toString(), this vector3 toString())
-			expect(string, is equal to(valueString))
-			(string, valueString) free()
+			value := "10.00, 20.00"
+			string := this vector3 toString()
+			expect(string, is equal to(value))
+			string free()
 			expect(FloatVector2D parse(value) x, is equal to(this vector3 x))
 			expect(FloatVector2D parse(value) y, is equal to(this vector3 y))
 		})
@@ -162,11 +162,6 @@ FloatVector2DTest: class extends Fixture {
 			almostZero := (0.1 + 0.1 + 0.1) - 0.3
 			empty = FloatVector2D new(almostZero, 0.1f)
 			expect(empty hasZeroArea, is true)
-		})
-		this add("toText", func {
-			text := FloatVector2D new(1.0f, 2.0f) toText() take()
-			expect(text, is equal to(t"1.00, 2.00"))
-			text free()
 		})
 		this add("limitLength", func {
 			vector := FloatVector2D new(1.f, 1.f) limitLength(0.75f)

--- a/test/geometry/FloatVector3DTest.ooc
+++ b/test/geometry/FloatVector3DTest.ooc
@@ -63,10 +63,10 @@ FloatVector3DTest: class extends Fixture {
 			expect(this vector0 z, is equal to(10.0f))
 		})
 		this add("casting", func {
-			value := t"10.00, 20.00, 30.00"
-			(valueString, string) := (value toString(), this vector3 toString())
-			expect(string, is equal to(valueString))
-			(string, valueString) free()
+			value := "10.00, 20.00, 30.00"
+			string := this vector3 toString()
+			expect(string, is equal to(value))
+			string free()
 			expect(FloatVector3D parse(value) x, is equal to(this vector3 x))
 			expect(FloatVector3D parse(value) y, is equal to(this vector3 y))
 			expect(FloatVector3D parse(value) z, is equal to(this vector3 z))
@@ -155,11 +155,6 @@ FloatVector3DTest: class extends Fixture {
 		this add("azimuth", func {
 			myvector := FloatVector3D new(1.0, 5.5, 0.1)
 			expect(myvector azimuth, is equal to(5.5f atan2(1.0f)) within(tolerance))
-		})
-		this add("toText", func {
-			text := FloatVector3D new(1.0f, 2.0f, 10.00f) toText() take()
-			expect(text, is equal to(t"1.00, 2.00, 10.00"))
-			text free()
 		})
 		this add("limitLength", func {
 			vector := FloatVector3D new(1.f, 1.f, 1.f) limitLength(0.75f)

--- a/test/geometry/IntBox2DTest.ooc
+++ b/test/geometry/IntBox2DTest.ooc
@@ -106,7 +106,7 @@ IntBox2DTest: class extends Fixture {
 			string free()
 		})
 		this add("parse", func {
-			box := IntBox2D parse(t"1, 2, 3, 4")
+			box := IntBox2D parse("1, 2, 3, 4")
 			expect(box left, is equal to(1))
 			expect(box top, is equal to(2))
 			expect(box right, is equal to(1 + 3))
@@ -159,11 +159,6 @@ IntBox2DTest: class extends Fixture {
 			expect(reducedBox right, is equal to(4))
 			expect(reducedBox bottom, is equal to(4))
 			expect(notReducedBox == box, is true)
-		})
-		this add("toText", func {
-			text := IntBox2D new (1, 2, 3, 4) toText() take()
-			expect(text, is equal to(t"1, 2, 3, 4"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/IntPoint2DTest.ooc
+++ b/test/geometry/IntPoint2DTest.ooc
@@ -47,10 +47,10 @@ IntPoint2DTest: class extends Fixture {
 			expect(result y, is equal to(this point0 x))
 		})
 		this add("casting", func {
-			value := t"10, 20"
-			(valueString, string) := (value toString(), this point3 toString())
-			expect(string, is equal to(valueString))
-			(string, valueString) free()
+			value := "10, 20"
+			string := this point3 toString()
+			expect(string, is equal to(value))
+			string free()
 			expect(IntPoint2D parse(value) x, is equal to(this point3 x))
 			expect(IntPoint2D parse(value) y, is equal to(this point3 y))
 		})
@@ -79,11 +79,6 @@ IntPoint2DTest: class extends Fixture {
 		this add("distance", func {
 			distance := this point0 distance(this point1)
 			expect(distance, is equal to(18.87f) within(0.01f))
-		})
-		this add("toText", func {
-			text := IntPoint2D new (22, -3) toText() take()
-			expect(text, is equal to(t"22, -3"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/IntPoint3DTest.ooc
+++ b/test/geometry/IntPoint3DTest.ooc
@@ -55,10 +55,10 @@ IntPoint3DTest: class extends Fixture {
 			expect(this point0 z, is equal to(8))
 		})
 		this add("casting", func {
-			value := t"10, 20, 0"
-			(valueString, string) := (value toString(), this point3 toString())
-			expect(string, is equal to(valueString))
-			(string, valueString) free()
+			value := "10, 20, 0"
+			string := this point3 toString()
+			expect(string, is equal to(value))
+			string free()
 			expect(IntPoint3D parse(value) x, is equal to(this point3 x))
 			expect(IntPoint3D parse(value) y, is equal to(this point3 y))
 			expect(IntPoint3D parse(value) z, is equal to(this point3 z))
@@ -88,11 +88,6 @@ IntPoint3DTest: class extends Fixture {
 			expect(result x, is equal to(22))
 			expect(result y, is equal to(10))
 			expect(result z, is equal to(8))
-		})
-		this add("toText", func {
-			text := IntPoint3D new (22, -3, 1) toText() take()
-			expect(text, is equal to(t"22, -3, 1"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/IntShell2DTest.ooc
+++ b/test/geometry/IntShell2DTest.ooc
@@ -89,16 +89,11 @@ IntShell2DTest: class extends Fixture {
 			expect(decreased bottom, is equal to(1))
 		})
 		this add("parse", func {
-			shell := IntShell2D parse(t"1, 2, 3, 4")
+			shell := IntShell2D parse("1, 2, 3, 4")
 			expect(shell left, is equal to(1))
 			expect(shell right, is equal to(2))
 			expect(shell top, is equal to(3))
 			expect(shell bottom, is equal to(4))
-		})
-		this add("toText", func {
-			text := IntShell2D new(1) toText() take()
-			expect(text, is equal to(t"1, 1, 1, 1"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/IntVector2DTest.ooc
+++ b/test/geometry/IntVector2DTest.ooc
@@ -55,10 +55,10 @@ IntVector2DTest: class extends Fixture {
 			expect(result y, is equal to(this vector0 x))
 		})
 		this add("casting", func {
-			value := t"10, 20"
-			(valueString, string) := (value toString(), this vector3 toString())
-			expect(string, is equal to(valueString))
-			(string, valueString) free()
+			value := "10, 20"
+			string := this vector3 toString()
+			expect(string, is equal to(value))
+			string free()
 			expect(IntVector2D parse(value) x, is equal to(this vector3 x))
 			expect(IntVector2D parse(value) y, is equal to(this vector3 y))
 		})
@@ -98,11 +98,6 @@ IntVector2DTest: class extends Fixture {
 			expect(empty hasZeroArea, is true)
 			expect(square hasZeroArea, is false)
 			expect(empty area, is equal to(0))
-		})
-		this add("toText", func {
-			text := IntVector2D new(10, 20) toText() take()
-			expect(text, is equal to(t"10, 20"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/IntVector3DTest.ooc
+++ b/test/geometry/IntVector3DTest.ooc
@@ -55,10 +55,10 @@ IntVector3DTest: class extends Fixture {
 			expect(this vector0 z, is equal to(8))
 		})
 		this add("casting", func {
-			value := t"10, 20, 0"
-			(valueString, string) := (value toString(), this vector3 toString())
-			expect(string, is equal to(valueString))
-			(string, valueString) free()
+			value := "10, 20, 0"
+			string := this vector3 toString()
+			expect(string, is equal to(value))
+			string free()
 			expect(IntVector3D parse(value) x, is equal to(this vector3 x))
 			expect(IntVector3D parse(value) y, is equal to(this vector3 y))
 			expect(IntVector3D parse(value) z, is equal to(this vector3 z))
@@ -94,11 +94,6 @@ IntVector3DTest: class extends Fixture {
 			expect(this vector1 hasZeroVolume, is false)
 			expect(this vector1 volume, is equal to(-1248))
 			expect(empty volume, is equal to(0))
-		})
-		this add("toText", func {
-			text := IntVector3D new(10, 20, 30) toText() take()
-			expect(text, is equal to(t"10, 20, 30"))
-			text free()
 		})
 	}
 }

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -396,11 +396,6 @@ QuaternionTest: class extends Fixture {
 			expect(y, is equal to(quaternion rotationY) within(tolerance))
 			expect(z, is equal to(quaternion rotationZ) within(tolerance))
 		})
-		this add("toText", func {
-			text := Quaternion new(1.0f, 0.0f, 1.0f, 0.0f) toText() take()
-			expect(text, is equal to(t"Real: 1.00 Imaginary: 0.00 1.00 0.00"))
-			text free()
-		})
 	}
 	free: override func {
 		this quaternionList free()

--- a/test/system/TextTest.ooc
+++ b/test/system/TextTest.ooc
@@ -240,17 +240,6 @@ TextTest: class extends Fixture {
 			text = t"%s %s %i %i" format("test", "number", 0, 1)
 			expect(text == t"test number 0 1")
 		})
-		this add("implicit toText", func {
-			one := t"123" + 456 + 7.89f
-			expect(one == t"1234567.89")
-			two := (Text new("12") + 3.45f + 6.78 + 9U) take()
-			expect(two == t"123.456.789")
-			three := t"1" + 2 + t"3" + 4 + 5.67f
-			expect(three == t"12345.67")
-			four := two + 0
-			expect(four == two + t"0")
-			two free()
-		})
 		this add("beginsWith, endsWith", func {
 			text := t"abcdefg"
 			expect(text beginsWith(t"abc"), is true)


### PR DESCRIPTION
- Removed `toText` and changed `parse` to accept `String` instead.
- Also removed not needed `toText` methods from `Numbers.ooc` and `types.ooc`.
- Moved implicit conversions from `Text` to `String`.

Confirmed 0 memory leaks.