### PR TITLE
Fixed EGLYuv recycling

### DIFF
--- a/source/draw/gpu/opengl/EGLYuv.ooc
+++ b/source/draw/gpu/opengl/EGLYuv.ooc
@@ -15,9 +15,10 @@ import backend/[GLTexture, EGLImage]
 
 version(!gpuOff) {
 EGLYuv: class extends OpenGLPacked {
-	_nativeBuffer: Pointer
-	nativeBuffer ::= this _nativeBuffer
+	_handle: Pointer
+	handle ::= this _handle
 	init: func (_buffer: GraphicBuffer, context: OpenGLContext) {
+		_handle = _buffer handle
 		super(EGLImage create(TextureType External, _buffer size, _buffer nativeBuffer, context backend), 3, context)
 	}
 	toRasterDefault: override func -> RasterImage { Debug error("toRasterDefault unimplemented for EGLYuv"); null }

--- a/source/draw/gpu/opengl/EGLYuv.ooc
+++ b/source/draw/gpu/opengl/EGLYuv.ooc
@@ -17,11 +17,11 @@ version(!gpuOff) {
 EGLYuv: class extends OpenGLPacked {
 	_handle: Pointer
 	handle ::= this _handle
-	init: func (_buffer: GraphicBuffer, context: OpenGLContext) {
-		_handle = _buffer handle
-		super(EGLImage create(TextureType External, _buffer size, _buffer nativeBuffer, context backend), 3, context)
+	init: func (buffer: GraphicBuffer, context: OpenGLContext) {
+		this _handle = buffer handle
+		super(EGLImage create(TextureType External, buffer size, buffer nativeBuffer, context backend), 3, context)
 	}
 	toRasterDefault: override func -> RasterImage { Debug error("toRasterDefault unimplemented for EGLYuv"); null }
-	toRasterDefault: override func ~target (target: RasterImage) { Debug error("toRasterDefault~target unimplemented for EGLYuv"); null }
+	toRasterDefault: override func ~target (target: RasterImage) { Debug error("toRasterDefault~target unimplemented for EGLYuv") }
 }
 }

--- a/source/draw/gpu/opengl/YuvExtensionContext.ooc
+++ b/source/draw/gpu/opengl/YuvExtensionContext.ooc
@@ -72,7 +72,7 @@ YuvExtensionContext: class extends OpenGLContext {
 			this createEGLYuv(image as GraphicBufferYuv420Semiplanar) free()
 	}
 	createEGLYuv: func (source: GraphicBufferYuv420Semiplanar) -> EGLYuv {
-		this _eglBin search(|eglYuv| source buffer nativeBuffer == eglYuv nativeBuffer) ?? EGLYuv new(source buffer, this)
+		this _eglBin search(|eglYuv| source buffer handle == eglYuv handle) ?? EGLYuv new(source buffer, this)
 	}
 	recycle: override func (image: OpenGLPacked) {
 		match (image) {


### PR DESCRIPTION
Recycling was previously done on the native buffer window instead of the buffer handle. This caused the recyle bin to get full immediately

review and verify I am not doing something stupid now, i guess there was some reason for using the nativeBuffer to begin with but I cannot remember the details though @emilwestergren 