### PR TITLE
moved close function from FileUnix to unistd

### DIFF
--- a/source/system/external/unistd.ooc
+++ b/source/system/external/unistd.ooc
@@ -27,3 +27,6 @@ isatty: extern func (fd: Int) -> Int
 gethostname: extern func (localSystemName: CString, localSystemNameLength: SizeT) -> Int
 sysconf: extern func (Int) -> Long
 usleep: extern func (UInt)
+version (unix || apple) {
+close: extern func (Int) -> Int
+}

--- a/source/system/native/FileUnix.ooc
+++ b/source/system/native/FileUnix.ooc
@@ -62,7 +62,6 @@ lstat: extern func (CString, FileStat*) -> Int
 fstat: extern func (Int, FileStat*) -> Int
 chmod: extern func (CString, ModeT) -> Int
 fchmod: extern func (Int, ModeT) -> Int
-close: extern func (Int) -> Int
 _mkdir: extern (mkdir) func (CString, ModeT) -> Int
 _mkfifo: extern (mkfifo) func (CString, ModeT) -> Int
 umask: extern func (ModeT) -> ModeT


### PR DESCRIPTION
In order to expose `close`