### PR TITLE
Added []= for Queue classes

### DIFF
--- a/source/collections/CircularQueue.ooc
+++ b/source/collections/CircularQueue.ooc
@@ -47,4 +47,5 @@ CircularQueue: class <T> extends Queue<T> {
 	dequeue: override func ~default (fallback: T) -> T { this _backend dequeue(fallback) }
 	peek: override func ~default (fallback: T) -> T { this _backend peek(fallback) }
 	operator [] (index: Int) -> T { this _backend[index] }
+	operator []= (index: Int, value: T) { this _backend[index] = value }
 }

--- a/source/collections/VectorQueue.ooc
+++ b/source/collections/VectorQueue.ooc
@@ -72,4 +72,10 @@ VectorQueue: class <T> extends Queue<T> {
 		position := (index >= 0 ? this _head + index : this _tail + index) modulo(this _capacity)
 		this _backend[position]
 	}
+	operator []= (index: Int, value: T) {
+		version(safe)
+			raise(index < -this count || index >= this count, "Indexing in set accessor of VectorQueue outside of range.")
+		position := (index >= 0 ? this _head + index : this _tail + index) modulo(this _capacity)
+		this _backend[position] = value
+	}
 }

--- a/source/concurrent/SynchronizedQueue.ooc
+++ b/source/concurrent/SynchronizedQueue.ooc
@@ -44,6 +44,17 @@ SynchronizedQueue: class <T> extends Queue<T> {
 		this _backend clear()
 		this _mutex unlock()
 	}
+	operator [] (index: Int) -> T {
+		this _mutex lock()
+		result := this _backend[index]
+		this _mutex unlock()
+		result
+	}
+	operator []= (index: Int, value: T) {
+		this _mutex lock()
+		this _backend[index] = value
+		this _mutex unlock()
+	}
 }
 
 BlockedQueue: class <T> extends SynchronizedQueue<T> {

--- a/source/system/structs/Queue.ooc
+++ b/source/system/structs/Queue.ooc
@@ -15,4 +15,6 @@ Queue: abstract class <T> {
 	enqueue: abstract func (item: T)
 	dequeue: abstract func ~default (fallback: T) -> T
 	peek: abstract func ~default (fallback: T) -> T
+	abstract operator [] (index: Int) -> T
+	abstract operator []= (index: Int, value: T)
 }

--- a/test/collections/VectorQueueTest.ooc
+++ b/test/collections/VectorQueueTest.ooc
@@ -98,8 +98,11 @@ VectorQueueTest: class extends Fixture {
 		})
 		this add("Queue positive indexing", func {
 			queue := this _createQueue(10, 5)
-			for (i in 0 .. 5)
+			for (i in 0 .. 5) {
 				expect(queue[i], is equal to(i))
+				queue[i] = i + 1
+				expect(queue[i], is equal to(i + 1))
+			}
 			queue free()
 		})
 		this add("Queue negative indexing", func {


### PR DESCRIPTION
And added `[]/[]=` operator to base `List` class, which showed me they did not exist in `SynchronizedQueue` at all.

Peer review @sebastianbaginski ?