### PR TITLE
Profiler::benchmark() uses TimeSpan instead of double

### DIFF
--- a/source/base/Profiler.ooc
+++ b/source/base/Profiler.ooc
@@ -50,11 +50,11 @@ Profiler: class {
 		This _profilers free()
 		This _profilers = null
 	}
-	benchmark: static func (task: Func, timeoutMilliseconds := TimeSpan milliseconds(1000.0)) -> Double {
+	benchmark: static func (task: Func, timeout := TimeSpan milliseconds(1000.0)) -> Double {
 		numberOfIterations := 0
 		timer := WallTimer new()
 		totalTime := TimeSpan new(0)
-		while (totalTime < timeoutMilliseconds) {
+		while (totalTime < timeout) {
 			numberOfIterations += 1
 			timer start()
 			task()

--- a/source/base/Profiler.ooc
+++ b/source/base/Profiler.ooc
@@ -50,17 +50,18 @@ Profiler: class {
 		This _profilers free()
 		This _profilers = null
 	}
-	benchmark: static func (task: Func, timeoutMilliseconds := 1000.0) -> Double {
+	benchmark: static func (task: Func, timeoutMilliseconds := TimeSpan milliseconds(1000.0)) -> Double {
 		numberOfIterations := 0
 		timer := WallTimer new()
 		totalTime := TimeSpan new(0)
-		while (totalTime toMilliseconds() < timeoutMilliseconds) {
+		while (totalTime < timeoutMilliseconds) {
 			numberOfIterations += 1
 			timer start()
 			task()
 			totalTime += timer stop()
 		}
 		timer free()
+		(task as Closure) free(Owner Receiver)
 		totalTime toMilliseconds() / (numberOfIterations * 1000.0)
 	}
 	_logResults: static func (logMethod: Func (String)) {

--- a/test/base/ProfilerTest.ooc
+++ b/test/base/ProfilerTest.ooc
@@ -38,7 +38,7 @@ ProfilerTest: class extends Fixture {
 	_testBenchmark: static func {
 		slowTask := func { Time sleepMilli(1) }
 		fastTask := func
-		expect(Profiler benchmark(slowTask, 5), is greater than(Profiler benchmark(fastTask, 5)))
+		expect(Profiler benchmark(slowTask, TimeSpan milliseconds(5)), is greater than(Profiler benchmark(fastTask, TimeSpan milliseconds(5))))
 		(slowTask as Closure, fastTask as Closure) free()
 	}
 }


### PR DESCRIPTION
review @marcusnaslund 