### PR TITLE
test for the allocator when returning recycled buffer

### DIFF
--- a/source/base/ByteBuffer.ooc
+++ b/source/base/ByteBuffer.ooc
@@ -123,7 +123,7 @@ _RecyclableByteBuffer: class extends ByteBuffer {
 		bin := This _getBin(size)
 		This _lock lock()
 		for (i in 0 .. bin count)
-			if ((bin[i] size) == size) {
+			if (bin[i] size == size && bin[i] _allocator == allocator) {
 				buffer = bin remove(i)
 				buffer referenceCount reset()
 				break


### PR DESCRIPTION
To prevent returning buffer allocated with other allocator when explicitly passing custom one.
Fixes https://github.com/magic-lang/ooc-kean/issues/1857
@marcusnaslund 