### PR TITLE
Runtime GPU check

### DIFF
--- a/source/draw/gpu/GpuContext.ooc
+++ b/source/draw/gpu/GpuContext.ooc
@@ -14,7 +14,6 @@ use concurrent
 import DrawContext
 import GpuImage, Map, GpuYuv420Semiplanar, Mesh
 
-version(!gpuOff) {
 ToRasterFuture: class extends Future<RasterImage> {
 	_result: RasterImage
 	init: func (=_result) {
@@ -34,7 +33,10 @@ ToRasterFuture: class extends Future<RasterImage> {
 
 GpuContext: abstract class extends DrawContext {
 	defaultMap ::= null as Map
-	init: func
+	init: func {
+		version(gpuOff)
+			raise("Creating GpuContext without GPU")
+	}
 	createMonochrome: abstract func (size: IntVector2D) -> GpuImage
 	createRgb: abstract func (size: IntVector2D) -> GpuImage
 	createRgba: abstract func (size: IntVector2D) -> GpuImage
@@ -54,5 +56,4 @@ GpuContext: abstract class extends DrawContext {
 		Promise empty
 	}
 	toRasterAsync: virtual func (source: GpuImage) -> ToRasterFuture { raise("toRasterAsync unimplemented"); null }
-}
 }

--- a/source/draw/gpu/GpuContext.ooc
+++ b/source/draw/gpu/GpuContext.ooc
@@ -35,7 +35,7 @@ GpuContext: abstract class extends DrawContext {
 	defaultMap ::= null as Map
 	init: func {
 		version(gpuOff)
-			raise("Creating GpuContext without GPU")
+			Debug error("Creating GpuContext without GPU")
 	}
 	createMonochrome: abstract func (size: IntVector2D) -> GpuImage
 	createRgb: abstract func (size: IntVector2D) -> GpuImage

--- a/source/draw/gpu/GpuImage.ooc
+++ b/source/draw/gpu/GpuImage.ooc
@@ -12,7 +12,6 @@ use base
 use concurrent
 import GpuContext
 
-version(!gpuOff) {
 GpuImage: abstract class extends Image {
 	_context: GpuContext
 	_defaultMap: Map
@@ -35,5 +34,4 @@ GpuImage: abstract class extends Image {
 	toRasterAsync: func -> ToRasterFuture { this _context toRasterAsync(this) }
 	toRasterDefault: abstract func -> RasterImage
 	toRasterDefault: abstract func ~target (target: RasterImage)
-}
 }

--- a/source/draw/gpu/GpuYuv420Semiplanar.ooc
+++ b/source/draw/gpu/GpuYuv420Semiplanar.ooc
@@ -10,7 +10,6 @@ use geometry
 use draw
 import GpuContext, GpuImage
 
-version(!gpuOff) {
 GpuYuv420Semiplanar: class extends GpuImage {
 	_y: GpuImage
 	_uv: GpuImage
@@ -101,5 +100,4 @@ GpuYuv420Semiplanar: class extends GpuImage {
 		this _toRgbaAuxiliary(target)
 		target
 	}
-}
 }


### PR DESCRIPTION
Instead of not being able to mention a GPU type without getting a compiler error in -DgpuOff, it is now possible to mention the generic GPU types in -DgpuOff as long as no GpuContext is being created and no internal OpenGL types are mentioned.

When no GpuContext can be created without a GPU, no GpuImage can be created without a GPU because a context is needed for creation.