### PR TITLE
Override list functions

### DIFF
--- a/source/math/BoolVectorList.ooc
+++ b/source/math/BoolVectorList.ooc
@@ -27,7 +27,7 @@ BoolVectorList: class extends VectorList<Bool> {
 			trues += (this[i] ? 1 : 0)
 		tallyTrues ? trues : this _count - trues
 	}
-	reverse: func -> This {
+	reverse: override func -> This {
 		super() as This
 	}
 	erosion: func (structuringElementSize: Int) -> This {

--- a/source/math/FloatComplexVectorList.ooc
+++ b/source/math/FloatComplexVectorList.ooc
@@ -57,7 +57,7 @@ FloatComplexVectorList: class extends VectorList<FloatComplex> {
 		result _count = this _count
 		result
 	}
-	copy: func -> This {
+	copy: override func -> This {
 		super() as This
 	}
 	addInto: func (other: This) {

--- a/source/math/FloatVectorList.ooc
+++ b/source/math/FloatVectorList.ooc
@@ -83,13 +83,13 @@ FloatVectorList: class extends VectorList<Float> {
 			result add(this[i] abs())
 		result
 	}
-	copy: func -> This {
+	copy: override func -> This {
 		result := This new(this _count)
 		for (i in 0 .. this _count)
 			result add(this[i])
 		result
 	}
-	reverse: func -> This {
+	reverse: override func -> This {
 		super() as This
 	}
 	addInto: func (other: This) {

--- a/source/math/IntVectorList.ooc
+++ b/source/math/IntVectorList.ooc
@@ -26,7 +26,7 @@ IntVectorList: class extends VectorList<Int> {
 		for (i in 0 .. capacity)
 			this add(value)
 	}
-	copy: func -> This {
+	copy: override func -> This {
 		super() as This
 	}
 	contains: func (value: Int) -> Bool {


### PR DESCRIPTION
`rock 1.0.22` will prohibit the use of `super()` in shadowed functions (functions not marked as override).
@marcusnaslund 