### PR TITLE
Fixed toRaster for padded output buffers.

### DIFF
--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -31,9 +31,7 @@ OpenGLMonochrome: class extends OpenGLPacked {
 	toRasterDefault: override func ~target (target: RasterImage) {
 		packed := this context createRgba(IntVector2D new(this size x / 4, this size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
-		buffer := (target as RasterMonochrome) buffer
-		(packed as OpenGLPacked) readPixels(buffer)
-		packed free()
+		(packed as OpenGLPacked) readPixels(target as RasterPacked) . free()
 	}
 	create: override func (size: IntVector2D) -> This { this context createMonochrome(size) as This }
 	channelCount: static Int = 1

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -151,7 +151,7 @@ OpenGLPacked: abstract class extends GpuImage {
 		this _renderTarget clear()
 		this _renderTarget unbind()
 	}
-	readPixels: func (buffer: ByteBuffer) { this _renderTarget readPixels(buffer) }
+	readPixels: func (target: RasterPacked) { this _renderTarget readPixels(target) }
 	upload: override func (image: RasterImage) {
 		if (image instanceOf(RasterPacked)) {
 			raster := image as RasterPacked

--- a/source/draw/gpu/opengl/OpenGLRgba.ooc
+++ b/source/draw/gpu/opengl/OpenGLRgba.ooc
@@ -32,10 +32,7 @@ OpenGLRgba: class extends OpenGLPacked {
 		this toRasterDefault(result)
 		result
 	}
-	toRasterDefault: override func ~target (target: RasterImage) {
-		buffer := (target as RasterRgba) buffer
-		this readPixels(buffer)
-	}
+	toRasterDefault: override func ~target (target: RasterImage) { this readPixels(target as RasterPacked) }
 	create: override func (size: IntVector2D) -> This { this context createRgba(size) as This }
 	channelCount: static Int = 4
 }

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -33,9 +33,7 @@ OpenGLUv: class extends OpenGLPacked {
 	toRasterDefault: override func ~target (target: RasterImage) {
 		packed := this context createRgba(IntVector2D new(this size x / 2, this size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
-		buffer := (target as RasterUv) buffer
-		(packed as OpenGLPacked) readPixels(buffer)
-		packed free()
+		(packed as OpenGLPacked) readPixels(target as RasterPacked) . free()
 	}
 	create: override func (size: IntVector2D) -> This { this context createUv(size) as This }
 	channelCount: static Int = 2

--- a/source/draw/gpu/opengl/backend/GLFramebufferObject.ooc
+++ b/source/draw/gpu/opengl/backend/GLFramebufferObject.ooc
@@ -21,7 +21,7 @@ GLFramebufferObject: abstract class {
 	unbind: abstract func
 	clear: abstract func
 	setClearColor: abstract func (color: ColorRgba)
-	readPixels: abstract func (buffer: ByteBuffer)
+	readPixels: abstract func (target: RasterPacked)
 	invalidate: abstract func
 }
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3FramebufferObject.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3FramebufferObject.ooc
@@ -38,13 +38,17 @@ Gles3FramebufferObject: class extends GLFramebufferObject {
 		glClearColor(tuple a, tuple b, tuple c, tuple d)
 		version(debugGL) { validateEnd("FramebufferObject setClearColor") }
 	}
-	readPixels: override func (buffer: ByteBuffer) {
+	readPixels: override func (target: RasterPacked) {
+		//NOTE: Hard coded to read RGBA only due to driver limitations
 		version(debugGL) { validateStart("FramebufferObject readPixels") }
-		pointer := buffer pointer
 		this bind()
 		glPixelStorei(GL_PACK_ALIGNMENT, 1)
+		pixelStride := target stride / 4
+		if (pixelStride != this size x)
+			glPixelStorei(GL_PACK_ROW_LENGTH, pixelStride)
 		glReadBuffer(GL_COLOR_ATTACHMENT0)
-		glReadPixels(0, 0, this size x, this size y, GL_RGBA, GL_UNSIGNED_BYTE, pointer)
+		glReadPixels(0, 0, this size x, this size y, GL_RGBA, GL_UNSIGNED_BYTE, target buffer pointer)
+		glPixelStorei(GL_PACK_ROW_LENGTH, 0)
 		this unbind()
 		version(debugGL) { validateEnd("FramebufferObject readPixels") }
 	}


### PR DESCRIPTION
It is now possible to use glReadPixels to copy from texture to padded output buffer.

@davidpiuva peer review