### PR TITLE
Fixed removeAt bugs in List

### DIFF
--- a/source/system/structs/List.ooc
+++ b/source/system/structs/List.ooc
@@ -15,7 +15,7 @@ List: abstract class <T> {
 	insert: abstract func (index: Int, item: T)
 	remove: abstract func ~last -> T
 	remove: abstract func ~atIndex (index: Int) -> T
-	removeAt: virtual func (index: Int) { this removeAt(index, index + 1) }
+	removeAt: abstract func (index: Int)
 	removeAt: func ~range (range: Range) { this removeAt(range min, range max) }
 	removeAt: abstract func ~indices (start, end: Int)
 	clear: abstract func

--- a/source/system/structs/VectorList.ooc
+++ b/source/system/structs/VectorList.ooc
@@ -51,6 +51,9 @@ VectorList: class <T> extends List<T>{
 		this _count -= 1
 		result
 	}
+	removeAt: override func (index: Int) {
+		this removeAt(index, index + 1)
+	}
 	removeAt: override func ~indices (start, end: Int) {
 		count := end - start
 		version(safe)


### PR DESCRIPTION
Yes, this should work.
No, it does not.
I get `the arg 'index' should be of type 'Int' instead of 'Int'` when trying to use `removeAt(Int)`.