### PR TITLE
Implemented isFull and first+last properties on Queues

### DIFF
--- a/source/collections/CircularQueue.ooc
+++ b/source/collections/CircularQueue.ooc
@@ -14,6 +14,8 @@ CircularQueue: class <T> extends Queue<T> {
 	_maximumCapacity: Int
 	count ::= this _backend count
 	capacity ::= this _backend capacity
+	isFull ::= this _backend isFull
+
 	init: func ~defaultCallback (capacity: Int) {
 		callback: Func (T)
 		if (T inheritsFrom(Object))

--- a/source/collections/VectorQueue.ooc
+++ b/source/collections/VectorQueue.ooc
@@ -13,7 +13,7 @@ VectorQueue: class <T> extends Queue<T> {
 	_tail := 0 // Index of newest element
 	_chunkCount := 32
 	capacity ::= this _capacity
-	full ::= this _count == this _capacity
+	isFull ::= this _count == this _capacity
 
 	init: func (capacity := 32) {
 		this _capacity = capacity
@@ -30,7 +30,7 @@ VectorQueue: class <T> extends Queue<T> {
 		this _count = 0
 	}
 	enqueue: override func (item: T) {
-		if (this full)
+		if (this isFull)
 			this _resize()
 		this _backend[this _tail] = item
 		this _tail = (this _tail + 1) % this _capacity

--- a/source/system/structs/Queue.ooc
+++ b/source/system/structs/Queue.ooc
@@ -10,6 +10,15 @@ Queue: abstract class <T> {
 	_count := 0
 	count ::= this _count
 	empty ::= this count == 0
+	first: T {
+		get { this[0] }
+		set (value) { this[0] = value }
+	}
+	last: T {
+		get { this[-1] }
+		set (value) { this[-1] = value }
+	}
+
 	init: func
 	clear: abstract func
 	enqueue: abstract func (item: T)

--- a/source/system/structs/VectorList.ooc
+++ b/source/system/structs/VectorList.ooc
@@ -6,7 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-VectorList: class <T> extends List<T>{
+VectorList: class <T> extends List<T> {
 	_vector: Vector<T>
 	pointer ::= this _vector _backend as Pointer
 	init: func ~default {

--- a/test/collections/CircularQueueTest.ooc
+++ b/test/collections/CircularQueueTest.ooc
@@ -54,6 +54,23 @@ CircularQueueTest: class extends Fixture {
 			(object, queue) free()
 			expect(MyClass instanceCount, is equal to(initialCount))
 		})
+		this add("First/Last properties", func {
+			queue := CircularQueue<Int> new(3)
+			queue enqueue(1) . enqueue(2) . enqueue(3)
+			expect(queue first, is equal to(1))
+			expect(queue last, is equal to(3))
+			queue first = 17
+			queue last = 19
+			expect(queue first, is equal to(17))
+			expect(queue last, is equal to(19))
+			queue enqueue(10)
+			expect(queue first, is equal to(2))
+			expect(queue last, is equal to(10))
+			queue enqueue(15)
+			expect(queue first, is equal to(19))
+			expect(queue last, is equal to(15))
+			queue free()
+		})
 	}
 }
 

--- a/test/collections/VectorQueueTest.ooc
+++ b/test/collections/VectorQueueTest.ooc
@@ -30,16 +30,16 @@ VectorQueueTest: class extends Fixture {
 
 			expect(queue count, is equal to(0))
 			expect(queue empty, is true)
-			expect(queue full, is false)
+			expect(queue isFull, is false)
 			queue enqueue(0)
 			expect(queue empty, is false)
 			queue enqueue(1)
 			queue enqueue(2)
 			expect(queue count, is equal to(3))
-			expect(queue full, is true)
+			expect(queue isFull, is true)
 			removedInt := queue dequeue(Int minimumValue)
 			expect(queue count, is equal to(2))
-			expect(queue full, is false)
+			expect(queue isFull, is false)
 			expect(removedInt, is equal to(0))
 			peekedInt: Int
 			peekedInt = queue peek(Int minimumValue)
@@ -57,7 +57,7 @@ VectorQueueTest: class extends Fixture {
 			queue enqueue(4)
 			queue enqueue(5)
 			expect(queue count, is equal to(3))
-			expect(queue full, is true)
+			expect(queue isFull, is true)
 			removedInt = queue dequeue(Int minimumValue)
 			expect(queue count, is equal to(2))
 			expect(removedInt, is equal to(3))
@@ -148,6 +148,21 @@ VectorQueueTest: class extends Fixture {
 			expect(queue empty, is true)
 			expect(queue dequeue(null), is Null)
 			(defaultValue, item, queue) free()
+		})
+		this add("First/Last properties", func {
+			queue := VectorQueue<Int> new(7)
+			queue enqueue(1) . enqueue(2) . enqueue(3)
+			expect(queue first, is equal to(1))
+			expect(queue last, is equal to(3))
+			queue first = 17
+			queue last = 19
+			expect(queue first, is equal to(17))
+			expect(queue last, is equal to(19))
+			expect(queue count, is equal to(3))
+			queue enqueue(10)
+			expect(queue last, is equal to(10))
+			expect(queue count, is equal to(4))
+			queue free()
 		})
 	}
 	_createQueue: func (capacity, fill: Int, replace := 0) -> VectorQueue<Int> {


### PR DESCRIPTION
Breaks the API (`full` -> `isFull`) but that's easy to fix.
Fixes #1863 

Peer review @sebastianbaginski ?