### PR TITLE
Compile-time debug output

### DIFF
--- a/source/system/Debug.ooc
+++ b/source/system/Debug.ooc
@@ -19,7 +19,7 @@ DebugLevel: enum {
 }
 
 Debug: class {
-	_level: static DebugLevel = DebugLevel Verbose
+	_level: static DebugLevel = DebugLevel Debug
 	level: static DebugLevel {
 		get { This _level }
 		set (value) { This _level = value }
@@ -54,3 +54,18 @@ Debug: class {
 }
 
 GlobalCleanup register(|| Debug free~all())
+
+version (debugLevelVerbose)
+	Debug level = DebugLevel Verbose
+version (debugLevelDebug)
+	Debug level = DebugLevel Debug
+version (debugLevelInfo)
+	Debug level = DebugLevel Info
+version (debugLevelWarning)
+	Debug level = DebugLevel Warning
+version (debugLevelError)
+	Debug level = DebugLevel Error
+version (debugLevelFatal)
+	Debug level = DebugLevel Fatal
+version (debugLevelSilent)
+	Debug level = DebugLevel Silent


### PR DESCRIPTION
Added version blocks to set `Debug level` at compile time. Please suggest better names if you have any. The order is so that a lower level overrides a higher one, so that calling `./test.sh -DdebugOutputVerbose` will print everything, and the last one is silent so that `-DdebugOutputSilent` will override any flags and be silent.

Also set the default level in `test.sh`. Would prefer to not have `Fatal` as the default, perhaps, but having another level will mean calling the script with `fatal` flag doesn't change anything... not without much more bash wizardry anyway.

Comments @sebastianbaginski ?