### PR TITLE
Now locking with correct usage when reading/writing to GraphicBufferYuv420Semiplanar

### DIFF
--- a/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
+++ b/source/draw/gpu/opengl/GraphicBufferYuv420Semiplanar.ooc
@@ -50,6 +50,12 @@ GraphicBufferYuv420Semiplanar: class extends RasterYuv420Semiplanar {
 		this _rgba referenceCount increase()
 		this _rgba
 	}
+	copy: override func -> RasterYuv420Semiplanar {
+		this buffer lock(GraphicBufferUsage ReadOften)
+		result := super()
+		this buffer unlock()
+		result
+	}
 	_bin := static RecycleBin<EGLRgba> new(100, |image| image referenceCount decrease())
 	free: static func ~all { This _bin clear() }
 }

--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -12,7 +12,7 @@ use draw
 use draw-gpu
 use collections
 use concurrent
-import OpenGLPacked, OpenGLMonochrome, OpenGLRgb, OpenGLRgba, OpenGLUv, OpenGLMesh, OpenGLPromise
+import OpenGLPacked, OpenGLMonochrome, OpenGLRgb, OpenGLRgba, OpenGLUv, OpenGLMesh, OpenGLPromise, GraphicBufferYuv420Semiplanar, GraphicBuffer
 import OpenGLMap
 import backend/[GLContext, GLRenderer]
 
@@ -198,5 +198,13 @@ OpenGLContext: class extends GpuContext {
 	getYuvToRgba: override func -> Map { this _yuvSemiplanarToRgba }
 	getRgbaToY: override func -> Map { this _rgbaToYuva }
 	getRgbaToUv: override func -> Map { this _rgbaToUvaa }
+	toRaster: override func ~target (source: GpuImage, target: RasterImage) -> Promise {
+		if (target instanceOf(GraphicBufferYuv420Semiplanar))
+			target as GraphicBufferYuv420Semiplanar buffer lock(GraphicBufferUsage WriteOften)
+		result := super(source, target)
+		if (target instanceOf(GraphicBufferYuv420Semiplanar))
+			target as GraphicBufferYuv420Semiplanar buffer unlock()
+		result
+	}
 }
 }


### PR DESCRIPTION
Fixes flickering bug when using `toRaster` with a GraphicBufferYuv420Semiplanar as target with unoptimized OpenGLContext.
@erikhagglund peer review