### PR TITLE
Removed use of invalidate.

### DIFF
--- a/source/draw/gpu/opengl/OpenGLPacked.ooc
+++ b/source/draw/gpu/opengl/OpenGLPacked.ooc
@@ -157,9 +157,6 @@ OpenGLPacked: abstract class extends GpuImage {
 			this _backend upload(raster buffer pointer, raster stride)
 		}
 	}
-	onRecycle: func {
-		this referenceCount reset()
-		this _renderTarget invalidate()
-	}
+	onRecycle: func { this referenceCount reset() }
 }
 }


### PR DESCRIPTION
This causes OpenGL errors on some NVIDIA drivers so I will disable it until we can fix the error and also prove that it makes any difference.
@erikhagglund peer review