### PR TITLE
Added target transform in DrawState

### DIFF
--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -150,11 +150,19 @@ DrawState: cover {
 		this
 	}
 	getTransformNormalized: func -> FloatTransform3D { this _transformNormalized }
-	setFlatTransform: func (flatTransform: FloatTransform2D) -> This {
+	setFlatTransformNormalized: func (flatTransform: FloatTransform2D) -> This {
 		this flatTransform = flatTransform
 		this
 	}
-	getFlatTransform: func -> FloatTransform2D { this flatTransform }
+	setFlatTransformReference: func ~ExplicitIntSize (flatTransform: FloatTransform2D, imageSize: IntVector2D) -> This {
+		this flatTransform = flatTransform referenceToNormalized(imageSize)
+		this
+	}
+	setFlatTransformReference: func ~ExplicitFloatSize (flatTransform: FloatTransform2D, imageSize: FloatVector2D) -> This {
+		this flatTransform = flatTransform referenceToNormalized(imageSize)
+		this
+	}
+	getFlatTransformNormalized: func -> FloatTransform2D { this flatTransform }
 	setOrigin: func (origin: FloatPoint2D) -> This {
 		this _originReference = origin
 		this

--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -36,6 +36,7 @@ DrawState: cover {
 	_destinationNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	_sourceNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	_focalLengthNormalized := 0.0f // Relative to image width
+	flatTransform := FloatTransform2D identity // 2D scaling done after projection matrix but before w division
 	init: func@ ~default
 	init: func@ ~target (=target)
 	setTarget: func (target: Image) -> This {
@@ -149,6 +150,11 @@ DrawState: cover {
 		this
 	}
 	getTransformNormalized: func -> FloatTransform3D { this _transformNormalized }
+	setFlatTransform: func (flatTransform: FloatTransform2D) -> This {
+		this flatTransform = flatTransform
+		this
+	}
+	getFlatTransform: func -> FloatTransform2D { this flatTransform }
 	setOrigin: func (origin: FloatPoint2D) -> This {
 		this _originReference = origin
 		this

--- a/source/draw/DrawState.ooc
+++ b/source/draw/DrawState.ooc
@@ -36,7 +36,7 @@ DrawState: cover {
 	_destinationNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	_sourceNormalized := FloatBox2D new(0.0f, 0.0f, 1.0f, 1.0f)
 	_focalLengthNormalized := 0.0f // Relative to image width
-	flatTransform := FloatTransform2D identity // 2D scaling done after projection matrix but before w division
+	targetTransform := FloatTransform2D identity // 2D scaling done after projection matrix but before w division
 	init: func@ ~default
 	init: func@ ~target (=target)
 	setTarget: func (target: Image) -> This {
@@ -150,19 +150,19 @@ DrawState: cover {
 		this
 	}
 	getTransformNormalized: func -> FloatTransform3D { this _transformNormalized }
-	setFlatTransformNormalized: func (flatTransform: FloatTransform2D) -> This {
-		this flatTransform = flatTransform
+	setTargetTransformNormalized: func (targetTransform: FloatTransform2D) -> This {
+		this targetTransform = targetTransform
 		this
 	}
-	setFlatTransformReference: func ~ExplicitIntSize (flatTransform: FloatTransform2D, imageSize: IntVector2D) -> This {
-		this flatTransform = flatTransform referenceToNormalized(imageSize)
+	setTargetTransformReference: func ~ExplicitIntSize (targetTransform: FloatTransform2D, imageSize: IntVector2D) -> This {
+		this targetTransform = targetTransform referenceToNormalized(imageSize)
 		this
 	}
-	setFlatTransformReference: func ~ExplicitFloatSize (flatTransform: FloatTransform2D, imageSize: FloatVector2D) -> This {
-		this flatTransform = flatTransform referenceToNormalized(imageSize)
+	setTargetTransformReference: func ~ExplicitFloatSize (targetTransform: FloatTransform2D, imageSize: FloatVector2D) -> This {
+		this targetTransform = targetTransform referenceToNormalized(imageSize)
 		this
 	}
-	getFlatTransformNormalized: func -> FloatTransform2D { this flatTransform }
+	getTargetTransformNormalized: func -> FloatTransform2D { this targetTransform }
 	setOrigin: func (origin: FloatPoint2D) -> This {
 		this _originReference = origin
 		this

--- a/source/draw/README.md
+++ b/source/draw/README.md
@@ -17,8 +17,8 @@ The destination is similar to the viewport by defining where to draw. The differ
 ## Transform
 Transform is the inverse camera matrix applied after the destination scaling.
 
-## FlatTransform
-FlatTransform can be used to translate and scale in image space. The difference from translating in camera space is that no parallax is applied because vertices at all depths moves equally in two dimensions. The center point of FlatTransform defines the center of perspective where no geometry is stretched from the planar projection.
+## TargetTransform
+TargetTransform can be used to translate and scale in image space. The difference from translating in camera space is that no parallax is applied because vertices at all depths moves equally in two dimensions. The center point of TargetTransform defines the center of perspective where no geometry is stretched from the planar projection.
 
 * This works as if the projection was applied after depth division by multiplying the projection matrix with a normalized translation. If we want to add a constant to something that will later be divided by depth then we simply add the constant multiplied by depth. For a perspective projection matrix, the translation will be multiplied by -Z and thereby tilt the Z axis. For an orthographic projection matrix, the translation will be multiplied by 1 as usual.
 
@@ -59,7 +59,7 @@ Using destination or transform on the CPU would require a rewrite of legacy draw
 | flipSourceY | X | X |  |
 | destination | X |  |  |
 | transform | X |  |  |
-| viewTransform | X |  |  |
+| targetTransform | X |  |  |
 | focalLength | X |  |  |
 | map | X |  |  |
 | mesh | X |  |  |

--- a/source/draw/README.md
+++ b/source/draw/README.md
@@ -17,6 +17,12 @@ The destination is similar to the viewport by defining where to draw. The differ
 ## Transform
 Transform is the inverse camera matrix applied after the destination scaling.
 
+## FlatTransform
+FlatTransform is applied after the projection matrix but before the hardware depth division for performance reasons.
+Scaling will scale vertex positions from the center of the target viewport.
+Translation is applied in a centered normalized scale from -1 to +1 as the standard projection space.
+Do not touch if you do not know how a projection matrix works since this is an advanced feature.
+
 ## Source
 The source is a subregion of the input image affecting generation of texture coordinates in the shader.
 
@@ -54,6 +60,7 @@ Using destination or transform on the CPU would require a rewrite of legacy draw
 | flipSourceY | X | X |  |
 | destination | X |  |  |
 | transform | X |  |  |
+| viewTransform | X |  |  |
 | focalLength | X |  |  |
 | map | X |  |  |
 | mesh | X |  |  |

--- a/source/draw/README.md
+++ b/source/draw/README.md
@@ -18,9 +18,9 @@ The destination is similar to the viewport by defining where to draw. The differ
 Transform is the inverse camera matrix applied after the destination scaling.
 
 ## TargetTransform
-TargetTransform can be used to translate and scale in image space. The difference from translating in camera space is that no parallax is applied because vertices at all depths moves equally in two dimensions. The center point of TargetTransform defines the center of perspective where no geometry is stretched from the planar projection.
+TargetTransform can be used to translate and scale in image space. The difference from translating in camera space is that no parallax is applied because vertices at all depths move equally in two dimensions. The center point of TargetTransform defines the center of perspective where no geometry is stretched from the planar projection.
 
-* This works as if the projection was applied after depth division by multiplying the projection matrix with a normalized translation. If we want to add a constant to something that will later be divided by depth then we simply add the constant multiplied by depth. For a perspective projection matrix, the translation will be multiplied by -Z and thereby tilt the Z axis. For an orthographic projection matrix, the translation will be multiplied by 1 as usual.
+This works as if the projection was applied after depth division by multiplying the projection matrix with a normalized translation. If we want to add a constant to something that will later be divided by depth then we simply add the constant multiplied by depth. For a perspective projection matrix, the translation will be multiplied by -Z and thereby tilt the Z axis. For an orthographic projection matrix, the translation will be multiplied by 1 as usual.
 
 ## Source
 The source is a subregion of the input image affecting generation of texture coordinates in the shader.

--- a/source/draw/README.md
+++ b/source/draw/README.md
@@ -18,10 +18,9 @@ The destination is similar to the viewport by defining where to draw. The differ
 Transform is the inverse camera matrix applied after the destination scaling.
 
 ## FlatTransform
-FlatTransform is applied after the projection matrix but before the hardware depth division for performance reasons.
-Scaling will scale vertex positions from the center of the target viewport.
-Translation is applied in a centered normalized scale from -1 to +1 as the standard projection space.
-Do not touch if you do not know how a projection matrix works since this is an advanced feature.
+FlatTransform can be used to translate and scale in image space. The difference from translating in camera space is that no parallax is applied because vertices at all depths moves equally in two dimensions. The center point of FlatTransform defines the center of perspective where no geometry is stretched from the planar projection.
+
+* This works as if the projection was applied after depth division by multiplying the projection matrix with a normalized translation. If we want to add a constant to something that will later be divided by depth then we simply add the constant multiplied by depth. For a perspective projection matrix, the translation will be multiplied by -Z and thereby tilt the Z axis. For an orthographic projection matrix, the translation will be multiplied by 1 as usual.
 
 ## Source
 The source is a subregion of the input image affecting generation of texture coordinates in the shader.

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -54,7 +54,7 @@ OpenGLPacked: abstract class extends GpuImage {
 		model := (drawState mesh) ? FloatTransform3D identity : this _createModelTransformNormalized(this size, drawState getDestinationNormalized(), focalLengthPerWidth * this size x)
 		view := (drawState mesh) ? FloatTransform3D identity : this _createView(targetSize, drawState getTransformNormalized())
 		projection := this _createProjection(targetSize, focalLengthPerWidth)
-		flat := drawState getFlatTransformNormalized()
+		flat := drawState getTargetTransformNormalized()
 		textureTransform := This _createTextureTransform(drawState getSourceNormalized(), drawState flipSourceX, drawState flipSourceY)
 		match (drawState blendMode) {
 			case BlendMode Add =>

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -54,6 +54,7 @@ OpenGLPacked: abstract class extends GpuImage {
 		model := (drawState mesh) ? FloatTransform3D identity : this _createModelTransformNormalized(this size, drawState getDestinationNormalized(), focalLengthPerWidth * this size x)
 		view := (drawState mesh) ? FloatTransform3D identity : this _createView(targetSize, drawState getTransformNormalized())
 		projection := this _createProjection(targetSize, focalLengthPerWidth)
+		flat := drawState getFlatTransform()
 		textureTransform := This _createTextureTransform(drawState getSourceNormalized(), drawState flipSourceX, drawState flipSourceY)
 		match (drawState blendMode) {
 			case BlendMode Add =>
@@ -84,7 +85,7 @@ OpenGLPacked: abstract class extends GpuImage {
 					gpuMap add("texture0", image)
 			}
 		}
-		gpuMap useProgram(this, projection * view * model, textureTransform)
+		gpuMap useProgram(this, flat * projection * view * model, textureTransform)
 		this _renderTarget bind()
 		if (drawState mesh)
 			drawState mesh draw()

--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -54,7 +54,7 @@ OpenGLPacked: abstract class extends GpuImage {
 		model := (drawState mesh) ? FloatTransform3D identity : this _createModelTransformNormalized(this size, drawState getDestinationNormalized(), focalLengthPerWidth * this size x)
 		view := (drawState mesh) ? FloatTransform3D identity : this _createView(targetSize, drawState getTransformNormalized())
 		projection := this _createProjection(targetSize, focalLengthPerWidth)
-		flat := drawState getFlatTransform()
+		flat := drawState getFlatTransformNormalized()
 		textureTransform := This _createTextureTransform(drawState getSourceNormalized(), drawState flipSourceX, drawState flipSourceY)
 		match (drawState blendMode) {
 			case BlendMode Add =>


### PR DESCRIPTION
The math is quite messy but it looks correct because a projection matrix does not set the w axis like a regular translation point. Translation in 3D is usually done by multiplying the constant one with x, y, z in the w axis so that the new translation is multiplied by one and simply added to the previous translation. The projection matrix does not have that constant one, so translation is instead applied to the tilt of the Z axis expressed in normalized space.
