### PR TITLE
Added flush after glFenceSync

### DIFF
--- a/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
+++ b/source/draw/gpu/opengl/backend/gles3/Gles3Fence.ooc
@@ -47,6 +47,7 @@ Gles3Fence: class extends GLFence {
 		if (this _backend != null)
 			glDeleteSync(this _backend)
 		this _backend = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
+		glFlush()
 		version(debugGL) { if (this _backend == null) Debug print("glFenceSync failed!") }
 		version(debugGL) { validateEnd("Fence sync") }
 	}


### PR DESCRIPTION
It solves the endless-wait-problem when `glClientWaitSync` is beeing called on a different thread than `glFenceSync`