### PR TITLE
Updated VectorList sort() to match improved sort

### DIFF
--- a/source/concurrent/SynchronizedList.ooc
+++ b/source/concurrent/SynchronizedList.ooc
@@ -72,9 +72,9 @@ SynchronizedList: class <T> extends List<T> {
 		this _mutex unlock()
 		result
 	}
-	sort: override func (greaterThan: Func (T, T) -> Bool) {
+	sort: override func (isLess: Func (T, T) -> Bool) {
 		this _mutex lock()
-		this _backend sort(greaterThan)
+		this _backend sort(isLess)
 		this _mutex unlock()
 	}
 	copy: override func -> This<T> {

--- a/source/system/structs/List.ooc
+++ b/source/system/structs/List.ooc
@@ -19,7 +19,7 @@ List: abstract class <T> {
 	clear: abstract func
 	reverse: abstract func -> This<T>
 	search: abstract func (matches: Func (T) -> Bool) -> Int
-	sort: abstract func (greaterThan: Func (T, T) -> Bool)
+	sort: abstract func (isLess: Func (T, T) -> Bool)
 	copy: abstract func -> This<T>
 	apply: abstract func (function: Func(T))
 	modify: abstract func (function: Func(T) -> T)

--- a/source/system/structs/VectorList.ooc
+++ b/source/system/structs/VectorList.ooc
@@ -123,7 +123,7 @@ VectorList: class <T> extends List<T>{
 		while (!inOrder) {
 			inOrder = true
 			for (i in 0 .. this count - 1)
-				if (!isLess(this[i], this[i + 1])) {
+				if (isLess(this[i + 1], this[i])) {
 					inOrder = false
 					tmp := this[i]
 					this[i] = this[i + 1]

--- a/source/system/structs/VectorList.ooc
+++ b/source/system/structs/VectorList.ooc
@@ -118,12 +118,12 @@ VectorList: class <T> extends List<T>{
 			}
 		result
 	}
-	sort: override func (greaterThan: Func (T, T) -> Bool) {
+	sort: override func (isLess: Func (T, T) -> Bool) {
 		inOrder := false
 		while (!inOrder) {
 			inOrder = true
 			for (i in 0 .. this count - 1)
-				if (greaterThan(this[i], this[i + 1])) {
+				if (!isLess(this[i], this[i + 1])) {
 					inOrder = false
 					tmp := this[i]
 					this[i] = this[i + 1]

--- a/test/concurrent/SynchronizedListTest.ooc
+++ b/test/concurrent/SynchronizedListTest.ooc
@@ -97,7 +97,7 @@ SynchronizedListTest: class extends Fixture {
 			list add(Int minimumValue) . add(Int maximumValue) . add(0) . add(-10) . add(10)
 			list sort(|first, second| first < second)
 			for (value in 0 .. list count - 1)
-				expect(list[value], is greater than(list[value + 1]))
+				expect(list[value], is less than(list[value + 1]))
 			list free()
 		})
 		this add("single thread - copy", func {

--- a/test/system/VectorListTest.ooc
+++ b/test/system/VectorListTest.ooc
@@ -200,7 +200,7 @@ VectorListTest: class extends Fixture {
 		})
 		this add("VectorList sort", func {
 			list := VectorList<Int> new()
-			list add(8) . add(16) . add(32)
+			list add(32) . add(16) . add(8)
 
 			sortedList := list copy()
 			sortedList sort(|v1, v2| v1 < v2)


### PR DESCRIPTION
`lowerBound`, `upperBound` and `search` all take an `isLess` comparator, whereas the `sort` method takes a `greaterThan` comparator. The former, I believe, is a lot more common and so we should do it here as well.