### PR TITLE
Added decimals argument for floating point toString()

### DIFF
--- a/source/geometry/FloatBox2D.ooc
+++ b/source/geometry/FloatBox2D.ooc
@@ -122,7 +122,7 @@ FloatBox2D: cover {
 		newSize := FloatVector2D mix(this size, other size, weight)
 		This createAround(newCenter, newSize)
 	}
-	toString: func -> String { (this leftTop toString() >> ", ") & this size toString() }
+	toString: func (decimals := 2) -> String { (this leftTop toString(decimals) >> ", ") & this size toString(decimals) }
 	toIntBox2D: func -> IntBox2D { IntBox2D new(this left, this top, this width, this height) }
 
 	operator + (other: This) -> This {

--- a/source/geometry/FloatConvexHull2D.ooc
+++ b/source/geometry/FloatConvexHull2D.ooc
@@ -126,10 +126,10 @@ FloatConvexHull2D: class {
 			(outsideLeft, outsideRight) free()
 		}
 	}
-	toString: func -> String {
+	toString: func (decimals := 2) -> String {
 		result := ""
 		for (i in 0 .. this count)
-			result = result >> "(" & this _points[i] toString() >> ") "
+			result = result >> "(" & this _points[i] toString(decimals) >> ") "
 		result
 	}
 	_pointsLinePseudoDistance: static func (leftPoint, rightPoint, queryPoint: FloatPoint2D) -> Float {

--- a/source/geometry/FloatEuclidTransform.ooc
+++ b/source/geometry/FloatEuclidTransform.ooc
@@ -30,8 +30,8 @@ FloatEuclidTransform: cover {
 		scaling := ((transform a * transform a + transform b * transform b) sqrt() + (transform d * transform d + transform e * transform e) sqrt()) / 2.0f
 		this init(FloatVector3D new(transform g, transform h, 0.0f), FloatRotation3D createRotationZ(rotationZ), scaling)
 	}
-	toString: func -> String {
-		"Translation: " << this translation toString() >> " Rotation: " & this rotation toString() >> " Scaling: " & this scaling toString()
+	toString: func (decimals := 6) -> String {
+		"Translation: " << this translation toString(decimals) >> " Rotation: " & this rotation toString(decimals) >> " Scaling: " & this scaling toString(decimals)
 	}
 
 	operator * (other: This) -> This { This new(this translation + other translation, this rotation * other rotation, this scaling * other scaling) }

--- a/source/geometry/FloatEuclidTransformVectorList.ooc
+++ b/source/geometry/FloatEuclidTransformVectorList.ooc
@@ -100,10 +100,10 @@ FloatEuclidTransformVectorList: class extends VectorList<FloatEuclidTransform> {
 		}
 		result
 	}
-	toString: func (separator := "\n") -> String {
-		result := this _count > 0 ? this[0] toString() : ""
+	toString: func (separator := "\n", decimals := 2) -> String {
+		result := this _count > 0 ? this[0] toString(decimals) : ""
 		for (i in 1 .. this _count)
-			result = (result >> separator) & this[i] toString()
+			result = (result >> separator) & this[i] toString(decimals)
 		result
 	}
 

--- a/source/geometry/FloatPoint2D.ooc
+++ b/source/geometry/FloatPoint2D.ooc
@@ -43,7 +43,7 @@ FloatPoint2D: cover {
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x as Int, this y as Int) }
 	toIntVector2D: func -> IntVector2D { IntVector2D new(this x as Int, this y as Int) }
 	toFloatVector2D: func -> FloatVector2D { FloatVector2D new(this x, this y) }
-	toString: func -> String { (this x toString() >> ", ") & this y toString() }
+	toString: func (decimals := 2) -> String { (this x toString(decimals) >> ", ") & this y toString(decimals) }
 
 	operator - -> This { This new(-this x, -this y) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y) }

--- a/source/geometry/FloatPoint2DVectorList.ooc
+++ b/source/geometry/FloatPoint2DVectorList.ooc
@@ -77,10 +77,10 @@ FloatPoint2DVectorList: class extends VectorList<FloatPoint2D> {
 	sortByX: func {
 		This _quicksortX(this _vector _backend as FloatPoint2D*, 0, this count - 1)
 	}
-	toString: func -> String {
+	toString: func (decimals := 2) -> String {
 		result := ""
 		for (i in 0 .. this _count)
-			result = result >> this[i] toString() >> "\n"
+			result = result >> this[i] toString(decimals) >> "\n"
 		result
 	}
 	resampleLinear: func (start, end, interval: Float) -> This {

--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -49,7 +49,7 @@ FloatPoint3D: cover {
 	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x as Int, this y as Int, this z as Int) }
 	toIntVector3D: func -> IntVector3D { IntVector3D new(this x as Int, this y as Int, this z as Int) }
 	toFloatVector3D: func -> FloatVector3D { FloatVector3D new(this x, this y, this z) }
-	toString: func -> String { "%.8f" formatFloat(this x) >> ", " & "%.8f" formatFloat(this y) >> ", " & "%.8f" formatFloat(this z) }
+	toString: func (decimals := 8) -> String { this x toString(decimals) >> ", " & this y toString(decimals) >> ", " & this z toString(decimals) }
 
 	operator - -> This { This new(-this x, -this y, -this z) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y, this z + other z) }

--- a/source/geometry/FloatRotation3D.ooc
+++ b/source/geometry/FloatRotation3D.ooc
@@ -25,7 +25,7 @@ FloatRotation3D: cover {
 		This new(this _quaternion sphericalLinearInterpolation(other _quaternion, factor))
 	}
 	angle: func (other: This) -> Float { this _quaternion angle(other _quaternion) }
-	toString: func -> String { this _quaternion toString() }
+	toString: func (decimals := 6) -> String { this _quaternion toString(decimals) }
 
 	operator * (other: This) -> This { This new(this _quaternion * other _quaternion) }
 	operator == (other: This) -> Bool { this _quaternion == other _quaternion }

--- a/source/geometry/FloatShell2D.ooc
+++ b/source/geometry/FloatShell2D.ooc
@@ -39,7 +39,7 @@ FloatShell2D: cover {
 	minimum: func (other: This) -> This {
 		This new(this left minimum(other left), this right minimum(other right), this top minimum(other top), this bottom minimum(other bottom))
 	}
-	toString: func -> String { (this left toString() >> ", ") & (this right toString() >> ", ") & (this top toString() >> ", ") & (this bottom toString() >> ", ") }
+	toString: func (decimals := 2) -> String { (this left toString(decimals) >> ", ") & (this right toString(decimals) >> ", ") & (this top toString(decimals) >> ", ") & (this bottom toString(decimals) >> ", ") }
 
 	operator + (other: This) -> This { This new(this left + other left, this right + other right, this top + other top, this bottom + other bottom) }
 	operator - (other: This) -> This { This new(this left - other left, this right - other right, this top - other top, this bottom - other bottom) }

--- a/source/geometry/FloatVector2D.ooc
+++ b/source/geometry/FloatVector2D.ooc
@@ -47,7 +47,7 @@ FloatVector2D: cover {
 	toIntPoint2D: func -> IntPoint2D { IntPoint2D new(this x as Int, this y as Int) }
 	toIntVector2D: func -> IntVector2D { IntVector2D new(this x as Int, this y as Int) }
 	toFloatPoint2D: func -> FloatPoint2D { FloatPoint2D new(this x, this y) }
-	toString: func -> String { (this x toString() >> ", ") & this y toString() }
+	toString: func (decimals := 2) -> String { (this x toString(decimals) >> ", ") & this y toString(decimals) }
 
 	operator - -> This { This new(-this x, -this y) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y) }

--- a/source/geometry/FloatVector3D.ooc
+++ b/source/geometry/FloatVector3D.ooc
@@ -50,7 +50,7 @@ FloatVector3D: cover {
 	toIntPoint3D: func -> IntPoint3D { IntPoint3D new(this x as Int, this y as Int, this z as Int) }
 	toIntVector3D: func -> IntVector3D { IntVector3D new(this x as Int, this y as Int, this z as Int) }
 	toFloatPoint3D: func -> FloatPoint3D { FloatPoint3D new(this x, this y, this z) }
-	toString: func -> String { (this x toString() >> ", ") & (this y toString() >> ", ") & this z toString() }
+	toString: func (decimals := 2) -> String { (this x toString(decimals) >> ", ") & (this y toString(decimals) >> ", ") & this z toString(decimals) }
 
 	operator - -> This { This new(-this x, -this y, -this z) }
 	operator + (other: This) -> This { This new(this x + other x, this y + other y, this z + other z) }

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -169,9 +169,8 @@ Quaternion: cover {
 		(axis, angle) := this toAxisAngle()
 		FloatVector3D new(axis x, axis y, axis z) * angle
 	}
-	toString: func -> String {
-		"Real: " << "%8f" formatFloat(this real) >>
-		" Imaginary: " & "%8f" formatFloat(this imaginary x) >> " " & "%8f" formatFloat(this imaginary y) >> " " & "%8f" formatFloat(this imaginary z)
+	toString: func (decimals := 6) -> String {
+		"Real: " << this real toString(decimals) >> " Imaginary: " & this imaginary x toString(decimals) >> " " & this imaginary y toString(decimals) >> " " & this imaginary z toString(decimals)
 	}
 
 	operator * (other: This) -> This {

--- a/source/math/FloatComplex.ooc
+++ b/source/math/FloatComplex.ooc
@@ -16,8 +16,8 @@ FloatComplex: cover {
 
 	init: func@ (=real, =imaginary)
 	init: func@ ~default { this init(0.0f, 0.0f) }
-	toString: func -> String {
-		this real toString() >> (this imaginary > 0 ? " +" : " ") & this imaginary toString() >> "i"
+	toString: func (decimals := 2) -> String {
+		this real toString(decimals) >> (this imaginary > 0 ? " +" : " ") & this imaginary toString(decimals) >> "i"
 	}
 	exponential: func -> This {
 		(this real) exp() * This new((this imaginary) cos(), (this imaginary) sin())

--- a/source/math/FloatComplexVectorList.ooc
+++ b/source/math/FloatComplexVectorList.ooc
@@ -69,10 +69,10 @@ FloatComplexVectorList: class extends VectorList<FloatComplex> {
 			thisPointer[i] imaginary = thisPointer[i] imaginary + otherPointer[i] imaginary
 		}
 	}
-	toString: func (separator := "\n") -> String {
-		result := this _count > 0 ? this[0] toString() : ""
+	toString: func (separator := "\n", decimals := 2) -> String {
+		result := this _count > 0 ? this[0] toString(decimals) : ""
 		for (i in 1 .. this _count)
-			result = (result >> separator) & this[i] toString()
+			result = (result >> separator) & this[i] toString(decimals)
 		result
 	}
 

--- a/source/math/FloatMatrix.ooc
+++ b/source/math/FloatMatrix.ooc
@@ -125,13 +125,13 @@ FloatMatrix: cover {
 				thisElements[i + second * t width] = buffer
 			}
 	}
-	toString: func -> String {
+	toString: func (decimals := 2) -> String {
 		t := this take()
 		result: String = ""
 		for (y in 0 .. t height) {
 			for (x in 0 .. t width - 1)
-				result = result & t[x, y] toString() >> ", "
-			result = result & t[t width - 1, y] toString()
+				result = result & t[x, y] toString(decimals) >> ", "
+			result = result & t[t width - 1, y] toString(decimals)
 			result = result >> "; "
 		}
 		this free(Owner Receiver)

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -97,10 +97,10 @@ FloatVectorList: class extends VectorList<Float> {
 		for (i in 0 .. minimumCount)
 			this[i] = this[i] + other[i]
 	}
-	toString: func (separator := "\n") -> String {
-		result := this _count > 0 ? this[0] toString() : ""
+	toString: func (separator := "\n", decimals := 2) -> String {
+		result := this _count > 0 ? this[0] toString(decimals) : ""
 		for (i in 1 .. this _count)
-			result = (result >> separator) & this[i] toString()
+			result = (result >> separator) & this[i] toString(decimals)
 		result
 	}
 	divideByMaxValue: func -> This {

--- a/source/system/Numbers.ooc
+++ b/source/system/Numbers.ooc
@@ -99,8 +99,8 @@ DBL_EPSILON: extern static Double
 
 LDouble: cover from long double {
 	isNumber ::= this == this
-	toString: func -> String {
-		"%.2f" formatDouble(this)
+	toString: func (decimals := 2) -> String {
+		("%." & decimals toString() & "f") formatDouble(this)
 	}
 	toText: func -> Text {
 		string := this toString()
@@ -115,15 +115,15 @@ LDouble: cover from long double {
 
 Double: cover from double extends LDouble {
 	isNumber ::= this == this
-	toString: func -> String {
-		"%.2f" formatDouble(this)
+	toString: func (decimals := 2) -> String {
+		("%." & decimals toString() & "f") formatDouble(this)
 	}
 }
 
 Float: cover from float extends LDouble {
 	isNumber ::= this == this
-	toString: func -> String {
-		"%.2f" formatFloat(this)
+	toString: func (decimals := 2) -> String {
+		("%." & decimals toString() & "f") formatFloat(this)
 	}
 }
 

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -357,7 +357,7 @@ QuaternionTest: class extends Fixture {
 		})
 		this add("toString", func {
 			string := this quaternion0 toString()
-			expect(string == "Real: 33.000000 Imaginary: 10.000000 -12.000000 54.500000")
+			expect(string, is equal to("Real: 33.000000 Imaginary: 10.000000 -12.000000 54.500000"))
 			string free()
 		})
 		this add("weightedQuaternionMean_X", func {

--- a/test/system/MathTest.ooc
+++ b/test/system/MathTest.ooc
@@ -118,6 +118,11 @@ MathTest: class extends Fixture {
 			string free()
 			expect(123.4f roundToValueDigits(2, true), is equal to(130.f) within(floatTolerance))
 			expect(123.4f roundToValueDigits(3, false), is equal to(123.f) within(floatTolerance))
+
+			(two, three) := (123.456f toString(2), 123.456f toString(3))
+			expect(two, is equal to("123.46"))
+			expect(three, is equal to("123.456"))
+			(two, three) free()
 		})
 		this add("Double", func {
 			expect(22.3 modulo(5), is equal to(2.3) within(doubleTolerance))
@@ -162,6 +167,11 @@ MathTest: class extends Fixture {
 			expect(nearZero greaterOrEqual(0.0), is true)
 			expect(nearZero greaterThan(0.0), is false)
 			expect(nearZero lessThan(0.0), is false)
+
+			(two, three) := (123.456 toString(2), 123.456 toString(3))
+			expect(two, is equal to("123.46"))
+			expect(three, is equal to("123.456"))
+			(two, three) free()
 		})
 		this add("SineInterpolation", func {
 			expect(0.0f sineInterpolation(), is equal to(0.0f) within(floatTolerance))


### PR DESCRIPTION
Fixes #1804 

Let's you call `toString()` with optional argument of the number of decimals. Useful when printing a `FloatVectorList` with arbitrary precision of each element, which sparked the original idea. Also added this feature for most classes in `math` and `geometry`.