### PR TITLE
Correct distance metric in RasterMonochrome

### DIFF
--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -115,7 +115,7 @@ RasterMonochrome: class extends RasterPacked {
 						result += distance sqrt()
 					}
 				}
-			result /= (sizeX squared + sizeY squared as Float sqrt())
+			result /= this size length
 		}
 		result
 	}

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -139,7 +139,7 @@ RasterUv: class extends RasterPacked {
 						result += (distance) sqrt() / 3
 					}
 				}
-			result /= ((sizeX squared + sizeY squared) as Float sqrt())
+			result /= this size length
 		}
 		result
 	}

--- a/test/draw/RasterMonochromeTest.ooc
+++ b/test/draw/RasterMonochromeTest.ooc
@@ -50,7 +50,7 @@ RasterMonochromeTest: class extends Fixture {
 			alphabet := " .,-_':;!+~=^?*abcdefghijklmnopqrstuvwxyz()[]{}|&%@#0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 			asciiImage := image1 toAscii(alphabet)
 			image2 := RasterMonochrome fromAscii(asciiImage)
-			expect(image1 distance(image2), is less than(0.01f))
+			expect(image1 distance(image2), is less than(4.f))
 			(image1, image2) referenceCount decrease()
 			(asciiImage, alphabet) free()
 		})


### PR DESCRIPTION
Fixes #1824 

Because dividing with `sizeX^2 + sqrt(sizeY^2)` gives a smaller number than dividing with `sqrt(sizeX^2 + sizeY^2)`, the distance between the two images is naturally slightly larger.

Also simplified a similar entry in `RasterUv distance()`.

Peer review @sebastianbaginski 