### PR TITLE
Added '-Ddeterministic' flag

### DIFF
--- a/source/math/FloatRandomGenerator.ooc
+++ b/source/math/FloatRandomGenerator.ooc
@@ -17,6 +17,9 @@ FloatRandomGenerator: abstract class {
 	}
 }
 
+version (deterministic)
+	FloatRandomGenerator permanentSeed = 73U
+
 FloatUniformRandomGenerator: class extends FloatRandomGenerator {
 	_state: UInt
 	_min, _max, _rangeCoefficient: Float

--- a/source/math/IntRandomGenerator.ooc
+++ b/source/math/IntRandomGenerator.ooc
@@ -19,6 +19,9 @@ IntRandomGenerator: abstract class {
 	}
 }
 
+version (deterministic)
+	IntRandomGenerator permanentSeed = 73
+
 IntUniformRandomGenerator: class extends IntRandomGenerator {
 	_state, _min, _max, _range: Int
 	_shortRange: Bool


### PR DESCRIPTION
Running with `-Ddeterministic` will set permanent seeds on the random generators.

Why 73? Because googling `best number` has https://en.wikipedia.org/wiki/73_(number) as first result.

Peer review @sebastianbaginski 