### PR TITLE
Reimplemented gpuOff.

### DIFF
--- a/source/draw/gpu/opengl/OpenGLPromise.ooc
+++ b/source/draw/gpu/opengl/OpenGLPromise.ooc
@@ -22,9 +22,8 @@ OpenGLPromise: class extends Promise {
 	}
 	sync: func { this _fence sync() }
 	wait: override func (time: TimeSpan) -> Bool { this _fence clientWait(time toNanoseconds()) }
+	duplicateFileDescriptor: func -> Int { this _fence duplicateFileDescriptor() }
 }
-
 OpenGLNativeFencePromise: class extends OpenGLPromise {
-	init: func (context: OpenGLContext) { super(EGLNativeFence new(context backend getDisplay())) }
-	duplicateFileDescriptor: func -> Int { this _fence as EGLNativeFence duplicateFileDescriptor() }
+	init: func (context: OpenGLContext) { super(EGLNativeFence create(context backend getDisplay())) }
 }

--- a/source/draw/gpu/opengl/backend/GLContext.ooc
+++ b/source/draw/gpu/opengl/backend/GLContext.ooc
@@ -30,11 +30,19 @@ GLContext: abstract class {
 	createIndexBufferObject: abstract func (vertices: FloatPoint3D[], textureCoordinates: FloatPoint2D[], indices: IntPoint3D[]) -> GLIndexBufferObject
 	getDisplay: abstract func -> Pointer
 	createContext: static func ~shared (display: Pointer, nativeBackend: Long, sharedContext: This = null) -> This {
-		// This function will check whether a context creation succeeded and if not try to create a context for another OpenGL version
-		Gles3Context create(display, nativeBackend, sharedContext as Gles3Context)
+		result: This = null
+		version (!gpuOff) {
+			// This function will check whether a context creation succeeded and if not try to create a context for another OpenGL version
+			result = Gles3Context create(display, nativeBackend, sharedContext as Gles3Context)
+		}
+		result
 	}
 	createContext: static func ~pbufferShared (sharedContext: This = null) -> This {
-		// This function will check whether a context creation succeeded and if not try to create a context for another OpenGL version
-		Gles3Context create(sharedContext as Gles3Context)
+		result: This = null
+		version (!gpuOff) {
+			// This function will check whether a context creation succeeded and if not try to create a context for another OpenGL version
+			result = Gles3Context create(sharedContext as Gles3Context)
+		}
+		result
 	}
 }

--- a/source/draw/gpu/opengl/backend/GLFence.ooc
+++ b/source/draw/gpu/opengl/backend/GLFence.ooc
@@ -15,4 +15,5 @@ GLFence: abstract class {
 	clientWait: abstract func (timeout: ULong = ULong maximumValue) -> Bool
 	wait: abstract func
 	sync: abstract func
+	duplicateFileDescriptor: virtual func -> Int { -1 }
 }

--- a/source/draw/gpu/opengl/backend/egl/EGLImage.ooc
+++ b/source/draw/gpu/opengl/backend/egl/EGLImage.ooc
@@ -12,7 +12,17 @@ import egl
 import ../gles3/Gles3Debug
 import ../[GLTexture, GLContext, GLExtensions]
 
