### PR TITLE
Correct equals() operator

### DIFF
--- a/source/system/math.ooc
+++ b/source/system/math.ooc
@@ -126,7 +126,7 @@ extend Double {
 	toRadians: func -> This { This pi / 180.0 * this }
 	toDegrees: func -> This { 180.0 / This pi * this }
 	clamp: func (floor, ceiling: This) -> This { this > ceiling ? ceiling : (this < floor ? floor : this) }
-	equals: func (other: This, tolerance := This epsilon) -> Bool { (this - other) abs() < tolerance }
+	equals: func (other: This, tolerance := This epsilon) -> Bool { (this - other) abs() <= tolerance }
 	lessThan: func (other: This, tolerance := This epsilon) -> Bool { this < other && !this equals(other, tolerance) }
 	greaterThan: func (other: This, tolerance := This epsilon) -> Bool { this > other && !this equals(other, tolerance) }
 	lessOrEqual: func (other: This, tolerance := This epsilon) -> Bool { !this greaterThan(other, tolerance) }
@@ -179,7 +179,7 @@ extend Float {
 	floor: extern (floorf) func -> This
 	truncate: extern (truncf) func -> This
 
-	equals: func (other: This, tolerance := This epsilon) -> Bool { (this - other) abs() < tolerance }
+	equals: func (other: This, tolerance := This epsilon) -> Bool { (this - other) abs() <= tolerance }
 	lessThan: func (other: This, tolerance := This epsilon) -> Bool { this < other && !this equals(other, tolerance) }
 	greaterThan: func (other: This, tolerance := This epsilon) -> Bool { this > other && !this equals(other, tolerance) }
 	lessOrEqual: func (other: This, tolerance := This epsilon) -> Bool { !this greaterThan(other, tolerance) }
@@ -272,7 +272,7 @@ extend LDouble {
 	floor: extern (floorl) func -> This
 	truncate: extern (truncl) func -> This
 
-	equals: func (other: This, tolerance := This defaultTolerance) -> Bool { (this - other) abs() < tolerance }
+	equals: func (other: This, tolerance := This defaultTolerance) -> Bool { (this - other) abs() <= tolerance }
 	lessThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this < other && !this equals(other, tolerance) }
 	greaterThan: func (other: This, tolerance := This defaultTolerance) -> Bool { this > other && !this equals(other, tolerance) }
 	lessOrEqual: func (other: This, tolerance := This defaultTolerance) -> Bool { !this greaterThan(other, tolerance) }

--- a/test/system/MathTest.ooc
+++ b/test/system/MathTest.ooc
@@ -75,8 +75,8 @@ MathTest: class extends Fixture {
 			expect(13.0f clamp(9.0f, 11.0f), is equal to(11.0f) within(floatTolerance))
 			expect((-2.0f) clamp(-1.9f, 5.0f), is equal to(-1.9f) within(floatTolerance)) // (-2.0f) with parentheses because of bug in rock
 
-			expect(1.9999999f equals(2.0f), is false)
-			expect(1.99999999f equals(2.0f), is true)
+			expect(1.999999f equals(2.0f), is false)
+			expect(1.9999999f equals(2.0f), is true)
 
 			expect((-2.3f) absolute, is equal to(2.3f) within(floatTolerance))
 			expect(2.3f absolute, is equal to(2.3f) within(floatTolerance))


### PR DESCRIPTION
Not including `=` is a mistake since `x==x` even as `tolerance` goes to `0` (which happens in c++ when comparing floating point with integer, for example - and this causes some deviations).