### PR TITLE
Remove multithread context code

### DIFF
--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -84,8 +84,6 @@ OpenGLContext: class extends GpuContext {
 		(this _pointsShader, this _renderer, this _recycleBin, this _backend) free()
 		super()
 	}
-	getMaxContexts: func -> Int { 1 }
-	getCurrentIndex: func -> Int { 0 }
 	drawQuad: func { this _renderer drawQuad() }
 	drawLines: func (pointList: VectorList<FloatPoint2D>, projection: FloatTransform3D, pen: Pen) {
 		positions := pointList pointer as Float*

--- a/source/draw/gpu/opengl/OpenGLMap.ooc
+++ b/source/draw/gpu/opengl/OpenGLMap.ooc
@@ -18,15 +18,11 @@ version(!gpuOff) {
 OpenGLMap: class extends Map {
 	_vertexSource: String
 	_fragmentSource: String
-	_program: GLShaderProgram[]
+	_program: GLShaderProgram = null
 	_currentProgram: GLShaderProgram { get {
-		index := this _context getCurrentIndex()
-		result := this _program[index]
-		if (result == null) {
-			result = this _context _backend createShaderProgram(this _vertexSource, this _fragmentSource)
-			this _program[index] = result
-		}
-		result
+		if (this _program == null)
+			this _program = this _context _backend createShaderProgram(this _vertexSource, this _fragmentSource)
+		this _program
 	}}
 	_context: OpenGLContext
 	init: func (vertexSource: String, fragmentSource: String, context: OpenGLContext) {
@@ -34,17 +30,13 @@ OpenGLMap: class extends Map {
 		this _vertexSource = vertexSource
 		this _fragmentSource = fragmentSource
 		this _context = context
-		this _program = GLShaderProgram[context getMaxContexts()] new()
 		if (vertexSource == null || fragmentSource == null)
 			Debug error("Vertex or fragment shader source not set")
 	}
 	init: func ~defaultVertex (fragmentSource: String, context: OpenGLContext) { this init(slurp("shaders/default.vert"), fragmentSource, context) }
 	free: override func {
-		for (i in 0 .. this _context getMaxContexts()) {
-			if (this _program[i] != null)
-				this _program[i] free()
-		}
-		this _program free()
+		if (this _program != null)
+			this _program free()
 		super()
 	}
 	useProgram: override func (forbiddenInput: Pointer, positionTransform, textureTransform: FloatTransform3D) {

--- a/source/draw/gpu/opengl/OpenGLMap.ooc
+++ b/source/draw/gpu/opengl/OpenGLMap.ooc
@@ -19,31 +19,26 @@ OpenGLMap: class extends Map {
 	_vertexSource: String
 	_fragmentSource: String
 	_program: GLShaderProgram = null
-	_currentProgram: GLShaderProgram { get {
-		if (this _program == null)
-			this _program = this _context _backend createShaderProgram(this _vertexSource, this _fragmentSource)
-		this _program
-	}}
 	_context: OpenGLContext
 	init: func (vertexSource: String, fragmentSource: String, context: OpenGLContext) {
 		super()
 		this _vertexSource = vertexSource
 		this _fragmentSource = fragmentSource
 		this _context = context
+		this _program = this _context _backend createShaderProgram(this _vertexSource, this _fragmentSource)
 		if (vertexSource == null || fragmentSource == null)
 			Debug error("Vertex or fragment shader source not set")
 	}
 	init: func ~defaultVertex (fragmentSource: String, context: OpenGLContext) { this init(slurp("shaders/default.vert"), fragmentSource, context) }
 	free: override func {
-		if (this _program != null)
-			this _program free()
+		this _program free()
 		super()
 	}
 	useProgram: override func (forbiddenInput: Pointer, positionTransform, textureTransform: FloatTransform3D) {
-		this _currentProgram useProgram()
+		this _program useProgram()
 		textureCount := 0
 		action := func (key: String, value: Object) {
-			program := this _currentProgram
+			program := this _program
 			if (value instanceOf(Cell)) {
 				cell := value as Cell
 				match (cell T) {


### PR DESCRIPTION
Since we don't support use of `OpenGLContext` from different threads we might as well remove the code trying to achieve this.

@davidpiuva peer review