### PR TITLE
Locking literals from being freed until global termination

### DIFF
--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -17,7 +17,6 @@ String: class {
 	_buffer: CharBuffer
 	size ::= this _buffer size
 	_locked := false // Only global termination may unlock and free literals
-	_unlock: func { this _locked = false }
 	init: func ~withBuffer (=_buffer)
 	init: func ~withCStr (s: CString) { init(s, s length()) }
 	init: func ~withCStrAndLength (s: CString, length: Int) { this _buffer = CharBuffer new(s, length) }
@@ -29,6 +28,7 @@ String: class {
 			super()
 		}
 	}
+	_unlock: func { this _locked = false }
 	equals: final func (other: This) -> Bool {
 		result := false
 		if (this == null)

--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -16,15 +16,18 @@ String: class {
 	// Avoid direct buffer access, as it breaks immutability.
 	_buffer: CharBuffer
 	size ::= this _buffer size
-
+	_locked := false // Only global termination may unlock and free literals
+	_unlock: func { this _locked = false }
 	init: func ~withBuffer (=_buffer)
 	init: func ~withCStr (s: CString) { init(s, s length()) }
 	init: func ~withCStrAndLength (s: CString, length: Int) { this _buffer = CharBuffer new(s, length) }
 	free: override func {
-		if (this _buffer mallocAddr == 0)
-			string_literal_free(this)
-		this _buffer free()
-		super()
+		if (!this _locked) {
+			if (this _buffer mallocAddr == 0)
+				string_literal_free(this)
+			this _buffer free()
+			super()
+		}
 	}
 	equals: final func (other: This) -> Bool {
 		result := false
@@ -202,6 +205,7 @@ operator << (left, right: String) -> String {
 }
 makeStringLiteral: func (str: CString, strLen: Int) -> String {
 	result := String new(CharBuffer new(str, strLen, true))
+	result _locked = true
 	string_literal_new(result)
 	result
 }

--- a/source/system/string/string_literal.c
+++ b/source/system/string/string_literal.c
@@ -59,8 +59,10 @@ void string_literal_free(void* ptr) {
 void string_literal_free_all() {
 	if (_literals) {
 		for (size_t i=0; i<_literalsCount; ++i)
-			if (_literals[i])
+			if (_literals[i]) {
+				String__String__unlock(_literals[i]);
 				String__String_free(_literals[i]);
+			}
 		free(_literals);
 		_literalsCapacity = 0;
 		_literalsCount = 0;

--- a/test/system/StringTest.ooc
+++ b/test/system/StringTest.ooc
@@ -11,6 +11,22 @@ use unit
 StringTest: class extends Fixture {
 	init: func {
 		super("String")
+		this add("literal", func {
+			// The & operand tries to free the literals but if the lock works then they should resist the attempt
+			result: String
+			for (i in 1 .. 100) {
+				result = "ab" & "cd"
+				expect(result, is equal to("abcd"))
+				result free()
+			}
+			ab := "ab"
+			cd := "cd"
+			for (i in 1 .. 100) {
+				result = ab & cd
+				expect(result, is equal to("abcd"))
+				result free()
+			}
+		})
 		this add("length", func {
 			expect("" length(), is equal to(0))
 			expect("y" length(), is equal to(1))


### PR DESCRIPTION
Alternative solution to https://github.com/magic-lang/ooc-kean/pull/1776

Fixes #1764