### PR TITLE
fixes some small thread-related issues

### DIFF
--- a/source/concurrent/SynchronizedQueue.ooc
+++ b/source/concurrent/SynchronizedQueue.ooc
@@ -63,8 +63,8 @@ BlockedQueue: class <T> extends SynchronizedQueue<T> {
 	}
 	cancel: func { this _waitLock with(|| this _canceled = true) . wakeAll() }
 	wait: func -> T {
-		result: T = null
 		this _waitLock lockWhen(func -> Bool { !this empty || this _canceled })
+		result: T = null
 		if (!this _canceled)
 			result = this _backend dequeue(result)
 		this _waitLock unlock()

--- a/test/concurrent/ThreadTest.ooc
+++ b/test/concurrent/ThreadTest.ooc
@@ -62,6 +62,7 @@ ThreadTest: class extends Fixture {
 		expect(value get(), is less than(expectedValue))
 		thread free()
 		startedCondition free()
+		mutex unlock()
 		mutex free()
 		value free()
 		(job as Closure) free()


### PR DESCRIPTION
- fixed destroying a locked mutex in `ThreadTest`
- removed race condition on static data generated by rock in `Pointer` class

@marcusnaslund 