### PR TITLE
Added simple chaining for Promise and Future classes

### DIFF
--- a/source/concurrent/Promise.ooc
+++ b/source/concurrent/Promise.ooc
@@ -36,6 +36,12 @@ _Synchronizer: abstract class {
 			result := this wait(TimeSpan maximumValue)
 		result
 	}
+	wait: static func ~timed (items: VectorList<This>, time := TimeSpan maximumValue) -> Bool {
+		result := true
+		for (i in 0 .. items count)
+			result = result && (time == TimeSpan maximumValue ? items[i] wait() : items[i] wait(time))
+		result
+	}
 	cancel: virtual func -> Bool { false }
 }
 

--- a/test/concurrent/PromiseTest.ooc
+++ b/test/concurrent/PromiseTest.ooc
@@ -88,6 +88,12 @@ PromiseTest: class extends Fixture {
 			promise2 = Promise start(this counter)
 			promise2 wait() . free()
 		})
+		this add("many promises", func {
+			list := VectorList<Promise> new()
+			list add(Promise start(this counter)) . add(Promise start(this counter)) . add(Promise start(this counter))
+			expect(Promise wait(list))
+			list free()
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #1906 

Allows us to simplify code like 

```ooc
promises: Promise[count]
for (i in 0 .. count)
   promises[i] = pool getPromise(f)
...
for (i in 0 .. count)
   promises[i] wait() . free()
promises free()
```

to

```ooc
promises := VectorList<Promise>
for (i in 0 .. count)
    promises add(threadPool getPromise(f))
...
Promise wait(promises)
promises free()
```
