### PR TITLE
Fixed pointer-to-int cast

### DIFF
--- a/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
@@ -47,7 +47,7 @@ Gles3Fence: class extends GLFence {
 		if (this _backend != null)
 			glDeleteSync(this _backend)
 		this _backend = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
-		version(debugGL) { if (this _backend as Int == 0) Debug print("glFenceSync failed!") }
+		version(debugGL) { if (this _backend != null) Debug print("glFenceSync failed!") }
 		version(debugGL) { validateEnd("Fence sync") }
 	}
 }


### PR DESCRIPTION
This cast throws a warning, which PRInt won't accept.
Is there a reason why we can't compare directly with null? @erikhagglund @emilwestergren 