### PR TITLE
Now using custom vertex shader when drawing lines.

### DIFF
--- a/source/draw/gpu/opengl/OpenGLContext.ooc
+++ b/source/draw/gpu/opengl/OpenGLContext.ooc
@@ -55,7 +55,7 @@ OpenGLContext: class extends GpuContext {
 		this _packMonochrome = OpenGLMap new(slurp("shaders/packMonochrome.vert"), slurp("shaders/packMonochrome.frag"), this)
 		this _packUv = OpenGLMap new(slurp("shaders/packUv.vert"), slurp("shaders/packUv.frag"), this)
 		this _packUvPadded = OpenGLMap new(slurp("shaders/packUvPadded.vert"), slurp("shaders/packUvPadded.frag"), this)
-		this _linesShader = OpenGLMapTransform new(slurp("shaders/color.frag"), this)
+		this _linesShader = OpenGLMap new(slurp("shaders/lines.vert"), slurp("shaders/color.frag"), this)
 		this _pointsShader = OpenGLMap new(slurp("shaders/points.vert"), slurp("shaders/color.frag"), this)
 		this _transformTextureMap = OpenGLMapTransform new(slurp("shaders/texture.frag"), this)
 		this _monochromeToRgba = OpenGLMapTransform new(slurp("shaders/monochromeToRgba.frag"), this)
@@ -86,7 +86,8 @@ OpenGLContext: class extends GpuContext {
 		positions := pointList pointer as Float*
 		shader := this getLineShader()
 		shader add("color", pen color normalized)
-		shader useProgram(null, projection, FloatTransform3D identity)
+		shader add("transform", projection)
+		shader useProgram(null, FloatTransform3D identity, FloatTransform3D identity)
 		this _renderer drawLines(positions, pointList count, 2, pen width)
 	}
 	drawPoints: func (pointList: VectorList<FloatPoint2D>, projection: FloatTransform3D, pen: Pen) {

--- a/source/draw/gpu/opengl/shaders/lines.vert
+++ b/source/draw/gpu/opengl/shaders/lines.vert
@@ -1,0 +1,6 @@
+#version 300 es
+uniform mat4 transform;
+layout(location = 0) in vec2 vertexPosition;
+void main() {
+	gl_Position = transform * vec4(vertexPosition.x, vertexPosition.y, 0.0f, 1.0f);
+}


### PR DESCRIPTION
Using the generic transform vertex shader caused some OpenGL drivers to fail when drawing lines.
@christopherlagerhult 