### PR TITLE
Made toString() work for negative TimeSpans

### DIFF
--- a/source/base/TimeSpan.ooc
+++ b/source/base/TimeSpan.ooc
@@ -36,22 +36,27 @@ TimeSpan: cover {
 	//  %S - seconds (based on total ticks)
 	//  %Z - milliseconds (based on total ticks)
 	toString: func (format := This defaultFormat) -> String {
-		(weekString, dayString, hourString) := (this toWeeks(), this toDays(), this toHours()) toString()
-		(minuteString, secondString, milliString) := (this toMinutes(), this toSeconds(), this toMilliseconds()) toString()
-		(dayModString, hourModString, minuteModString) := (this toDays() modulo(7), this toHours() modulo(24), this toMinutes() modulo(60)) toString()
-		(secondModString, milliModString) := (this toSeconds() modulo(60), this toMilliseconds() modulo(1000)) toString()
-		result := format replaceAll("%w", weekString)
-		result = result replaceAll("%D", dayString, true, true)
-		result = result replaceAll("%H", hourString, true, true)
-		result = result replaceAll("%M", minuteString, true, true)
-		result = result replaceAll("%S", secondString, true, true)
-		result = result replaceAll("%Z", milliString, true, true)
-		result = result replaceAll("%d", dayModString, true, true)
-		result = result replaceAll("%h", hourModString, true, true)
-		result = result replaceAll("%m", minuteModString, true, true)
-		result = result replaceAll("%s", secondModString, true, true)
-		result = result replaceAll("%z", milliModString, true, true)
-		(weekString, dayString, hourString, minuteString, secondString, milliString, dayModString, hourModString, minuteModString, secondModString, milliModString) free()
+		result: String
+		if (this _ticks < 0L)
+			result = "-(" << this negate() toString(format) >> ")"
+		else {
+			(weekString, dayString, hourString) := (this toWeeks(), this toDays(), this toHours()) toString()
+			(minuteString, secondString, milliString) := (this toMinutes(), this toSeconds(), this toMilliseconds()) toString()
+			(dayModString, hourModString, minuteModString) := (this toDays() modulo(7), this toHours() modulo(24), this toMinutes() modulo(60)) toString()
+			(secondModString, milliModString) := (this toSeconds() modulo(60), this toMilliseconds() modulo(1000)) toString()
+			result = format replaceAll("%w", weekString)
+			result = result replaceAll("%D", dayString, true, true)
+			result = result replaceAll("%H", hourString, true, true)
+			result = result replaceAll("%M", minuteString, true, true)
+			result = result replaceAll("%S", secondString, true, true)
+			result = result replaceAll("%Z", milliString, true, true)
+			result = result replaceAll("%d", dayModString, true, true)
+			result = result replaceAll("%h", hourModString, true, true)
+			result = result replaceAll("%m", minuteModString, true, true)
+			result = result replaceAll("%s", secondModString, true, true)
+			result = result replaceAll("%z", milliModString, true, true)
+			(weekString, dayString, hourString, minuteString, secondString, milliString, dayModString, hourModString, minuteModString, secondModString, milliModString) free()
+		}
 		result
 	}
 	compareTo: func (other: This) -> Order {

--- a/test/base/TimeSpanTest.ooc
+++ b/test/base/TimeSpanTest.ooc
@@ -119,14 +119,17 @@ TimeSpanTest: class extends Fixture {
 		this add("toString", func {
 			span := TimeSpan millisecond() + TimeSpan second() + TimeSpan minute() + TimeSpan hour() + TimeSpan day() + TimeSpan week()
 			defaultString := span toString()
-			expect(defaultString == "1 weeks, 1 days, 1 hours, 1 minutes, 1 seconds, 1 milliseconds")
+			expect(defaultString, is equal to("1 weeks, 1 days, 1 hours, 1 minutes, 1 seconds, 1 milliseconds"))
 			dayString := span toString("%D")
-			expect(dayString == "8")
+			expect(dayString, is equal to("8"))
 			Astring := TimeSpan day() toString("%H %M %S %h %m %s")
-			expect(Astring == "24 1440 86400 0 0 0")
+			expect(Astring, is equal to("24 1440 86400 0 0 0"))
 			Bstring := TimeSpan hour() toString("%d %D text %m %M")
-			expect(Bstring == "0 0 text 0 60")
-			(defaultString, dayString, Astring, Bstring) free()
+			expect(Bstring, is equal to("0 0 text 0 60"))
+			negativeSpan := TimeSpan day() negate()
+			negativeString := negativeSpan toString("%H %M %S %h %m %s")
+			expect(negativeString, is equal to("-(24 1440 86400 0 0 0)"))
+			(defaultString, dayString, Astring, Bstring, negativeString) free()
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1836 
Simplest possible solution:

```ooc
if (this _ticks < 0L)
	result = "-(" << this negate() toString(format) >> ")"
else
	// ...
```

An easier-to-read diff is here: https://github.com/magic-lang/ooc-kean/pull/1867/files?w=1