-EGLImage: class extends GLTexture {
+EGLImage: abstract class {
+	create: static func (type: TextureType, size: IntVector2D, nativeBuffer: Pointer, context: GLContext) -> GLTexture {
+		result: GLTexture = null
+		version (!gpuOff)
+			result = _EGLImage new(type, size, nativeBuffer, context)
+		result
+	}
+}
+
+version (!gpuOff) {
+_EGLImage: class extends GLTexture {
 	_eglBackend: Pointer
 	_eglDisplay: Pointer
 	_nativeBuffer: Pointer
@@ -52,4 +62,5 @@ EGLImage: class extends GLTexture {
 		(type == TextureType Rgba || type == TextureType Rgb || type == TextureType External) ?
 		This new(type, size, nativeBuffer, context) : null
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/egl/EGLNativeFence.ooc
+++ b/source/draw/gpu/opengl/backend/egl/EGLNativeFence.ooc
@@ -5,14 +5,23 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
 use base
 import egl
 import ../[GLExtensions, GLFence]
 import ../gles3/Gles3Debug
 import ../gles3/external/gles3
 
-EGLNativeFence: class extends GLFence {
+EGLNativeFence: abstract class {
+	create: static func (display: Pointer) -> GLFence {
+		result: GLFence = null
+		version (!gpuOff)
+			result = _EGLNativeFence new(display)
+		result
+	}
+}
+
+version(!gpuOff) {
+_EGLNativeFence: class extends GLFence {
 	_display: Pointer
 	init: func (=_display) { super() }
 	free: override func {
@@ -41,4 +50,5 @@ EGLNativeFence: class extends GLFence {
 		version(debugGL) { validateEnd("EGLNativeFence eglDupNativeFenceFDANDROID") }
 		result
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/egl/EglDisplayContext.ooc
+++ b/source/draw/gpu/opengl/backend/egl/EglDisplayContext.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 use base
 use geometry
 import egl
@@ -141,3 +141,4 @@ EglDisplayContext: class extends DisplayContext {
 	}
 }
 GlobalCleanup register(|| EglDisplayContext _mutex free(), 10)
+}

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Context.ooc
@@ -14,6 +14,7 @@ import ../[GLContext, GLFence, GLTexture, GLVertexArrayObject, GLIndexBufferObje
 import external/gles3
 import Gles3Debug, Gles3Fence, Gles3FramebufferObject, Gles3Quad, Gles3Renderer, Gles3ShaderProgram, Gles3Texture, Gles3VolumeTexture, Gles3VertexArrayObject, Gles3IndexBufferObject
 
+version(!gpuOff) {
 Gles3Context: class extends GLContext {
 	_displayContext: DisplayContext
 	getDisplayContextSafely: func -> DisplayContext { this == null ? null : this _displayContext }
@@ -92,4 +93,5 @@ Gles3Context: class extends GLContext {
 	create: static func ~pbufferShared (sharedContext: This = null) -> This {
 		result := This new(EglDisplayContext new(sharedContext getDisplayContextSafely() as EglDisplayContext))
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Debug.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Debug.ooc
@@ -6,6 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+version(!gpuOff) {
 use base
 import ../egl/egl
 import external/gles3
@@ -96,5 +97,6 @@ printVersionInfo: func {
 	Debug print~free("OpenGL vendor: %s" format(vendor))
 	Debug print~free("OpenGL renderer: %s" format(renderer))
 	Debug print~free("OpenGL version: %s" format(version))
+}
 }
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
@@ -6,6 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+version(!gpuOff) {
 use base
 import external/gles3
 import ../GLFence
@@ -51,4 +52,5 @@ Gles3Fence: class extends GLFence {
 		glFlush()
 		version(debugGL) { validateEnd("Fence sync") }
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3FramebufferObject.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3FramebufferObject.ooc
@@ -6,6 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+version(!gpuOff) {
 use base
 use geometry
 use draw
@@ -102,4 +103,5 @@ Gles3FramebufferObject: class extends GLFramebufferObject {
 		glFlush()
 		version(debugGL) { validateEnd("FramebufferObject flush") }
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3IndexBufferObject.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3IndexBufferObject.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 use base
 use geometry
 import external/gles3
@@ -54,4 +54,5 @@ Gles3IndexBufferObject: class extends GLIndexBufferObject {
 	}
 	positionLayout: static UInt = 0
 	textureCoordinateLayout: static UInt = 1
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Quad.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Quad.ooc
@@ -6,6 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+version(!gpuOff) {
 use geometry
 
 import external/gles3
@@ -40,4 +41,5 @@ Gles3Quad: class extends GLQuad {
 		this vao unbind()
 		version(debugGL) { validateEnd("Quad draw") }
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Renderer.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Renderer.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 import Gles3Quad
 import external/gles3
 import ../GLRenderer
@@ -37,4 +37,5 @@ Gles3Renderer: class extends GLRenderer {
 		glDisableVertexAttribArray(0)
 		version(debugGL) { validateEnd("Renderer drawPoints") }
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3ShaderProgram.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 use base
 use geometry
 use draw
@@ -132,4 +132,5 @@ Gles3ShaderProgram: class extends GLShaderProgram {
 		version(debugGL) { validateEnd("ShaderProgram _compileShaders") }
 		success
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3Texture.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Texture.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 use geometry
 use base
 import external/gles3
@@ -141,4 +141,5 @@ Gles3Texture: class extends GLTexture {
 		version(debugGL) { validateEnd("Texture _allocate") }
 		true
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3VertexArrayObject.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3VertexArrayObject.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 use base
 use geometry
 import external/gles3
@@ -52,4 +52,5 @@ Gles3VertexArrayObject: class extends GLVertexArrayObject {
 	}
 	positionLayout: static UInt = 0
 	textureCoordinateLayout: static UInt = 1
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3VertexBufferObject.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3VertexBufferObject.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 use base
 use geometry
 import external/gles3
@@ -69,4 +69,5 @@ Gles3VertexBufferObject: class {
 	}
 	positionLayout: static UInt = 0
 	textureCoordinateLayout: static UInt = 1
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/Gles3VolumeTexture.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3VolumeTexture.ooc
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
  */
-
+version(!gpuOff) {
 use geometry
 use base
 import external/gles3
@@ -54,4 +54,5 @@ Gles3VolumeTexture: class extends GLVolumeTexture {
 		this unbind()
 		version(debugGL) { validateEnd("VolumeTexture upload") }
 	}
+}
 }

--- a/source/draw/gpu/opengl/backend/gles3/external/gles3.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/external/gles3.ooc
@@ -6,6 +6,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+version(!gpuOff) {
 include GLES3/gl3, GLES3/gl3ext, GLES3/gl3platform, GLES2/gl2ext
 PFNGLEGLIMAGETARGETTEXTURE2DOESPROC_OOC: cover from PFNGLEGLIMAGETARGETTEXTURE2DOESPROC
 
@@ -1006,3 +1007,4 @@ glInvalidateSubFramebuffer: extern func (target: UInt, numAttachments: Int, atta
 glTexStorage2D: extern func (target: UInt, levels: Int, internalformat: UInt, width: Int, height: Int)
 glTexStorage3D: extern func (target: UInt, levels: Int, internalformat: UInt, width: Int, height: Int, depth: Int)
 glGetInternalformativ: extern func (target: UInt, internalformat: UInt, pname: UInt, bufSize: Int, params: Int*)
+}

--- a/source/system/Debug.ooc
+++ b/source/system/Debug.ooc
@@ -30,10 +30,12 @@ Debug: class {
 		This _printFunction = f
 	}
 	print: static func (string: String, level := DebugLevel Debug) {
+		println("NON FREE")
 		if (level as Int >= This _level as Int && This _level != DebugLevel Silent)
 			This _printFunction(string)
 	}
 	print: static func ~free (string: String, level := DebugLevel Debug) {
+		println("FREE")
 		This print(string, level)
 		string free()
 	}


### PR DESCRIPTION
`gpuOff` is now (basically) only implemented in the lowest layer where the actual dependency to OpenGL lies.