### PR TITLE
Debug deadlock

### DIFF
--- a/source/concurrent/Promise.ooc
+++ b/source/concurrent/Promise.ooc
@@ -19,7 +19,19 @@ _Synchronizer: abstract class {
 	_state: _PromiseState
 	init: func
 	wait: abstract func (time: TimeSpan) -> Bool
-	wait: func ~forever -> Bool { this wait(TimeSpan maximumValue) }
+	wait: func ~forever -> Bool {
+		version(debugDeadlock) {
+			timeLimit_msec := 2_000
+			timer := CpuTimer new() . start()
+			result := this wait(TimeSpan milliseconds(timeLimit_msec))
+			if (timer stop() > timeLimit_msec)
+				Debug error("Error! [" + this class name + " stalled for more than " + timeLimit_msec + " ticks and timed out]")
+			timer free()
+		}
+		else
+			result := this wait(TimeSpan maximumValue)
+		result
+	}
 	cancel: virtual func -> Bool { false }
 }
 

--- a/source/system/external/pthread.ooc
+++ b/source/system/external/pthread.ooc
@@ -23,6 +23,7 @@ pthread_cond_broadcast: extern func (cond: PThreadCond*) -> Int
 pthread_cond_wait: extern func (cond: PThreadCond*, mutex: PThreadMutex*) -> Int
 pthread_cond_destroy: extern func (cond: PThreadCond*) -> Int
 
+pthread_mutex_timedlock: extern func (PThreadMutex*, TimeSpec*) -> Int
 pthread_mutex_lock: extern func (PThreadMutex*)
 pthread_mutex_unlock: extern func (PThreadMutex*)
 pthread_mutex_init: extern func (PThreadMutex*, PThreadMutexAttr*)


### PR DESCRIPTION
Using the version(debugDeadlock) flag will now raise an error when a promise/mutexunix takes "too long" to finish.
Notes: 

- ~~Mutexes are ignored since Android uses ``std::mutex`` instead of our ``Mutex.ooc``.~~
- A timer is used for the timeout check since  ``_Synchronizer _state`` is currently very unreliable:  ``_Synchronizer`` objects created by ``Threadpool`` have tasks whose state are changed instead. ``OutputFrame`` seems to ignore the state variable as it uses a ``WaitCondition`` for the actual wait.
- ~~The timer uses ticks rather than seconds for the timeout due to the fact that ``_Task wait()`` is implemented that way.~~

