### PR TITLE
Cleanup in Timer classes

### DIFF
--- a/source/base/Profiler.ooc
+++ b/source/base/Profiler.ooc
@@ -53,15 +53,15 @@ Profiler: class {
 	benchmark: static func (task: Func, timeoutMilliseconds := 1000.0) -> Double {
 		numberOfIterations := 0
 		timer := WallTimer new()
-		totalTime := 0.0
-		while (totalTime < timeoutMilliseconds * 1000.0) {
+		totalTime := TimeSpan new(0)
+		while (totalTime toMilliseconds() < timeoutMilliseconds) {
 			numberOfIterations += 1
 			timer start()
 			task()
 			totalTime += timer stop()
 		}
 		timer free()
-		totalTime / (numberOfIterations * 1000)
+		totalTime toMilliseconds() as Double / (numberOfIterations * 1000)
 	}
 	_logResults: static func (logMethod: Func (String)) {
 		for (i in 0 .. This _profilers count) {

--- a/source/base/Profiler.ooc
+++ b/source/base/Profiler.ooc
@@ -61,7 +61,7 @@ Profiler: class {
 			totalTime += timer stop()
 		}
 		timer free()
-		totalTime toMilliseconds() as Double / (numberOfIterations * 1000)
+		totalTime toMilliseconds() / (numberOfIterations * 1000.0)
 	}
 	_logResults: static func (logMethod: Func (String)) {
 		for (i in 0 .. This _profilers count) {

--- a/source/base/Timer.ooc
+++ b/source/base/Timer.ooc
@@ -19,12 +19,10 @@ Timer: abstract class {
 	_max: Double
 	_average: Double
 
-	init: func {
-		this _min = INFINITY
-		this _max = 0.0
-	}
+	init: func { this reset() }
 	start: abstract func
 	stop: abstract func -> Double
+	isRunning: virtual func -> Bool { !this _min equals(0.0) && !this _max equals(0.0) }
 	measure: func (action: Func) -> Double {
 		this start()
 		action()
@@ -40,13 +38,7 @@ Timer: abstract class {
 		this _average = this _total / this _count
 	}
 	reset: virtual func {
-		this _startTime = 0
-		this _endTime = 0
-		this _result = 0
-		this _total = 0
-		this _count = 0
-		this _min = 0
-		this _average = 0
+		(this _startTime, this _endTime, this _result, this _total, this _count, this _min, this _max, this _average) = (0, 0, 0, 0, 0, 0, 0, 0)
 	}
 }
 

--- a/source/base/Timer.ooc
+++ b/source/base/Timer.ooc
@@ -6,6 +6,8 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+ use base
+
 clock: extern func -> LLong
 CLOCKS_PER_SEC: extern const LLong
 
@@ -21,9 +23,9 @@ Timer: abstract class {
 
 	init: func { this reset() }
 	start: abstract func
-	stop: abstract func -> Double
-	isRunning: virtual func -> Bool { !this _min equals(0.0) && !this _max equals(0.0) }
-	measure: func (action: Func) -> Double {
+	stop: abstract func -> TimeSpan
+	isRunning: virtual func -> Bool { !this _startTime equals(0.0) || !this _endTime equals(0.0) }
+	measure: func (action: Func) -> TimeSpan {
 		this start()
 		action()
 		this stop()
@@ -38,28 +40,28 @@ Timer: abstract class {
 		this _average = this _total / this _count
 	}
 	reset: virtual func {
-		(this _startTime, this _endTime, this _result, this _total, this _count, this _min, this _max, this _average) = (0, 0, 0, 0, 0, 0, 0, 0)
+		(this _min, this _max, this _startTime, this _endTime, this _result, this _total, this _count, this _average) = (Double positiveInfinity, 0, 0, 0, 0, 0, 0, 0)
 	}
 }
 
 WallTimer: class extends Timer {
 	init: func { super() }
 	start: override func { this _startTime = (Time runTimeMicro() as Double) } // Note: Only millisecond precision on Win32
-	stop: override func -> Double {
+	stop: override func -> TimeSpan {
 		this _endTime = (Time runTimeMicro() as Double)
 		this _result = this _endTime - this _startTime
 		this _update()
-		this _result
+		TimeSpan microseconds(this _result)
 	}
 }
 
 CpuTimer: class extends Timer {
 	init: func { super() }
 	start: override func { this _startTime = (clock() as Double) }
-	stop: override func -> Double {
+	stop: override func -> TimeSpan {
 		this _endTime = (clock() as Double)
 		this _result = 1000.0 * (this _endTime - this _startTime) / CLOCKS_PER_SEC
 		this _update()
-		this _result
+		TimeSpan milliseconds(this _result)
 	}
 }

--- a/source/base/Timer.ooc
+++ b/source/base/Timer.ooc
@@ -40,7 +40,8 @@ Timer: abstract class {
 		this _average = this _total / this _count
 	}
 	reset: virtual func {
-		(this _min, this _max, this _startTime, this _endTime, this _result, this _total, this _count, this _average) = (Double positiveInfinity, 0, 0, 0, 0, 0, 0, 0)
+		this _min = Double positiveInfinity
+		(this _max, this _startTime, this _endTime, this _result, this _total, this _count, this _average) = (0, 0, 0, 0, 0, 0, 0)
 	}
 }
 

--- a/source/concurrent/Promise.ooc
+++ b/source/concurrent/Promise.ooc
@@ -25,11 +25,11 @@ _Synchronizer: abstract class {
 	wait: abstract func (time: TimeSpan) -> Bool
 	wait: func ~forever -> Bool {
 		version(debugDeadlock) {
-			timeLimitMilliseconds := 1000
+			timeLimit := TimeSpan milliseconds(1000)
 			timer := WallTimer new() . start()
-			result := this wait(TimeSpan milliseconds(timeLimitMilliseconds))
-			if (timer stop() / 1000 > timeLimitMilliseconds)
-				Debug error("Error! [" + this class name + " stalled for more than " + timeLimitMilliseconds + " milliseconds and timed out]")
+			result := this wait(timeLimit)
+			if (timer stop() > timeLimit)
+				Debug error("Error! [" + this class name + " stalled for more than " + timeLimit toMilliseconds() + " milliseconds and timed out]")
 			timer free()
 		}
 		else

--- a/source/concurrent/ThreadPool.ooc
+++ b/source/concurrent/ThreadPool.ooc
@@ -43,8 +43,7 @@ _Task: abstract class {
 			status = this wait()
 		else {
 			timer := WallTimer new() . start()
-			microseconds := time toMicroseconds()
-			while (timer stop() < microseconds && !status) {
+			while (timer stop() < time && !status) {
 				status = (this _state != _PromiseState Unfinished)
 				if (!status)
 					Time sleepMilli(1)

--- a/source/unit/Fixture.ooc
+++ b/source/unit/Fixture.ooc
@@ -53,7 +53,7 @@ Fixture: abstract class {
 			This failureNames add(this name clone())
 		}
 		This _print(result ? " done" : " failed")
-		testTime := timer stop() / 1_000_000.0
+		testTime := timer stop() toSeconds()
 		This totalTime += testTime
 		if (testTime > 0.1)
 			This _print(" in %.2fs" format(testTime), true)

--- a/test/base/TimerTest.ooc
+++ b/test/base/TimerTest.ooc
@@ -32,34 +32,39 @@ TimerTest: class extends Fixture {
 		this add("reset", func {
 			expect(this wallTimer _count, is equal to(2))
 			expect(this cpuTimer _count, is equal to(2))
+			expect(this wallTimer isRunning(), is true)
+			expect(this cpuTimer isRunning(), is true)
 			this wallTimer reset()
 			this cpuTimer reset()
+			expect(this wallTimer isRunning(), is false)
+			expect(this cpuTimer isRunning(), is false)
 			expect(this wallTimer _count, is equal to(0))
 			expect(this cpuTimer _count, is equal to(0))
 		})
 		this add("measure", func {
 			resultWall := this wallTimer measure(this measureFunc)
 			resultCpu := this cpuTimer measure(this measureFunc)
-			expect(resultWall, is greater than(0.01))
-			expect(resultCpu, is greater than(0.01))
+			expect(this wallTimer isRunning(), is true)
+			expect(this cpuTimer isRunning(), is true)
+			expect(resultWall toMilliseconds(), is greater than(10))
+			expect(resultCpu toMilliseconds(), is greater than(10))
 			(this measureFunc as Closure) free()
 		})
 	}
-	wallTimerTestFunction: func (loopLength: Int) -> Double {
+	wallTimerTestFunction: func (loopLength: Int) -> Long {
 		sum := 0
 		this wallTimer start()
 		for (i in 0 .. loopLength) { sum = (sum + i) % 10 }
-		this wallTimer stop()
+		this wallTimer stop() toMilliseconds()
 	}
-	cpuTimerTestFunction: func (loopLength: Int) -> Double {
+	cpuTimerTestFunction: func (loopLength: Int) -> Long {
 		sum := 0
 		this cpuTimer start()
 		for (i in 0 .. loopLength) { sum = (sum + i) % 10 }
-		this cpuTimer stop()
+		this cpuTimer stop() toMilliseconds()
 	}
 	free: override func {
-		this wallTimer free()
-		this cpuTimer free()
+		(this wallTimer, this cpuTimer) free()
 		super()
 	}
 }


### PR DESCRIPTION
Fixes #1894 

`Timer::stop` returns a `TimeSpan`. Added an `isRunning` method. Also some minor cleanup in the `Timer` classes.