### PR TITLE
Release 2.18 preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ooc-kean changes by release
 
+## Release 2.18.0
+
+- **Minor redesign and error assertions added in Image classes**
+- **Added []-operators for FloatVector3D**
+
 ## Release 2.17.0
 
 - **Added transform of FloatVector3D**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release  2.17.0
+# Release  2.18.0
 
 magic-sdk (formerly ooc-kean)
 ========
@@ -15,7 +15,7 @@ Tests can be run using the `test.sh` script.
 ### Dependencies
 The following software is necessary to build ooc-kean:
 * [rock 1.0.22](https://github.com/magic-lang/rock/releases/tag/rock_1.0.22)
-* gcc 4.9.3
+* gcc 5.4.0
 
 ### Linux
 ooc-kean has been built and tested on the following platforms:

--- a/release.json
+++ b/release.json
@@ -1,9 +1,9 @@
 {
 	"name": "ooc-kean",
-	"release": "2.17.0",
+	"release": "2.18.0",
 	"dependencies": {
 		"rock": "https://github.com/magic-lang/rock/releases/tag/rock_1.0.22",
-		"gcc": "4.9.3"
+		"gcc": "5.4.0"
 		}
 
 }


### PR DESCRIPTION
gcc version updated since this is default in ubuntu 16.04.