### PR TITLE
VectorList resizes by *2

### DIFF
--- a/source/system/structs/Vector.ooc
+++ b/source/system/structs/Vector.ooc
@@ -12,9 +12,7 @@ Vector: abstract class <T> {
 	_freeContent: Bool
 	capacity ::= this _capacity
 	init: func ~preallocated (=_backend, =_capacity, freeContent := true)
-	init: func (=_capacity, freeContent := true) {
-		this _freeContent = freeContent
-	}
+	init: func (=_capacity, freeContent := true) { this _freeContent = freeContent }
 	free: override func {
 		memfree(this _backend)
 		super()

--- a/source/system/structs/Vector.ooc
+++ b/source/system/structs/Vector.ooc
@@ -33,6 +33,9 @@ Vector: abstract class <T> {
 		else if (capacity > this capacity)
 			this _capacity = capacity
 	}
+	grow: func {
+		this resize(this capacity < 512 ? this capacity * 2 : this capacity + 512)
+	}
 	move: func (sourceStart, targetStart: Int, capacity := 0) {
 		if (capacity < 1)
 			capacity = this capacity - sourceStart

--- a/source/system/structs/VectorList.ooc
+++ b/source/system/structs/VectorList.ooc
@@ -23,7 +23,7 @@ VectorList: class <T> extends List<T> {
 	}
 	add: override func (item: T) {
 		if (this _vector capacity <= this _count)
-			this _vector resize(this _vector capacity * 2)
+			this _vector grow()
 		this _vector[this _count] = item
 		this _count += 1
 	}
@@ -36,7 +36,7 @@ VectorList: class <T> extends List<T> {
 	}
 	insert: override func (index: Int, item: T) {
 		if (this _vector capacity <= this _count)
-			this _vector resize(this _vector capacity * 2)
+			this _vector grow()
 		this _vector copy(index, index + 1)
 		this _vector[index] = item
 		this _count += 1

--- a/source/system/structs/VectorList.ooc
+++ b/source/system/structs/VectorList.ooc
@@ -13,7 +13,7 @@ VectorList: class <T> extends List<T> {
 		this init(32)
 	}
 	init: func ~heap (capacity: Int, freeContent := true) {
-		this init(HeapVector<T> new(capacity, freeContent))
+		this init(HeapVector<T> new(1 maximum(capacity), freeContent))
 	}
 	init: func (=_vector)
 	free: override func {
@@ -23,7 +23,7 @@ VectorList: class <T> extends List<T> {
 	}
 	add: override func (item: T) {
 		if (this _vector capacity <= this _count)
-			this _vector resize(this _vector capacity + 8)
+			this _vector resize(this _vector capacity * 2)
 		this _vector[this _count] = item
 		this _count += 1
 	}
@@ -36,7 +36,7 @@ VectorList: class <T> extends List<T> {
 	}
 	insert: override func (index: Int, item: T) {
 		if (this _vector capacity <= this _count)
-			this _vector resize(this _vector capacity + 8)
+			this _vector resize(this _vector capacity * 2)
 		this _vector copy(index, index + 1)
 		this _vector[index] = item
 		this _count += 1


### PR DESCRIPTION
Fixes #1980 

We have to enforce a positive size in the constructor, the other project is creating a 0 size list sometimes. That's probably a bug and should be fixed, but this seems like a smart fix anyway.

Otherwise seems to work well, we make a lot fewer resizes and `test` runtimes are not affected.