### PR TITLE
FileReader takes String, not Text, argument

### DIFF
--- a/source/system/io/FileReader.ooc
+++ b/source/system/io/FileReader.ooc
@@ -9,19 +9,16 @@
 import io/[Reader, File]
 
 FileReader: class extends Reader {
-	fileName: Text
 	file: FStream
-
 	init: func ~withFile (fileObject: File) {
-		init(Text new(fileObject getPath()))
+		init(fileObject getPath())
 	}
-	init: func ~withName (fileName: Text) {
+	init: func ~withName (fileName: String) {
 		// mingw fseek/ftell are *really* unreliable with text mode
 		// if for some reason you need to open in text mode, use
 		// FileReader new(fileName, "rt")
-		init(fileName, t"rb")
+		init(fileName, "rb")
 	}
-
 	/**
 	 * Open a file for reading, given its name and the mode in which to open it.
 	 *
@@ -33,19 +30,15 @@ FileReader: class extends Reader {
 	 * suffix "b" = binary mode
 	 * suffix "t" = text mode (warning: rewind/mark are unreliable in text mode under mingw32)
 	 */
-	init: func ~withMode (=fileName, mode: Text) {
-		(fileNameString, modeString) := (this fileName take() toString(), mode toString())
-		this file = FStream open(fileNameString, modeString)
-		(fileNameString, modeString) free()
+	init: func ~withMode (fileName, mode: String) {
+		this file = FStream open(fileName, mode)
 		if (!this file) {
 			err := getOSError()
 			Exception new(This, "Couldn't open #{fileName} for reading: #{err}") throw()
 		}
 	}
-
 	init: func ~fromFStream (=file)
 	free: override func {
-		this fileName free(Owner Receiver)
 		this file close()
 		super()
 	}

--- a/source/system/structs/HashMap.ooc
+++ b/source/system/structs/HashMap.ooc
@@ -253,8 +253,8 @@ HashMap: class <K, V> {
 			case => memcmp(first, second, K size) == 0
 		}
 	}
-	readFromFile: static func (filename: Text) -> This<String, String> {
-		reader := FileReader new(filename, t"r")
+	readFromFile: static func (filename: String) -> This<String, String> {
+		reader := FileReader new(filename, "r")
 		result := This<String, String> new()
 		while (reader hasNext()) {
 			string := reader readLine()

--- a/test/io/ProcessTest.ooc
+++ b/test/io/ProcessTest.ooc
@@ -32,7 +32,7 @@ ProcessTest: class extends Fixture {
 			scriptArgs free()
 
 			Time sleepMilli(250)
-			reader := FileReader new(t"test/io/output/sum.txt")
+			reader := FileReader new("test/io/output/sum.txt")
 			expect(reader hasNext())
 			data := CString new(16)
 			reader read(data, 0, 15)

--- a/test/plot/SvgPlotTest.ooc
+++ b/test/plot/SvgPlotTest.ooc
@@ -110,8 +110,8 @@ SvgPlotTest: class extends Fixture {
 			filename free()
 		})
 		this add("Output check", func {
-			generatedFile := FileReader new(t"test/plot/output/example.svg")
-			comparisonFile := FileReader new(t"test/plot/input/exampleComparison.svg")
+			generatedFile := FileReader new("test/plot/output/example.svg")
+			comparisonFile := FileReader new("test/plot/input/exampleComparison.svg")
 			while (generatedFile hasNext() && comparisonFile hasNext()) {
 				(generatedString, comparisonString) := (generatedFile readUntil(' '), comparisonFile readUntil(' '))
 				// If they differ, it can only be due to (small) roundoff errors

--- a/test/system/FileTest.ooc
+++ b/test/system/FileTest.ooc
@@ -34,7 +34,7 @@ FileTest: class extends Fixture {
 			expect(file exists())
 			fileCopy := File new(pathCopy)
 			file copyTo(fileCopy)
-			reader := FileReader new(Text new(pathCopy))
+			reader := FileReader new(pathCopy)
 			expect(reader hasNext())
 			expect(reader read(), is equal to('a'))
 			expect(reader read(), is equal to('b'))

--- a/test/system/HashMapTest.ooc
+++ b/test/system/HashMapTest.ooc
@@ -209,7 +209,7 @@ HashMapTest: class extends Fixture {
 			hashmap free()
 
 			tolerance := 0.00001f
-			input := HashMap readFromFile(t"test/system/output/mathmap.txt")
+			input := HashMap readFromFile("test/system/output/mathmap.txt")
 			expect(input, is notNull)
 			expect(input count, is equal to(4))
 			(piString, eString, sqrtTwoString, primeString) := (input get("pi"), input get("e"), input get("sqrt(2)"), input get("primes"))


### PR DESCRIPTION
And adapts other classes to match.

`FileReader` also does not store the `fileName` anymore.