### PR TITLE
Free static array in GlobalCleanup

### DIFF
--- a/source/draw/gpu/opengl/GraphicBuffer.ooc
+++ b/source/draw/gpu/opengl/GraphicBuffer.ooc
@@ -100,3 +100,5 @@ GraphicBuffer: class {
 		result
 	}
 }
+
+GlobalCleanup register(|| GraphicBuffer _alignedWidth free(), 10)


### PR DESCRIPTION
This particular array cause no memory leak, but is visible in the `still reachable` section when running valgrind. @sebastianbaginski 