### PR TITLE
StringBuilder frees content if required

### DIFF
--- a/source/base/StringBuilder.ooc
+++ b/source/base/StringBuilder.ooc
@@ -10,8 +10,8 @@ StringBuilder: class {
 	_items: VectorList<String>
 	count ::= this _items count
 
-	init: func (capacity := 32) {
-		this _items = VectorList<String> new(capacity, false)
+	init: func (capacity := 32, ownsMemory := false) {
+		this _items = VectorList<String> new(capacity, ownsMemory)
 	}
 	free: override func {
 		this _items free()

--- a/test/base/StringBuilderTest.ooc
+++ b/test/base/StringBuilderTest.ooc
@@ -48,6 +48,12 @@ StringBuilderTest: class extends Fixture {
 			expect(result == "12QQQ90")
 			(result, builder) free()
 		})
+		this add("owns memory", func {
+			builder := StringBuilder new(5, true)
+			temp := "78" + "90"
+			builder add("12" + "34") . add("34" + "56") . add(temp)
+			builder free()
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #1822 

`memcheck.sh` of the test verifies 0 leaks.