### PR TITLE
Standardized Point and Vector conversions

### DIFF
--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -6,10 +6,11 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-use math
-import FloatVector2D
 import IntPoint2D
+import IntVector2D
+import FloatVector2D
 use base
+use math
 
 FloatPoint2D: cover {
 	x, y: Float
@@ -40,6 +41,7 @@ FloatPoint2D: cover {
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y)) }
 	polar: static func (radius, azimuth: Float) -> This { This new(radius * cos(azimuth), radius * sin(azimuth)) }
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x as Int, this y as Int) }
+	toIntVector2D: func -> IntVector2D { IntVector2D new(this x as Int, this y as Int) }
 	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x, this y) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }
 

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -6,11 +6,12 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-use math
-import FloatPoint2D
 import IntPoint3D
+import IntVector3D
+import FloatPoint2D
 import FloatVector3D
 use base
+use math
 
 FloatPoint3D: cover {
 	x, y, z: Float
@@ -46,6 +47,7 @@ FloatPoint3D: cover {
 	clamp: func ~point (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
 	clamp: func ~float (floor, ceiling: Float) -> This { This new(this x clamp(floor, ceiling), this y clamp(floor, ceiling), this z clamp(floor, ceiling)) }
 	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x as Int, this y as Int, this z as Int) }
+	toIntVector3D: func -> IntVector3D { IntVector3D new(this x as Int, this y as Int, this z as Int) }
 	toFloatVector3D: func -> FloatVector3D { FloatVector3D new(this x, this y, this z) }
 	toString: func -> String { "%.8f" formatFloat(this x) >> ", " & "%.8f" formatFloat(this y) >> ", " & "%.8f" formatFloat(this z) }
 

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -6,10 +6,11 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-use math
-import FloatPoint2D
+import IntPoint2D
 import IntVector2D
+import FloatPoint2D
 use base
+use math
 
 FloatVector2D: cover {
 	x, y: Float
@@ -43,6 +44,7 @@ FloatVector2D: cover {
 	maximum: func ~Float (floor: Float) -> This { this maximum(This new(floor)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y)) }
 	limitLength: func (maximum: Float) -> This { this norm > maximum ? this normalized * maximum : this }
+	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x as Int, this y as Int) }
 	toIntVector2D: func -> IntVector2D { IntVector2D new(this x as Int, this y as Int) }
 	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x, this y) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -6,11 +6,11 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-use math
-import FloatPoint3D
 import IntPoint3D
 import IntVector3D
+import FloatPoint3D
 use base
+use math
 
 FloatVector3D: cover {
 	x, y, z: Float
@@ -47,6 +47,7 @@ FloatVector3D: cover {
 	maximum: func (floor: This) -> This { This new(this x maximum(floor x), this y maximum(floor y), this z maximum(floor z)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
 	limitLength: func (maximum: Float) -> This { this norm > maximum ? this normalized * maximum : this }
+	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x as Int, this y as Int, this z as Int) }
 	toIntVector3D: func -> IntVector3D { IntVector3D new(this x as Int, this y as Int, this z as Int) }
 	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x, this y, this z) }
 	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }

--- a/source/geometry/IntPoint2D.ooc
+++ b/source/geometry/IntPoint2D.ooc
@@ -8,6 +8,7 @@
 
 import IntVector2D
 import FloatPoint2D
+import FloatVector2D
 use base
 use math
 
@@ -22,7 +23,9 @@ IntPoint2D: cover {
 	minimum: func (ceiling: This) -> This { This new(this x minimum(ceiling x), this y minimum(ceiling y)) }
 	maximum: func (floor: This) -> This { This new(this x maximum(floor x), this y maximum(floor y)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y)) }
+	toIntVector2D: func -> IntVector2D { IntVector2D new(this x, this y) }
 	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x as Float, this y as Float) }
+	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x as Float, this y as Float) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }
 
 	operator - -> This { This new(-this x, -this y) }

--- a/source/geometry/IntPoint3D.ooc
+++ b/source/geometry/IntPoint3D.ooc
@@ -6,9 +6,10 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-import IntVector3D
 import IntPoint2D
+import IntVector3D
 import FloatPoint3D
+import FloatVector3D
 use base
 
 IntPoint3D: cover {
@@ -21,7 +22,9 @@ IntPoint3D: cover {
 	minimum: func (ceiling: This) -> This { This new(this x minimum(ceiling x), this y minimum(ceiling y), this z minimum(ceiling z)) }
 	maximum: func (floor: This) -> This { This new(this x maximum(floor x), this y maximum(floor y), this z maximum(floor z)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
+	toIntVector3D: func -> IntVector3D { IntVector3D new(this x, this y, this z) }
 	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x as Float, this y as Float, this z as Float) }
+	toFloatVector3D: func -> FloatVector3D { FloatVector3D new(this x as Float, this y as Float, this z as Float) }
 	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
 
 	operator - -> This { This new(-this x, -this y, -this z) }

--- a/source/geometry/IntVector2D.ooc
+++ b/source/geometry/IntVector2D.ooc
@@ -7,6 +7,7 @@
  */
 
 import IntPoint2D
+import FloatPoint2D
 import FloatVector2D
 use base
 
@@ -30,8 +31,9 @@ IntVector2D: cover {
 	maximum: func ~Int (floor: Int) -> This { this maximum(This new(floor)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y)) }
 	polar: static func (radius, azimuth: Float) -> This { This new((radius * cos(azimuth)) as Int, (radius * sin(azimuth)) as Int) }
-	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x as Float, this y as Float) }
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x, this y) }
+	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x as Float, this y as Float) }
+	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x as Float, this y as Float) }
 	toString: func -> String { (this x toString() >> ", ") & this y toString() }
 
 	operator - -> This { This new(-this x, -this y) }

--- a/source/geometry/IntVector3D.ooc
+++ b/source/geometry/IntVector3D.ooc
@@ -7,6 +7,7 @@
  */
 
 import IntPoint3D
+import FloatPoint3D
 import FloatVector3D
 use base
 
@@ -22,6 +23,8 @@ IntVector3D: cover {
 	minimum: func (ceiling: This) -> This { This new(this x minimum(ceiling x), this y minimum(ceiling y), this z minimum(ceiling z)) }
 	maximum: func (floor: This) -> This { This new(this x maximum(floor x), this y maximum(floor y), this z maximum(floor z)) }
 	clamp: func (floor, ceiling: This) -> This { This new(this x clamp(floor x, ceiling x), this y clamp(floor y, ceiling y), this z clamp(floor z, ceiling z)) }
+	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x, this y, this z) }
+	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x as Float, this y as Float, this z as Float) }
 	toFloatVector3D: func -> FloatVector3D { FloatVector3D new(this x as Float, this y as Float, this z as Float) }
 	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
 


### PR DESCRIPTION
Fixes #1799 

I would have preferred to use overloads of the `as` operator more, but this is how we're doing it and changing it everywhere isn't feasible.