### PR TITLE
Added blend modes to blitter

### DIFF
--- a/source/draw/Image.ooc
+++ b/source/draw/Image.ooc
@@ -67,7 +67,7 @@ Image: abstract class {
 	distance: virtual abstract func (other: This) -> Float
 	equals: func (other: This) -> Bool { this size == other size && this distance(other) < 10 * Float epsilon }
 	isValidIn: func (x, y: Int) -> Bool { x >= 0 && x < this size x && y >= 0 && y < this size y }
-	// Writes white text on the existing image (with black background if solid is true)
+	// Writes white text on the existing image (with black background if blendMode is Fill)
 	write: func (message: String, fontAtlas: This, localOrigin: IntPoint2D, blendMode: BlendMode = BlendMode White) {
 		skippedRows := 2
 		columns := 16

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -43,25 +43,56 @@ RasterMonochrome: class extends RasterPacked {
 		if (monochrome != image)
 			monochrome referenceCount decrease()
 	}
-	// Precondition: Do not draw out of bound
-	_blitWhiteRaw: static func (target, source: Byte*, startSrcX, startSrcY, startDstX, startDstY, width, height, targetStride, sourceStride: Int) {
-		for (y in 0 .. height) {
-			dstY := startDstY + y
-			srcY := startSrcY + y
-			writer := target + startDstX + (dstY * targetStride)
-			reader := source + startSrcX + (srcY * sourceStride)
-			for (x in 0 .. width) {
-				sourceColor: Float = reader@
-				targetColor: Float = writer@
-				blendColor: Int = (targetColor * (1.0f - (sourceColor / 255.0f))) + sourceColor // Source intensity as alpha
-				if (blendColor > 255) blendColor = 255 // Limit intensity
-				writer@ = blendColor // Write to target
-				reader += 1
-				writer += 1
+	// Preconditions:
+	//   Do not draw out of bound.
+	//   Do not let the target region overlap the source region.
+	_blitRaw: static func (target, source: Byte*, startSrcX, startSrcY, startDstX, startDstY, width, height, targetStride, sourceStride: Int, blendMode: BlendMode) {
+		if (width > 0) {
+			upperLeftTarget := target + startDstX + (startDstY * targetStride)
+			upperLeftSource := source + startSrcX + (startSrcY * sourceStride)
+			writerLineStart := upperLeftTarget
+			readerLineStart := upperLeftSource
+			match (blendMode) {
+				case BlendMode White =>
+					for (y in 0 .. height) {
+						writer := writerLineStart
+						reader := readerLineStart
+						for (x in 0 .. width) {
+							sourceColor: Float = reader@
+							targetColor: Float = writer@
+							blendColor: Int = (targetColor * (1.0f - (sourceColor / 255.0f))) + sourceColor // Source intensity as alpha
+							if (blendColor > 255) blendColor = 255 // Limit intensity
+							writer@ = blendColor // Write to target
+							reader += 1
+							writer += 1
+						}
+						writerLineStart += targetStride
+						readerLineStart += sourceStride
+					}
+				case BlendMode Add =>
+					for (y in 0 .. height) {
+						writer := writerLineStart
+						reader := readerLineStart
+						for (x in 0 .. width) {
+							blendColor: Int = reader@ + writer@ // Simple addition
+							if (blendColor > 255) blendColor = 255 // Limit intensity
+							writer@ = blendColor // Write to target
+							reader += 1
+							writer += 1
+						}
+						writerLineStart += targetStride
+						readerLineStart += sourceStride
+					}
+				case => // Fill or unhandled
+					for (y in 0 .. height) {
+						memcpy(writerLineStart, readerLineStart, width) // Direct memory copy
+						writerLineStart += targetStride
+						readerLineStart += sourceStride
+					}
 			}
 		}
 	}
-	blitWhiteSource: override func (source: Image, offset: IntVector2D, sourceBox: IntBox2D) {
+	blitSource: override func (source: Image, offset: IntVector2D, sourceBox: IntBox2D, blendMode: BlendMode) {
 		if (!source instanceOf(This))
 			Debug error("Only a RasterMonochrome can be blitted on a RasterMonochrome.")
 		startSrc := sourceBox leftTop
@@ -79,7 +110,7 @@ RasterMonochrome: class extends RasterPacked {
 		dimensions := endDst - startDst
 		endSrc := startSrc + dimensions
 		if (startSrc x >= 0 && startSrc y >= 0 && endSrc x <= source size x && endSrc y <= source size y && startDst x >= 0 && startDst y >= 0 && endDst x <= this size x && endDst y <= this size y) {
-			this _blitWhiteRaw(this buffer pointer, (source as This) buffer pointer, startSrc x, startSrc y, startDst x, startDst y, dimensions x, dimensions y, this stride, (source as This) stride)
+			this _blitRaw(this buffer pointer, (source as This) buffer pointer, startSrc x, startSrc y, startDst x, startDst y, dimensions x, dimensions y, this stride, (source as This) stride, blendMode)
 		}
 	}
 	fill: override func (color: ColorRgba) { this buffer memset(color r) }

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -113,6 +113,33 @@ RasterMonochrome: class extends RasterPacked {
 			this _blitRaw(this buffer pointer, (source as This) buffer pointer, startSrc x, startSrc y, startDst x, startDst y, dimensions x, dimensions y, this stride, (source as This) stride, blendMode)
 		}
 	}
+	exactDistance: func (other: This) -> Int {
+		if (this size != other size)
+			return Int maximumValue;
+		else {
+			result := 0
+			thisUpperLeft := this buffer pointer
+			otherUpperLeft := other buffer pointer
+			thisStride := this stride
+			otherStride := other stride
+			thisLineStart := thisUpperLeft
+			otherLineStart := otherUpperLeft
+			for (y in 0 .. this size y) {
+				thisPixel := thisLineStart
+				otherPixel := otherLineStart
+				for (x in 0 .. this size x) {
+					thisColor: Int = thisPixel@
+					otherColor: Int = otherPixel@
+					result += thisColor > otherColor ? thisColor - otherColor : otherColor - thisColor
+					thisPixel += 1
+					otherPixel += 1
+				}
+				thisLineStart += thisStride
+				otherLineStart += otherStride
+			}
+			return result;
+		}
+	}
 	fill: override func (color: ColorRgba) { this buffer memset(color r) }
 	copy: override func -> This { This new(this buffer copy(), this size, this stride) }
 	apply: override func ~rgb (action: Func(ColorRgb)) {

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -119,7 +119,7 @@ RasterMonochrome: class extends RasterPacked {
 	}
 	exactDistance: func (other: This) -> Int {
 		if (this size != other size)
-			return Int maximumValue;
+			Int maximumValue
 		else {
 			result := 0
 			thisUpperLeft := this buffer pointer
@@ -141,7 +141,7 @@ RasterMonochrome: class extends RasterPacked {
 				thisLineStart += thisStride
 				otherLineStart += otherStride
 			}
-			return result;
+			result
 		}
 	}
 	fill: override func (color: ColorRgba) { this buffer memset(color r) }

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -58,9 +58,11 @@ RasterMonochrome: class extends RasterPacked {
 						writer := writerLineStart
 						reader := readerLineStart
 						for (x in 0 .. width) {
+							// White function
 							sourceColor: Float = reader@
 							targetColor: Float = writer@
 							blendColor: Int = (targetColor * (1.0f - (sourceColor / 255.0f))) + sourceColor // Source intensity as alpha
+
 							if (blendColor > 255) blendColor = 255 // Limit intensity
 							writer@ = blendColor // Write to target
 							reader += 1
@@ -74,7 +76,9 @@ RasterMonochrome: class extends RasterPacked {
 						writer := writerLineStart
 						reader := readerLineStart
 						for (x in 0 .. width) {
+							// Add function
 							blendColor: Int = reader@ + writer@ // Simple addition
+
 							if (blendColor > 255) blendColor = 255 // Limit intensity
 							writer@ = blendColor // Write to target
 							reader += 1

--- a/test/draw/gpu/BlitTest.ooc
+++ b/test/draw/gpu/BlitTest.ooc
@@ -107,8 +107,8 @@ BlitTest: class extends Fixture {
 				<               >
 				<               >"
 			)
-			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode Add)
-			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode White)
+			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode Add, 0) // Bit exact
+			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode White, 16) // Approximated
 			correctImage free()
 		})
 		this add("Blit fill", func {
@@ -125,16 +125,16 @@ BlitTest: class extends Fixture {
 				<              >
 				<              >"
 			)
-			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode Fill)
+			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(4, 2), BlendMode Fill, 0) // Bit exact
 			correctImage free()
 		})
 	}
 	testOffset: func (source, expected: RasterMonochrome, offset: IntVector2D) {
-		this testOffsetMode(source, expected, offset, BlendMode Fill)
-		this testOffsetMode(source, expected, offset, BlendMode Add)
-		this testOffsetMode(source, expected, offset, BlendMode White)
+		this testOffsetMode(source, expected, offset, BlendMode Fill, 0) // Bit exact
+		this testOffsetMode(source, expected, offset, BlendMode Add, 0) // Bit exact
+		this testOffsetMode(source, expected, offset, BlendMode White, 16) // Approximated
 	}
-	testOffsetMode: func (source, expected: RasterMonochrome, offset: IntVector2D, blendMode: BlendMode) {
+	testOffsetMode: func (source, expected: RasterMonochrome, offset: IntVector2D, blendMode: BlendMode, cpuTolerance: Int) {
 		resultCpu := RasterMonochrome new(expected size)
 		resultCpu fill(ColorRgba black)
 		resultCpu blit(this sourceImage, offset, blendMode)
@@ -142,11 +142,11 @@ BlitTest: class extends Fixture {
 		resultGpu fill(ColorRgba black)
 		resultGpu blit(this sourceImage, offset, blendMode)
 		resultCpuFromGpu := resultGpu toRaster()
-		expect(resultCpu distance(expected), is less than(0.05f))
-		expect(resultCpuFromGpu distance(expected), is less than(0.05f))
+		expect(resultCpu exactDistance(expected), is less than(cpuTolerance + 1))
+		expect(resultCpuFromGpu distance(expected), is less than(0.05))
 		(resultCpu, resultGpu, resultCpuFromGpu) free()
 	}
-	testBlend: func (source, expected: RasterMonochrome, offsetA: IntVector2D, offsetB: IntVector2D, blendModeB: BlendMode) {
+	testBlend: func (source, expected: RasterMonochrome, offsetA: IntVector2D, offsetB: IntVector2D, blendModeB: BlendMode, cpuTolerance: Int) {
 		resultCpu := RasterMonochrome new(expected size)
 		resultCpu fill(ColorRgba black)
 		resultCpu blit(this sourceImage, offsetA, BlendMode Fill)
@@ -156,8 +156,8 @@ BlitTest: class extends Fixture {
 		resultGpu blit(this sourceImage, offsetA, BlendMode Fill)
 		resultGpu blit(this sourceImage, offsetB, blendModeB)
 		resultCpuFromGpu := resultGpu toRaster()
-		expect(resultCpu distance(expected), is less than(0.05f))
-		expect(resultCpuFromGpu distance(expected), is less than(0.05f))
+		expect(resultCpu exactDistance(expected), is less than(cpuTolerance + 1))
+		expect(resultCpuFromGpu distance(expected), is less than(0.05))
 		(resultCpu, resultGpu, resultCpuFromGpu) free()
 	}
 	free: override func {

--- a/test/draw/gpu/BlitTest.ooc
+++ b/test/draw/gpu/BlitTest.ooc
@@ -91,14 +91,70 @@ BlitTest: class extends Fixture {
 			this testOffset(this sourceImage, correctImage, IntVector2D new(4, 1))
 			correctImage free()
 		})
+		this add("Blit blend", func {
+			correctImage := RasterMonochrome fromAscii(
+				"< *X>
+				<XXXXXXXX       >
+				<X*    *X       >
+				<X*    *X       >
+				<X*   XXX       >
+				<X****XXXXXXXX  >
+				<XXXXXXXX   *X  >
+				<     X*    *X  >
+				<     X*   XXX  >
+				<     X****XXX  >
+				<     XXXXXXXX  >
+				<               >
+				<               >"
+			)
+			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode Add)
+			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode White)
+			correctImage free()
+		})
+		this add("Blit fill", func {
+			correctImage := RasterMonochrome fromAscii(
+				"< *X>
+				<XXXXXXXX      >
+				<X*    *X      >
+				<X*  XXXXXXXX  >
+				<X*  X*    *X  >
+				<X***X*    *X  >
+				<XXXXX*   XXX  >
+				<    X****XXX  >
+				<    XXXXXXXX  >
+				<              >
+				<              >"
+			)
+			this testBlend(this sourceImage, correctImage, IntVector2D new(0, 0), IntVector2D new(5, 4), BlendMode Fill)
+			correctImage free()
+		})
 	}
 	testOffset: func (source, expected: RasterMonochrome, offset: IntVector2D) {
+		this testOffsetMode(source, expected, offset, BlendMode Fill)
+		this testOffsetMode(source, expected, offset, BlendMode Add)
+		this testOffsetMode(source, expected, offset, BlendMode White)
+	}
+	testOffsetMode: func (source, expected: RasterMonochrome, offset: IntVector2D, blendMode: BlendMode) {
 		resultCpu := RasterMonochrome new(expected size)
 		resultCpu fill(ColorRgba black)
-		resultCpu blitWhite(this sourceImage, offset)
+		resultCpu blit(this sourceImage, offset, blendMode)
 		resultGpu := gpuContext createMonochrome(expected size)
 		resultGpu fill(ColorRgba black)
-		resultGpu blitWhite(this sourceImage, offset)
+		resultGpu blit(this sourceImage, offset, blendMode)
+		resultCpuFromGpu := resultGpu toRaster()
+		expect(resultCpu distance(expected), is less than(0.05f))
+		expect(resultCpuFromGpu distance(expected), is less than(0.05f))
+		(resultCpu, resultGpu, resultCpuFromGpu) free()
+	}
+	testBlend: func (source, expected: RasterMonochrome, offsetA: IntVector2D, offsetB: IntVector2D, blendModeB: BlendMode) {
+		resultCpu := RasterMonochrome new(expected size)
+		resultCpu fill(ColorRgba black)
+		resultCpu blit(this sourceImage, offsetA, BlendMode Fill)
+		resultCpu blit(this sourceImage, offsetB, blendModeB)
+		resultGpu := gpuContext createMonochrome(expected size)
+		resultGpu fill(ColorRgba black)
+		resultGpu blit(this sourceImage, offsetA, BlendMode Fill)
+		resultGpu blit(this sourceImage, offsetB, blendModeB)
 		resultCpuFromGpu := resultGpu toRaster()
 		expect(resultCpu distance(expected), is less than(0.05f))
 		expect(resultCpuFromGpu distance(expected), is less than(0.05f))


### PR DESCRIPTION
Added fill and add blend modes for blitting. These modes are bit exact when used on the CPU blitter.
Only the luma channel is affected by blitting to keep it fast.

The default image comparison used for handling the oddities of OpenGL had too much room for incorrect offsets so it is not used to test CPU blitting anymore.