### PR TITLE
More sense among DebugLevels

### DIFF
--- a/source/base/Debug.ooc
+++ b/source/base/Debug.ooc
@@ -9,35 +9,39 @@
 import io/FileWriter
 
 DebugLevel: enum {
-	Everything
+	Verbose
 	Debug
-	Notification
+	Info
 	Warning
-	Recoverable
-	Message
-	Critical
+	Error
+	Fatal
+	Silent
 }
 
 Debug: class {
-	_level: static DebugLevel = DebugLevel Everything
+	_level: static DebugLevel = DebugLevel Verbose
+	level: static DebugLevel {
+		get { This _level }
+		set (value) { This _level = value }
+	}
 	_printFunction: static Func (String) = func (s: String) { println(s) }
 	initialize: static func (f: Func (String)) {
 		(This _printFunction as Closure) free()
 		This _printFunction = f
 	}
-	print: static func (string: String, level := DebugLevel Everything) {
-		if (This _level == level || This _level == DebugLevel Everything)
+	print: static func (string: String, level := DebugLevel Debug) {
+		if (level as Int >= This _level as Int && This _level != DebugLevel Silent)
 			This _printFunction(string)
 	}
-	print: static func ~free (string: String, level := DebugLevel Everything) {
+	print: static func ~free (string: String, level := DebugLevel Debug) {
 		This print(string, level)
 		string free()
 	}
 	error: static func (message: String, origin: Class = null) {
 		if (origin)
-			This print~free("%s: %s" format(origin name toCString(), message))
+			This print~free("%s: %s" format(origin name toCString(), message), DebugLevel Fatal)
 		else
-			This print(message)
+			This print(message, DebugLevel Fatal)
 		raise(message, origin)
 	}
 	error: static func ~assert (condition: Bool, message: String, origin: Class = null) {

--- a/test/base/DebugTest.ooc
+++ b/test/base/DebugTest.ooc
@@ -11,6 +11,7 @@ use unit
 
 DebugTest: class extends Fixture {
 	outputString: String = null
+	oldLevel: DebugLevel
 
 	init: func {
 		super("Debug")
@@ -19,21 +20,22 @@ DebugTest: class extends Fixture {
 				this outputString free()
 			this outputString = message clone()
 		})
-		Debug _level = DebugLevel Everything
+		this oldLevel = Debug level
+		Debug _level = DebugLevel Verbose
 
 		this add("test print", func {
-			Debug print("first", DebugLevel Everything)
+			Debug print("first", DebugLevel Verbose)
 			expect(this outputString, is equal to("first"))
 			Debug print("second", DebugLevel Warning)
 			expect(this outputString, is equal to("second"))
-			Debug print("third", DebugLevel Everything)
+			Debug print("third", DebugLevel Verbose)
 			expect(this outputString, is equal to("third"))
 		})
 		this add("higher level", func {
 			Debug _level = DebugLevel Warning
-			Debug print("first", DebugLevel Warning)
+			Debug print("first", DebugLevel Error)
 			expect(this outputString, is equal to("first"))
-			Debug print("second", DebugLevel Notification)
+			Debug print("second", DebugLevel Info)
 			expect(this outputString, is equal to("first"))
 		})
 		this add("test error", func {
@@ -48,6 +50,7 @@ DebugTest: class extends Fixture {
 		})
 	}
 	free: override func {
+		Debug level = this oldLevel
 		this outputString free()
 		super()
 	}


### PR DESCRIPTION
- Changed states to mimic LogCat types and order.
- Changed `print` to print out everything with *at least* the set level, not just the current level. Except `Silent`.
- `error()` prints message with `Fatal` level

A later PR will allow `test.sh` (and maybe `build.sh` in other projects?) to select which level is default - which will help clean up debug output from tests. Default could be `Error` and the nightly test can run with a lower level.

Peer review @sebastianbaginski @erikhagglund 