### PR TITLE
Introduced squared norm to avoid floating roundoff

### DIFF
--- a/source/geometry/FloatPoint3D.ooc
+++ b/source/geometry/FloatPoint3D.ooc
@@ -18,6 +18,7 @@ FloatPoint3D: cover {
 	x, y, z: Float
 
 	norm ::= (this x squared + this y squared + this z squared) sqrt()
+	squaredNorm ::= (this x squared + this y squared + this z squared)
 	isZero ::= this norm equals(0.0f)
 	normalized ::= this isZero ? (this as This) : (this / this norm)
 	azimuth ::= this y atan2(this x)

--- a/source/geometry/Quaternion.ooc
+++ b/source/geometry/Quaternion.ooc
@@ -24,10 +24,11 @@ Quaternion: cover {
 	isValid ::= this real isNumber && this imaginary isValid
 	isIdentity ::= this real equals(1.f) && this imaginary isZero
 	isZero ::= this real equals(0.f) && this imaginary isZero
-	norm ::= (this real squared + this imaginary norm squared) sqrt()
+	norm ::= (this real squared + this imaginary squaredNorm) sqrt()
+	squaredNorm ::= this real squared + this imaginary squaredNorm
 	normalized ::= this / this norm
 	conjugate ::= This new(this real, -this imaginary)
-	inverse ::= this conjugate / (this real squared + this imaginary norm squared)
+	inverse ::= this conjugate / squaredNorm
 	transform ::= this toFloatTransform3D()
 	direction ::= (this logarithm imaginary) normalized
 	// NOTE: Separation into parts assumes order of application X -> Y -> Z

--- a/source/math/FloatComplex.ooc
+++ b/source/math/FloatComplex.ooc
@@ -12,7 +12,7 @@ FloatComplex: cover {
 	real, imaginary: Float
 
 	conjugate ::= This new(this real, - this imaginary)
-	absoluteValue ::= (this real pow(2) + this imaginary pow(2)) sqrt()
+	absoluteValue ::= (this real squared + this imaginary squared) sqrt()
 
 	init: func@ (=real, =imaginary)
 	init: func@ ~default { this init(0.0f, 0.0f) }
@@ -30,7 +30,7 @@ FloatComplex: cover {
 	operator + (other: This) -> This { This new(this real + other real, this imaginary + other imaginary) }
 	operator - (other: This) -> This { This new(this real - other real, this imaginary - other imaginary) }
 	operator * (other: This) -> This { This new(this real * other real - this imaginary * other imaginary, this real * other imaginary + this imaginary * other real) }
-	operator / (other: This) -> This { (this * other conjugate) / (other absoluteValue pow(2)) }
+	operator / (other: This) -> This { (this * other conjugate) / (other absoluteValue squared) }
 	operator == (other: This) -> Bool { this real equals(other real) && this imaginary equals(other imaginary) }
 	operator != (other: This) -> Bool { !(this == other) }
 	operator * (other: Float) -> This { This new(other * this real, other * this imaginary) }
@@ -47,7 +47,7 @@ FloatComplex: cover {
 	}
 }
 operator * (left: Float, right: FloatComplex) -> FloatComplex { FloatComplex new(left * right real, left * right imaginary) }
-operator / (left: Float, right: FloatComplex) -> FloatComplex { (left * right conjugate) / (right absoluteValue pow(2)) }
+operator / (left: Float, right: FloatComplex) -> FloatComplex { (left * right conjugate) / (right absoluteValue squared) }
 
 extend Cell<FloatComplex> {
 	toString: func ~floatcomplex -> String { (this val as FloatComplex) toString() }


### PR DESCRIPTION
Also using `squared` avoids casting to/from `double` (in C).