### PR TITLE
removed unsafe property access from ReferenceCounter

### DIFF
--- a/source/base/ReferenceCounter.ooc
+++ b/source/base/ReferenceCounter.ooc
@@ -14,9 +14,9 @@ ReferenceCounter: class {
 	_kill := false
 	_lock: Mutex
 	isSafe: Bool {
-		get { !this _lock instanceOf(MutexUnsafe) }
+		get { this _isSafe() }
 		set(value) {
-			if (this isSafe != value) {
+			if (this _isSafe() != value) {
 				this _lock free()
 				this _lock = Mutex new(value ? MutexType Safe : MutexType Unsafe)
 			}
@@ -53,4 +53,5 @@ ReferenceCounter: class {
 	decrease: func { this update(-1) }
 	reset: func { this _count = 0 }
 	toString: func -> String { "Object ID: " << this _target as Pointer toString() >> " Count: " & this _count toString() }
+	_isSafe: func -> Bool { !this _lock instanceOf(MutexUnsafe) }
 }

--- a/test/base/ReferenceCounterTest.ooc
+++ b/test/base/ReferenceCounterTest.ooc
@@ -43,6 +43,11 @@ ReferenceCounterTest: class extends Fixture {
 		object := TestObject new(isAlive&)
 		counter := ReferenceCounter new(object)
 		counter isSafe = true
+		expect(counter isSafe, is true)
+		counter isSafe = false
+		expect(counter isSafe, is false)
+		counter isSafe = true
+		expect(counter isSafe, is true)
 		numberOfThreads := 8
 		countPerThread := 500
 		threads := Thread[numberOfThreads] new()


### PR DESCRIPTION
Fixes bug mentioned in https://github.com/magic-lang/ooc-kean/pull/1811
@marcusnaslund 