### PR TITLE
Now flushing after glFenceSync

### DIFF
--- a/source/draw/gpu/opengl/backend/EGLNativeFence.ooc
+++ b/source/draw/gpu/opengl/backend/EGLNativeFence.ooc
@@ -8,7 +8,7 @@
 
 use base
 import egl/egl
-import GLExtensions, GLFence, gles3/Gles3Debug
+import GLExtensions, GLFence, gles3/Gles3Debug, gles3/external/gles3
 
 version(!gpuOff) {
 EGLNativeFence: class extends GLFence {
@@ -23,6 +23,8 @@ EGLNativeFence: class extends GLFence {
 	sync: override func {
 		version(debugGL) { validateStart("EGLNativeFence eglCreateSyncKHR") }
 		this _backend = GLExtensions eglCreateSyncKHR(this _display, EGL_SYNC_NATIVE_FENCE_ANDROID, null as Int*)
+		// Need to flush the eglCreateSyncKHR command when wait is done in other context
+		glFlush()
 		version(debugGL) { validateEnd("EGLNativeFence eglCreateSyncKHR") }
 	}
 	clientWait: override func (timeout: ULong = ULong maximumValue) -> Bool {

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
@@ -48,6 +48,8 @@ Gles3Fence: class extends GLFence {
 			glDeleteSync(this _backend)
 		this _backend = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
 		version(debugGL) { if (this _backend == null) Debug print("glFenceSync failed!") }
+		// Need to flush the glFenceSync command when wait is done in other context
+		glFlush()
 		version(debugGL) { validateEnd("Fence sync") }
 	}
 }


### PR DESCRIPTION
4.1.2 Signaling
Footnote 3: The simple flushing behavior defined by SYNC_FLUSH_COMMANDS_BIT
will not help when waiting for a fence command issued in another context’s
command stream to complete. Applications which block on a fence sync object
must take additional steps to assure that the context from which the
corresponding fence command was issued has flushed that command to the
graphics pipeline.