### PR TITLE
Adapt to rock 1.0.22

### DIFF
--- a/source/system/Memory.ooc
+++ b/source/system/Memory.ooc
@@ -66,6 +66,9 @@ GlobalCleanup: class {
 			(This _functionPointers, This _priorities) = (null, null)
 		}
 	}
+	// Since we want to support unload/reload of modules and Memory should be unloaded last,
+	// rock will not emit calls to Memory_unload(), so we must call it manually.
+	// GlobalCleanup unload() should be the last instruction before we enter the de-initialized state.
 	unload: static func {
 		This run()
 		Memory_unload()

--- a/source/system/Memory.ooc
+++ b/source/system/Memory.ooc
@@ -23,6 +23,8 @@ memcpy: extern func (Pointer, Pointer, SizeT)
 memfree: extern (free) func (Pointer)
 alloca: extern func (SizeT) -> Pointer
 
+Memory_unload: extern func
+
 // Used for executing any/all cleanup (free~all) functions before program exit
 // Default priority is 0 and will be executed first, then 1, 2, 3... etc.
 GlobalCleanup: class {
@@ -63,5 +65,9 @@ GlobalCleanup: class {
 			(This _functionPointers, This _priorities) free()
 			(This _functionPointers, This _priorities) = (null, null)
 		}
+	}
+	unload: static func {
+		This run()
+		Memory_unload()
 	}
 }

--- a/source/system/string/string_literal.c
+++ b/source/system/string/string_literal.c
@@ -7,9 +7,10 @@
 #if defined(__WIN32__) || defined(__WIN64__)
 
 typedef HANDLE mutex_t;
+static HANDLE mutex_init() { return CreateMutex(NULL, FALSE, NULL); }
 static void mutex_lock(mutex_t* m) {
 	if (*m == NULL) {
-		HANDLE mutex = CreateMutex(NULL, FALSE, NULL);
+		HANDLE mutex = mutex_init();
 		if (InterlockedCompareExchangePointer(m, mutex, NULL) != NULL)
 			CloseHandle(mutex);
 	}

--- a/source/system/string/string_literal.c
+++ b/source/system/string/string_literal.c
@@ -7,7 +7,6 @@
 #if defined(__WIN32__) || defined(__WIN64__)
 
 typedef HANDLE mutex_t;
-#define MUTEX_INIT NULL
 static void mutex_lock(mutex_t* m) {
 	if (*m == NULL) {
 		HANDLE mutex = CreateMutex(NULL, FALSE, NULL);

--- a/source/system/string/string_literal.c
+++ b/source/system/string/string_literal.c
@@ -25,6 +25,7 @@ typedef pthread_mutex_t mutex_t;
 static void mutex_lock(mutex_t* m) { pthread_mutex_lock(m); }
 static void mutex_unlock(mutex_t* m) { pthread_mutex_unlock(m); }
 static void mutex_free(mutex_t*  m) { pthread_mutex_destroy(m); }
+static void mutex_init(mutex_t* m) { pthread_mutex_init(m, NULL); }
 
 #endif
 
@@ -68,5 +69,8 @@ void string_literal_free_all() {
 		_literalsCount = 0;
 		_literals = 0;
 		mutex_free(&_literalsMutex);
+		// Since it is possible to put a ooc program in an unloaded state and then reinitialize it without terminating it,
+		// we must reinitialize the mutex here in order to ensure its validity *before* any modules are reloaded.
+		mutex_init(&_literalsMutex);
 	}
 }

--- a/source/system/string/string_literal.c
+++ b/source/system/string/string_literal.c
@@ -7,10 +7,11 @@
 #if defined(__WIN32__) || defined(__WIN64__)
 
 typedef HANDLE mutex_t;
-static HANDLE mutex_init() { return CreateMutex(NULL, FALSE, NULL); }
+static void mutex_init(mutex_t *m) { *m = CreateMutex(NULL, FALSE, NULL); }
 static void mutex_lock(mutex_t* m) {
 	if (*m == NULL) {
-		HANDLE mutex = mutex_init();
+		HANDLE mutex = NULL;
+		mutex_init(&mutex);
 		if (InterlockedCompareExchangePointer(m, mutex, NULL) != NULL)
 			CloseHandle(mutex);
 	}


### PR DESCRIPTION
Regarding **`GlobalCleanup unload()`**
Since we want to support unload/reload of modules and `Memory` must be unloaded last, rock will not emit calls to `Memory_unload()`, so we must call it manually. `GlobalCleanup unload()` should be the last instruction before we enter the de-initialized state.

@sebastianbaginski review