### PR TITLE
Added priority value to GlobalCleanup calls

### DIFF
--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -55,16 +55,12 @@ ByteBuffer: class {
 		memcpy(other pointer + destination, this pointer + start, length)
 	}
 	new: static func ~size (size: Int, allocator := Allocator defaultAllocator()) -> This { _RecyclableByteBuffer new(size, allocator) }
-	new: static func ~recover (pointer: Byte*, size: Int, recover: Func (This) -> Bool) -> This {
-		_RecoverableByteBuffer new(pointer, size, recover)
-	}
-	free: static func ~all {
-		_RecyclableByteBuffer _free~all()
-	}
+	new: static func ~recover (pointer: Byte*, size: Int, recover: Func (This) -> Bool) -> This { _RecoverableByteBuffer new(pointer, size, recover) }
+	free: static func ~all { _RecyclableByteBuffer _free~all() }
 }
 
-GlobalCleanup register(|| ByteBuffer free~all(), true)
-GlobalCleanup register(|| Allocator free~all(), true)
+GlobalCleanup register(|| ByteBuffer free~all(), 8)
+GlobalCleanup register(|| Allocator free~all(), 9)
 
 _SlicedByteBuffer: class extends ByteBuffer {
 	_parent: ByteBuffer

--- a/source/system/Memory.ooc
+++ b/source/system/Memory.ooc
@@ -24,30 +24,44 @@ memfree: extern (free) func (Pointer)
 alloca: extern func (SizeT) -> Pointer
 
 // Used for executing any/all cleanup (free~all) functions before program exit
+// Default priority is 0 and will be executed first, then 1, 2, 3... etc.
 GlobalCleanup: class {
 	_functionPointers: static VectorList<Closure> = null
-	register: static func (pointer: Func, last := false) {
-		if (This _functionPointers == null)
+	_priorities: static VectorList<Int> = null
+	_maxPriority := static 1
+	register: static func (pointer: Func, priority := 0) {
+		if (This _functionPointers == null) {
 			This _functionPointers = VectorList<Closure> new()
-		if (last)
-			This _functionPointers insert(0, pointer as Closure)
-		else
-			This _functionPointers add(pointer as Closure)
+			This _priorities = VectorList<Int> new()
+		}
+		This _functionPointers add(pointer as Closure)
+		This _priorities add(priority)
+		if (priority > This _maxPriority)
+			This _maxPriority = priority
 	}
 	run: static func {
 		if (This _functionPointers != null) {
-			while (!This _functionPointers empty) {
-				next := This _functionPointers remove(This _functionPointers count - 1)
-				(next as Func)()
-				(next) free()
+			priority := 0
+			while (!This _functionPointers empty && priority < This _maxPriority) {
+				index := This _functionPointers count - 1
+				while (index >= 0) {
+					if (This _priorities[index] == priority) {
+						This _priorities removeAt(index)
+						next := This _functionPointers remove(index)
+						(next as Func)()
+						(next) free()
+					}
+					index -= 1
+				}
+				priority += 1
 			}
 			This clear()
 		}
 	}
 	clear: static func {
 		if (This _functionPointers != null) {
-			This _functionPointers free()
-			This _functionPointers = null
+			(This _functionPointers, This _priorities) free()
+			(This _functionPointers, This _priorities) = (null, null)
 		}
 	}
 }

--- a/source/system/String.ooc
+++ b/source/system/String.ooc
@@ -293,4 +293,4 @@ cStringPtrToStringPtr: func (cstr: CString*, len: Int) -> String* {
 	toRet
 }
 
-GlobalCleanup register(|| String free~all(), true)
+GlobalCleanup register(|| String free~all(), 10)

--- a/test/system/MemoryTest.ooc
+++ b/test/system/MemoryTest.ooc
@@ -14,8 +14,8 @@ MemoryTest: class extends Fixture {
 		super("Memory")
 		this add("Global cleanup", func {
 			// Workaround to avoid changing the GlobalCleanup stack saved from other tests
-			saveStack := GlobalCleanup _functionPointers
-			GlobalCleanup _functionPointers = null
+			(savedFunctions, savedPriorities) := (GlobalCleanup _functionPointers, GlobalCleanup _priorities)
+			(GlobalCleanup _functionPointers, GlobalCleanup _priorities) = (null, null)
 
 			GlobalCleanup register(This decrease)
 			expect(GlobalCleanup _functionPointers, is notNull)
@@ -34,7 +34,7 @@ MemoryTest: class extends Fixture {
 			expect(GlobalCleanup _functionPointers, is Null)
 
 			// Return the saved stack to GlobalCleanup
-			GlobalCleanup _functionPointers = saveStack
+			(GlobalCleanup _functionPointers, GlobalCleanup _priorities) = (savedFunctions, savedPriorities)
 		})
 	}
 	decrease: static func { This value -= 1 }


### PR DESCRIPTION
Fixes #1848 

I could also create a `Func`+priority pair and use the `SortedVectorList`, but we don't really need the complexity or performance. There shouldn't be that many items in this list, and if one registers a call with priority 123456789, one is just stupid.

Maybe the priority should be a `Byte`, we don't need the entire `Int` range, and then we won't have any problems.

Thoughts, peer review @sebastianbaginski ?