### PR TITLE
remove access to private data in ReferenceCounter

### DIFF
--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -99,7 +99,7 @@ _RecyclableByteBuffer: class extends ByteBuffer {
 				version(debugByteBuffer) { Debug print("ByteBuffer bin full; freeing one ByteBuffer") }
 				bin remove(0) _forceFree()
 			}
-			this referenceCount _count = 0
+			this referenceCount reset()
 			bin add(this)
 			This _lock unlock()
 		}
@@ -118,7 +118,7 @@ _RecyclableByteBuffer: class extends ByteBuffer {
 		for (i in 0 .. bin count)
 			if ((bin[i] size) == size) {
 				buffer = bin remove(i)
-				buffer referenceCount _count = 0
+				buffer referenceCount reset()
 				break
 			}
 		This _lock unlock()

--- a/source/base/ReferenceCounter.ooc
+++ b/source/base/ReferenceCounter.ooc
@@ -22,6 +22,7 @@ ReferenceCounter: class {
 			}
 		}
 	}
+	count ::= this _count
 	init: func (target: Object, mutexType := MutexType Safe) {
 		this _target = target
 		this _lock = Mutex new(mutexType)
@@ -50,5 +51,6 @@ ReferenceCounter: class {
 	}
 	increase: func { this update(1) }
 	decrease: func { this update(-1) }
+	reset: func { this _count = 0 }
 	toString: func -> String { "Object ID: " << this _target as Pointer toString() >> " Count: " & this _count toString() }
 }

--- a/test/base/ByteBufferTest.ooc
+++ b/test/base/ByteBufferTest.ooc
@@ -53,9 +53,9 @@ ByteBufferTest: class extends Fixture {
 			yuv := ByteBuffer new(30000)
 			y := yuv slice(0, 20000)
 			uv := yuv slice(20000, 10000)
-			expect(yuv referenceCount _count, is equal to(2))
+			expect(yuv referenceCount count, is equal to(2))
 			y referenceCount decrease()
-			expect(yuv referenceCount _count, is equal to(1))
+			expect(yuv referenceCount count, is equal to(1))
 			uv referenceCount decrease()
 		})
 		this add("memset", func {


### PR DESCRIPTION
No new functionality, I just wanted to update it so the private data stays private (easier to replace the implementation later).
@marcusnaslund 