### PR TITLE
Fixing weird tilting bug

### DIFF
--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -140,7 +140,7 @@ RasterPacked: abstract class extends RasterImage {
 	asRasterPacked: func (other: This) -> This { other }
 	save: override func (filename: String) -> Int {
 		File createParentDirectories(filename)
-		StbImage writePng(filename, this size x, this size y, this bytesPerPixel, this buffer pointer, this size x * this bytesPerPixel)
+		StbImage writePng(filename, this size x, this size y, this bytesPerPixel, this buffer pointer, this stride)
 	}
 	swapChannels: func (first, second: Int) {
 		version(safe)

--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -24,7 +24,7 @@ OpenGLMonochrome: class extends OpenGLPacked {
 		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage {
-		stride := ((this size x + 3) / 4) * 4
+		stride := this size x align(4)
 		result := RasterMonochrome new(this size, stride)
 		this toRasterDefault(result)
 		result

--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -24,12 +24,13 @@ OpenGLMonochrome: class extends OpenGLPacked {
 		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage {
-		result := RasterMonochrome new(this size)
+		stride := ((this size x + 3) / 4) * 4
+		result := RasterMonochrome new(this size, stride)
 		this toRasterDefault(result)
 		result
 	}
 	toRasterDefault: override func ~target (target: RasterImage) {
-		packed := this context createRgba(IntVector2D new(this size x / 4, this size y))
+		packed := this context createRgba(IntVector2D new(target stride / 4, target size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
 		(packed as OpenGLPacked) readPixels(target as RasterPacked) . free()
 	}

--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -29,6 +29,7 @@ OpenGLMonochrome: class extends OpenGLPacked {
 		this toRasterDefault(result)
 		result
 	}
+	// Precondition: target stride is a multiple of 4 bytes to allow packing into RGBA with even rows
 	toRasterDefault: override func ~target (target: RasterImage) {
 		if (target stride % 4 != 0)
 			Debug error("toRasterDefault requires a target stride in multiples of 4 bytes!")

--- a/source/draw/gpu/opengl/OpenGLMonochrome.ooc
+++ b/source/draw/gpu/opengl/OpenGLMonochrome.ooc
@@ -30,6 +30,8 @@ OpenGLMonochrome: class extends OpenGLPacked {
 		result
 	}
 	toRasterDefault: override func ~target (target: RasterImage) {
+		if (target stride % 4 != 0)
+			Debug error("toRasterDefault requires a target stride in multiples of 4 bytes!")
 		packed := this context createRgba(IntVector2D new(target stride / 4, target size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
 		(packed as OpenGLPacked) readPixels(target as RasterPacked) . free()

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -26,7 +26,7 @@ OpenGLUv: class extends OpenGLPacked {
 		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage {
-		stride := ((this size x * 2 + 3) / 4) * 4
+		stride := (this size x * 2) align(4)
 		result := RasterUv new(this size, stride)
 		this toRasterDefault(result)
 		result

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -26,12 +26,13 @@ OpenGLUv: class extends OpenGLPacked {
 		this init(rasterImage size, rasterImage stride, rasterImage buffer pointer, context)
 	}
 	toRasterDefault: override func -> RasterImage {
-		result := RasterUv new(this size)
+		stride := ((this size x * 2 + 3) / 4) * 4
+		result := RasterUv new(this size, stride)
 		this toRasterDefault(result)
 		result
 	}
 	toRasterDefault: override func ~target (target: RasterImage) {
-		packed := this context createRgba(IntVector2D new(this size x / 2, this size y))
+		packed := this context createRgba(IntVector2D new(target stride / 4, target size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
 		(packed as OpenGLPacked) readPixels(target as RasterPacked) . free()
 	}

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -31,6 +31,7 @@ OpenGLUv: class extends OpenGLPacked {
 		this toRasterDefault(result)
 		result
 	}
+	// Precondition: target stride is a multiple of 4 bytes to allow packing into RGBA with even rows
 	toRasterDefault: override func ~target (target: RasterImage) {
 		if (target stride % 4 != 0)
 			Debug error("toRasterDefault requires a target stride in multiples of 4 bytes!")

--- a/source/draw/gpu/opengl/OpenGLUv.ooc
+++ b/source/draw/gpu/opengl/OpenGLUv.ooc
@@ -32,6 +32,8 @@ OpenGLUv: class extends OpenGLPacked {
 		result
 	}
 	toRasterDefault: override func ~target (target: RasterImage) {
+		if (target stride % 4 != 0)
+			Debug error("toRasterDefault requires a target stride in multiples of 4 bytes!")
 		packed := this context createRgba(IntVector2D new(target stride / 4, target size y))
 		this context packToRgba(this, packed, IntBox2D new(packed size))
 		(packed as OpenGLPacked) readPixels(target as RasterPacked) . free()

--- a/test/draw/gpu/BlitTest.ooc
+++ b/test/draw/gpu/BlitTest.ooc
@@ -23,6 +23,15 @@ BlitTest: class extends Fixture {
 		<X****XXX>
 		<XXXXXXXX>"
 	)
+	unalignedSourceImage := RasterMonochrome fromAscii(
+		"< *X>
+		<XXXXXXXX  >
+		<X*    *X  >
+		<X*    *X  >
+		<X*   XXX  >
+		<X****XXX  >
+		<XXXXXXXX  >"
+	)
 	init: func {
 		super("BlitTest")
 		this add("Blit inside", func {
@@ -39,6 +48,22 @@ BlitTest: class extends Fixture {
 				<                >"
 			)
 			this testOffset(this sourceImage, correctImage, IntVector2D new(3, 2))
+			correctImage free()
+		})
+		this add("Unaligned", func {
+			correctImage := RasterMonochrome fromAscii(
+				"< *X>
+				<               >
+				<               >
+				<   XXXXXXXX    >
+				<   X*    *X    >
+				<   X*    *X    >
+				<   X*   XXX    >
+				<   X****XXX    >
+				<   XXXXXXXX    >
+				<               >"
+			)
+			this testOffset(this unalignedSourceImage, correctImage, IntVector2D new(3, 2))
 			correctImage free()
 		})
 		this add("Blit upper left", func {
@@ -80,7 +105,7 @@ BlitTest: class extends Fixture {
 		(resultCpu, resultGpu, resultCpuFromGpu) free()
 	}
 	free: override func {
-		this sourceImage free()
+		(this sourceImage, this unalignedSourceImage) free()
 		super()
 	}
 }


### PR DESCRIPTION
Packing to RGBA causes some problems when small test images are not aligned to 4 bytes like most videos are.