### PR TITLE
Removed dead code from GpuImage

### DIFF
--- a/source/draw/gpu/GpuImage.ooc
+++ b/source/draw/gpu/GpuImage.ooc
@@ -15,9 +15,7 @@ import GpuContext
 GpuImage: abstract class extends Image {
 	_context: GpuContext
 	filter: Bool { get set }
-	init: func (size: IntVector2D, =_context) {
-		super(size)
-	}
+	init: func (size: IntVector2D, =_context) { super(size) }
 	resizeTo: override func (size: IntVector2D) -> This {
 		result := this create(size) as This
 		DrawState new(result) setInputImage(this) draw()

--- a/source/draw/gpu/GpuImage.ooc
+++ b/source/draw/gpu/GpuImage.ooc
@@ -14,12 +14,9 @@ import GpuContext
 
 GpuImage: abstract class extends Image {
 	_context: GpuContext
-	_defaultMap: Map
-	_getDefaultMap: virtual func (image: Image) -> Map { this _defaultMap }
 	filter: Bool { get set }
 	init: func (size: IntVector2D, =_context) {
 		super(size)
-		this _defaultMap = this _context defaultMap
 	}
 	resizeTo: override func (size: IntVector2D) -> This {
 		result := this create(size) as This


### PR DESCRIPTION
Dead code that should have been removed when DrawState replaced surface and canvas almost a year ago.