### PR TITLE
Removed debug init() call in QuaternionTest

### DIFF
--- a/test/base/DebugTest.ooc
+++ b/test/base/DebugTest.ooc
@@ -12,9 +12,11 @@ use unit
 DebugTest: class extends Fixture {
 	outputString: String = null
 	oldLevel: DebugLevel
+	oldPrintFunction: Func (String)
 
 	init: func {
 		super("Debug")
+		this oldPrintFunction = Debug _printFunction
 		Debug initialize(func (message: String) {
 			if (this outputString != null)
 				this outputString free()
@@ -52,6 +54,7 @@ DebugTest: class extends Fixture {
 	free: override func {
 		Debug level = this oldLevel
 		this outputString free()
+		Debug _printFunction = oldPrintFunction
 		super()
 	}
 }

--- a/test/geometry/QuaternionTest.ooc
+++ b/test/geometry/QuaternionTest.ooc
@@ -13,7 +13,6 @@ use math
 use geometry
 
 QuaternionTest: class extends Fixture {
-	Debug initialize(func (s: String) { println(s) })
 	quaternion0 := Quaternion new(33.0f, 10.0f, -12.0f, 54.5f)
 	quaternion1 := Quaternion new(10.0f, 17.0f, -10.0f, 14.5f)
 	quaternion2 := Quaternion new(43.0f, 27.0f, -22.0f, 69.0f)


### PR DESCRIPTION
Git tells me to blame @thomasfanell 20 months ago, so you get to do the review. :)